### PR TITLE
Allows installation of local python packages

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,6 +37,7 @@ services:
       dockerfile: dockerfiles/Dockerfile
     volumes:
       - ./src:/vol/janeway/src
+      - ./lib:/vol/janeway/lib
       - ./db/janeway.sqlite3:/db/janeway.sqlite3
     ports:
       - "8000:8000"

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -5,6 +5,7 @@ RUN apt-get update
 RUN apt-get install -y pylint
 RUN pip3 install -r requirements.txt --src /tmp/src
 RUN pip3 install -r dev-requirements.txt --src /tmp/src
+RUN pip3 install -e lib/* || true
 RUN cp src/core/janeway_global_settings.py src/core/settings.py
 
 EXPOSE 8000


### PR DESCRIPTION
Just add the python packages under janeway/lib/ and they will get installed in the janeway docker image when running `make rebuild`.

Libraries are isntalled in development mode, changes to the local libraries will reflect on the running containers withouth having to re-run `make rebuild`