### PR TITLE
add author view, url and template

### DIFF
--- a/src/journal/urls.py
+++ b/src/journal/urls.py
@@ -115,6 +115,10 @@ urlpatterns = [
     # Editorial team
     url(r'^editorialteam/(?P<group_id>\d+)/$',
         views.editorial_team, name='editorial_team_group'),
+    
+    # Authors page
+    url(r'^authors/$',
+        views.author_list, name='authors'),
 
     # Search
     url(r'^search/$',

--- a/src/journal/urls.py
+++ b/src/journal/urls.py
@@ -115,7 +115,6 @@ urlpatterns = [
     # Editorial team
     url(r'^editorialteam/(?P<group_id>\d+)/$',
         views.editorial_team, name='editorial_team_group'),
-    
     # Authors page
     url(r'^authors/$',
         views.author_list, name='authors'),

--- a/src/journal/views.py
+++ b/src/journal/views.py
@@ -1303,7 +1303,6 @@ def author_list(request):
     }
     return render(request, template, context)
 
-
 def sitemap(request):
     """
     Renders an XML sitemap based on articles and pages available to the journal.

--- a/src/journal/views.py
+++ b/src/journal/views.py
@@ -1288,6 +1288,7 @@ def editorial_team(request, group_id=None):
 
     return render(request, template, context)
 
+@has_journal
 def author_list(request):
     """
     Displays list of authors. 

--- a/src/journal/views.py
+++ b/src/journal/views.py
@@ -1288,6 +1288,20 @@ def editorial_team(request, group_id=None):
 
     return render(request, template, context)
 
+def author_list(request):
+    """
+    Displays list of authors. 
+    :param request: HttpRequest object
+    :return: HttpResponse object
+    """
+    author_list = request.journal.users_with_role('author')
+    template = 'journal/authors.html'
+
+    context = {
+        'author_list': author_list,
+    }
+    return render(request, template, context)
+
 
 def sitemap(request):
     """

--- a/src/themes/default/templates/journal/authors.html
+++ b/src/themes/default/templates/journal/authors.html
@@ -6,14 +6,8 @@
 
 {% block body %}
 
-    {% if request.journal %}
-        <h3>Authors of: {{ request.journal.name }}</h3>
-    {% else %}
-        <h3>{% trans "Authors" %}</h3>
-    {% endif %}    
-    
+    <h3>Authors</h3>
     <div class="row">
-        
         {% for author in author_list %}
             <div class="col-md-3 row-eq-height">
                 <div class="card" style="width: 20rem;">
@@ -35,8 +29,5 @@
             </div>
         {% endfor %}
     </div>
-    
 
 {% endblock body %}
-
-

--- a/src/themes/default/templates/journal/authors.html
+++ b/src/themes/default/templates/journal/authors.html
@@ -1,0 +1,42 @@
+{% extends "core/base.html" %}
+{% load static from staticfiles %}
+
+{% block title %}Authors{% endblock title %}
+{% block page_title %}Authors{% endblock page_title %}
+
+{% block body %}
+
+    {% if request.journal %}
+        <h3>Authors of: {{ request.journal.name }}</h3>
+    {% else %}
+        <h3>{% trans "Authors" %}</h3>
+    {% endif %}    
+    
+    <div class="row">
+        
+        {% for author in author_list %}
+            <div class="col-md-3 row-eq-height">
+                <div class="card" style="width: 20rem;">
+                    <img class="card-img-top img-fluid editorial-image" src="{% if author.profile_image %}{{ author.profile_image.url }}{% else %}{% static "common/img/icons/users.png" %}{% endif %}"
+                         alt="Card image cap">
+                    <div class="card-block">
+                        <h5 class="card-title">{{ author.full_name }}</h5>
+                        <p>
+                            <small>{{ author.affiliation }}</small>
+                        </p>
+                        {% if author.enable_public_profile %}
+                            <p>
+                                <small><a href="{% url 'core_public_profile' author.uuid %}">View Profile</a>
+                                </small>
+                            </p>{% endif %}
+                        {% include "elements/journal/editorial_social_content.html" with user=author %}
+                    </div>
+                </div>
+            </div>
+        {% endfor %}
+    </div>
+    
+
+{% endblock body %}
+
+


### PR DESCRIPTION
#748 
This creates a view function to see all authors of a journal from the front end and then gives the option to link to their public profile if it is enabled. So a view for an author that shows the list of published articles as I described in the original issue is not necessary.