### PR TITLE
gitignore all .sqlite* files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,7 +58,7 @@ target/
 
 # Django
 src/core/settings.py
-*.sqlite3
+*.sqlite*
 *.db
 /src/files/articles
 /src/files/journals


### PR DESCRIPTION
Current defaults in the makefile create a file called `db/janeway.sqlite`, without the `3` suffix. This file ought to be ignored by git.