### PR TITLE
#802: Fixes article URLs with double base URLs

### DIFF
--- a/src/templates/admin/journal/sitemap.xml
+++ b/src/templates/admin/journal/sitemap.xml
@@ -3,7 +3,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
     {% for article in articles %}
     <url>
-        <loc>{{ request.journal.site_url }}{{ article.url }}</loc>
+        <loc>{{ article.url }}</loc>
         <lastmod>{{ article.date_published|date:"Y-m-d" }}</lastmod>
         <changefreq>yearly</changefreq>
     </url>


### PR DESCRIPTION
Closes #802

There were a couple other badly formatted article URLs