### PR TITLE
Add publication event, auto-increment method to journal.models Issue

### DIFF
--- a/src/events/logic.py
+++ b/src/events/logic.py
@@ -188,6 +188,10 @@ class Events:
     # raised when proofing is complete
     ON_PROOFING_COMPLETE = 'on_proofing_complete'
 
+    #kwargs: request, article
+    # raised when an article is marked as published
+    ON_ARTICLE_PUBLISHED = 'on_article_published'
+
     # kwargs: request, article
     # raised when an Editor notifies an author that publication is set
     ON_AUTHOR_PUBLICATION = 'on_author_publication'

--- a/src/journal/models.py
+++ b/src/journal/models.py
@@ -512,6 +512,33 @@ class Issue(models.Model):
         orderings = [ordering.order for ordering in ArticleOrdering.objects.filter(issue=self)]
         return max(orderings) + 1 if orderings else 0
 
+    @staticmethod
+    def auto_increment_volume_issue(journal):
+        """
+        Takes a journal as input
+        Looks at latest non-collection issue in journal,
+        Returns a tuple of ints representing the next (volume, issue)
+        """
+        from datetime import datetime
+
+        # get the latest issue from the specified journal
+        latest_issue = Issue.objects.filter(journal=journal, issue_type='Issue').latest('date')
+
+        # if no issues in journal, start at 1:1
+        if not latest_issue:
+            return (1, 1)
+
+        # if issues exist, iterate - if new year, add 1 to volume and reset issue to 1
+        # otherwise keep volume the same and add 1 to issue
+        else:
+            if datetime.now().year > latest_issue.date.year:
+                volume = latest_issue.volume + 1
+                issue = 1
+                return (volume, issue)
+            else:
+                issue = latest_issue.issue + 1
+                return (latest_issue.volume, issue)
+
     def __str__(self):
         return u'{0}: {1} {2} ({3})'.format(self.volume, self.issue, self.issue_title, self.date.year)
 

--- a/src/journal/views.py
+++ b/src/journal/views.py
@@ -691,6 +691,13 @@ def publish_article(request, article_id):
 
             article.save()
 
+            # Fire publication event
+            kwargs = {'article': article,
+                        'request': request}
+            event_logic.Events.raise_event(event_logic.Events.ON_ARTICLE_PUBLISHED,
+                                            task_object=article,
+                                            **kwargs)
+
             # Attempt to register xref DOI
             for identifier in article.identifier_set.all():
                 if identifier.id_type == 'doi':


### PR DESCRIPTION
Please check to make sure I'm setting things up correctly. Added an event for when an article is marked as published, and a staticmethod to the Issue class that generates the next logical volume and issue numbers based on the last released (non-collection) issue. If there are no issues, it returns (1, 1).