### PR TITLE
Improvements to the new Journal.site_url function

### DIFF
--- a/src/core/janeway_global_settings.py
+++ b/src/core/janeway_global_settings.py
@@ -140,6 +140,9 @@ TEMPLATES = [
                 'django.template.loaders.filesystem.Loader',
                 'django.template.loaders.app_directories.Loader',
             ],
+            'builtins': [
+                'core.templatetags.fqdn',
+            ]
         },
     },
 ]

--- a/src/core/templatetags/fqdn.py
+++ b/src/core/templatetags/fqdn.py
@@ -5,14 +5,14 @@ register = template.Library()
 
 
 @register.simple_tag(takes_context=True)
-def journal_url(context, url_name, *args):
+def journal_url(context, url_name=None, *args):
     request = context['request']
-    try:
-        url = reverse(url_name, args=args)
-        return '{0}{1}'.format(request.journal.full_url(request), url)
-    except NoReverseMatch:
-        return 'URL not matched.'
+    if url_name is not None:
+        path = reverse(url_name, args=args)
+    else:
+        path = None
 
+    return request.journal.site_url(path=path)
 
 @register.simple_tag(takes_context=True)
 def journal_base_url(context, journal):

--- a/src/journal/models.py
+++ b/src/journal/models.py
@@ -201,7 +201,7 @@ class Journal(AbstractSiteModel):
         if request and request.journal == self:
             return request.build_absolute_uri(path)
         else:
-            return journal.press.journal_path_url(self, path)
+            return self.press.journal_path_url(self, path)
 
     def full_url(self, request=None):
         logging.warning("Using journal.full_url is deprecated")

--- a/src/journal/models.py
+++ b/src/journal/models.py
@@ -186,28 +186,26 @@ class Journal(AbstractSiteModel):
         return press
 
     def site_url(self, path=""):
-        port = None
-
         if settings.URL_CONFIG == "path":
-            netloc = self.press.domain
-            path = path or self.code
-            request = logic.get_current_request()
-            if request is not None:
-                port = request.get_port()
-        else:
-            netloc = self.domain
-            path = path
+            return self._site_path_url(path)
 
         return logic.build_url(
-                netloc=netloc,
+                netloc=journal.domain,
                 scheme=self.SCHEMES[self.is_secure],
-                port=port,
+                port=None,
                 path=path,
         )
 
+    def _site_path_url(self, path=""):
+        request = logic.get_current_request()
+        if request and request.journal == self:
+            return request.build_absolute_uri(path)
+        else:
+            return journal.press.journal_path_url(self, path)
+
     def full_url(self, request=None):
         logging.warning("Using journal.full_url is deprecated")
-        return self.site_url
+        return self.site_url()
 
     def full_reverse(self, request, url_name, kwargs):
         base_url = self.full_url(request)

--- a/src/press/models.py
+++ b/src/press/models.py
@@ -116,6 +116,25 @@ class Press(AbstractSiteModel):
                                             ':{0}'.format(request.port) if request != 80 or request.port == 443 else '',
                                             '/press' if settings.URL_CONFIG == 'path' else '')
 
+    def journal_path_url(self, journal, path=None):
+        """ Returns a Journal's path mode url relative to its press """
+
+        _path = journal.code
+        request = logic.get_current_request()
+        if request:
+            port = request.get_port()
+        else:
+            port = None
+        if path is not None:
+            _path += path
+
+        return logic.build_url(
+            netloc=self.domain,
+            scheme=self.SCHEMES[self.is_secure],
+            port=port,
+            path=_path,
+        )
+
     @staticmethod
     def press_cover(request, absolute=True):
         if request.press.thumbnail_image:

--- a/src/templates/admin/preprints/author_article.html
+++ b/src/templates/admin/preprints/author_article.html
@@ -1,5 +1,4 @@
 {% extends "admin/core/base.html" %}
-{% load fqdn %}
 
 {% block title %}{{ preprint.title|striptags }}{% endblock %}
 {% block title-section %}Preprint #{{ preprint.pk }} - {{ preprint.title|safe }}{% endblock %}

--- a/src/templates/admin/press/press_manager_index.html
+++ b/src/templates/admin/press/press_manager_index.html
@@ -1,7 +1,6 @@
 {% extends "admin/core/base.html" %}
 {% load foundation %}
 {% load static from staticfiles %}
