### PR TITLE
Label for license updated to just the shortname.

### DIFF
--- a/src/submission/admin.py
+++ b/src/submission/admin.py
@@ -13,7 +13,7 @@ from submission import models
 
 class LicenseChoiceField(forms.ModelChoiceField):
     def label_from_instance(self, obj):
-        return "{0}: {1}".format(obj.journal.code, obj.short_name)
+        return obj.short_name
 
 
 class FrozenAuthorAdmin(admin.ModelAdmin):


### PR DESCRIPTION
Closes #626 

Related issue to limit the license list in Admin: https://github.com/BirkbeckCTP/janeway/issues/713