-{% load fqdn %}
 
 {% block title %}Press Manager{% endblock %}
 {% block title-section %}Press Manager{% endblock %}

--- a/src/themes/OLH/templates/core/base.html
+++ b/src/themes/OLH/templates/core/base.html
@@ -22,8 +22,8 @@
     } catch (e) {
     }</script>
     {% block css %}{% endblock %}
-    <link href="{{ request.journal.site_url }}{% url 'rss_articles' %}" type="application/atom+xml" rel="alternate" title="Article Feed for Journal">
-    <link href="{{ request.journal.site_url }}{% url 'rss_news' %}" type="application/atom+xml" rel="alternate" title="News Feed for Journal">
+    <link href="{% journal_url 'rss_articles' %}" type="application/atom+xml" rel="alternate" title="Article Feed for Journal">
+    <link href="{% journal_url 'rss_news' %}" type="application/atom+xml" rel="alternate" title="News Feed for Journal">
     {% if request.journal and journal.favicon %}
         <link rel="icon" href="{{ journal.favicon.url }}" type="image/vnd.microsoft.icon" />
     {% elif request.press.favicon %}

--- a/src/themes/OLH/templates/journal/article.html
+++ b/src/themes/OLH/templates/journal/article.html
@@ -37,7 +37,7 @@
     <meta name="DC.Source.ISSN" content="{{ journal_settings.general.issn }}"/>
     <meta name="DC.Source.Issue" content="{{ article.issue.issue }}"/>
     <meta name="DC.Source.Volume" content="{{ article.issue.volume }}"/>
-    <meta name="DC.Source.URI" content="{{ request.journal.site_url }}{% url 'website_index' %}"/>
+    <meta name="DC.Source.URI" content="{% journal_url 'website_index' %}"/>
     <meta name="DC.Title" content="{{ article.title | striptags }}"/>
 
     <meta name="citation_journal_title" content="{{ journal_settings.general.journal_name }}"/>

--- a/src/themes/OLH/templates/press/press_journals.html
+++ b/src/themes/OLH/templates/press/press_journals.html
@@ -1,7 +1,6 @@
 {% extends "press/core/base.html" %}
 {% load settings %}
 {% load i18n %}
-{% load fqdn %}
 
 {% block page_title %}{% trans "Journals" %}{% endblock page_title %}
 

--- a/src/themes/default/templates/core/base.html
+++ b/src/themes/default/templates/core/base.html
@@ -20,9 +20,9 @@
     <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet"
           integrity="sha384-wvfXpqpZZVQGK6TAh5PVlGOfQNHSoD2xbE+QkPxCAFlNEevoEH3Sl0sibVcOQVnN" crossorigin="anonymous">
     {% block css %}{% endblock %}
-    <link href="{{ request.journal.site_url }}{% url 'rss_articles' %}" type="application/atom+xml" rel="alternate"
+    <link href="{% journal_url 'rss_articles' %}" type="application/atom+xml" rel="alternate"
           title="Article Feed for Journal">
-    <link href="{{ request.journal.site_url }}{% url 'rss_news' %}" type="application/atom+xml" rel="alternate"
+    <link href="{% journal_url 'rss_news' %}" type="application/atom+xml" rel="alternate"
           title="News Feed for Journal">
     {% if journal.favicon %}
         <link rel="icon" href="{{ journal.favicon.url }}" type="image/vnd.microsoft.icon"/>{% endif %}

--- a/src/themes/default/templates/journal/article.html
+++ b/src/themes/default/templates/journal/article.html
@@ -40,7 +40,7 @@
     <meta name="DC.Source.ISSN" content="{{ journal_settings.general.issn }}"/>
     <meta name="DC.Source.Issue" content="{{ article.issue.issue }}"/>
     <meta name="DC.Source.Volume" content="{{ article.issue.volume }}"/>
-    <meta name="DC.Source.URI" content="{{ request.journal.site_url }}{% url 'website_index' %}"/>
+    <meta name="DC.Source.URI" content="{% journal_url 'website_index' %}"/>
     <meta name="DC.Title" content="{{ article.title | striptags }}"/>
 
     <meta name="citation_journal_title" content="{{ journal_settings.general.journal_name }}"/>

--- a/src/themes/material/templates/core/base.html
+++ b/src/themes/material/templates/core/base.html
@@ -14,9 +14,9 @@
     <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet"
           integrity="sha384-wvfXpqpZZVQGK6TAh5PVlGOfQNHSoD2xbE+QkPxCAFlNEevoEH3Sl0sibVcOQVnN" crossorigin="anonymous">
     {% block css %}{% endblock %}
-    <link href="{{ request.journal.site_url }}{% url 'rss_articles' %}" type="application/atom+xml" rel="alternate"
+    <link href="{% journal_url 'rss_articles' %}" type="application/atom+xml" rel="alternate"
           title="Article Feed for Journal">
-    <link href="{{ request.journal.site_url }}{% url 'rss_news' %}" type="application/atom+xml" rel="alternate"
+    <link href="{% journal_url 'rss_news' %}" type="application/atom+xml" rel="alternate"
           title="News Feed for Journal">
     {% if journal.favicon %}
         <link rel="icon" href="{{ journal.favicon.url }}" type="image/vnd.microsoft.icon"/>{% endif %}

--- a/src/themes/material/templates/journal/article.html
+++ b/src/themes/material/templates/journal/article.html
@@ -43,7 +43,7 @@
     <meta name="DC.Source.ISSN" content="{{ journal_settings.general.issn }}"/>
     <meta name="DC.Source.Issue" content="{{ article.issue.issue }}"/>
     <meta name="DC.Source.Volume" content="{{ article.issue.volume }}"/>
-    <meta name="DC.Source.URI" content="{{ request.journal.site_url }}{% url 'website_index' %}"/>
+    <meta name="DC.Source.URI" content="{% journal_url 'website_index' %}"/>
     <meta name="DC.Title" content="{{ article.title | striptags }}"/>
 
     <meta name="citation_journal_title" content="{{ journal_settings.general.journal_name }}"/>

--- a/src/utils/install/journal_defaults.json
+++ b/src/utils/install/journal_defaults.json
@@ -761,7 +761,7 @@
             "type": "rich-text"
         },
         "value": {
-            "default": "<p>Dear {{ typeset_task.typesetter.full_name }},</p><p>This is an automatic notification from {{ request.user.full_name }} that you have been assigned to the production of article {{ typeset_task.assignment.article.title }}. </p><p>You can view further information on this <a href=\"{{ request.journal.site_url }}{% url 'typesetter_requests' %}\" style=\"background-color: rgb(255, 255, 255);\">here</a>.</p><p>Regards,</p><p>{{ request.user.signature|safe }}</p>"
+            "default": "<p>Dear {{ typeset_task.typesetter.full_name }},</p><p>This is an automatic notification from {{ request.user.full_name }} that you have been assigned to the production of article {{ typeset_task.assignment.article.title }}. </p><p>You can view further information on this <a href=\"{% journal_url 'typesetter_requests' %}\" style=\"background-color: rgb(255, 255, 255);\">here</a>.</p><p>Regards,</p><p>{{ request.user.signature|safe }}</p>"
         }
     },
     {
@@ -881,7 +881,7 @@
             "type": "rich-text"
         },
         "value": {
-            "default": "<p>Dear {{ typesetter_proofing_task.typesetter.full_name }},</p><p>Changes have been requested for article \"{{ article.title }}\".</p><p>You can access this request from the <a href=\"{{ request.journal.site_url }}{% url 'proofing_requests' %}\">requests page</a></p><p>Regards,<br></p><p>{{ request.user.signature|safe }}</p><p><br></p>"
+            "default": "<p>Dear {{ typesetter_proofing_task.typesetter.full_name }},</p><p>Changes have been requested for article \"{{ article.title }}\".</p><p>You can access this request from the <a href=\"{% journal_url 'proofing_requests' %}\">requests page</a></p><p>Regards,<br></p><p>{{ request.user.signature|safe }}</p><p><br></p>"
         }
     },
     {


### PR DESCRIPTION
Fixes #790 

It modifies an entry in `janeway_global_settings.py` that is probably currently overriden in 1.3.1 installations.

In #787 I'm looking at improving the new settings loader to merge certain settings types instead of just overriding them, which should make it possible to expand janeway_global_settings without requiring changes onto 1.3.1  `settings.py` files