### PR TITLE
add OLH and material themes templates for author list 

### DIFF
--- a/src/themes/OLH/templates/journal/authors.html
+++ b/src/themes/OLH/templates/journal/authors.html
@@ -10,12 +10,15 @@
     <div class="row" data-equalizer data-equalize-on="medium">
        
         {% for author in author_list %}
+
             <div class="medium-3 columns {% if forloop.last %}end{% endif %}">
                 <div class="{% if journal_settings.general.enable_editorial_images %}editorial-team{% endif %} callout" data-equalizer-watch>
                    
                     {% if journal_settings.general.enable_editorial_images %}
+
                         <img class="thumbnail editorial-image" src="{% if author.profile_image %}{{ author.profile_image.url }}{% else %}{% static "common/img/icons/users.png" %}{% endif %}"
                              alt="Photo of Uranus.">
+
                     {% endif %}
                    
                     <strong>{{ author.full_name }}</strong><br/>
@@ -24,11 +27,13 @@
                     </i>
                     <br/>
                     
-                    {% if user.enable_public_profile %}
+                    {% if author.enable_public_profile %}
+
                         <p>
                             <small><a href="{% url 'core_public_profile' author.uuid %}">View
                                 Profile</a></small>
                         </p>
+                        
                     {% endif %}
 
                     {% include "elements/journal/editorial_social_content.html" with user=author %}

--- a/src/themes/OLH/templates/journal/authors.html
+++ b/src/themes/OLH/templates/journal/authors.html
@@ -1,0 +1,43 @@
+{% extends "core/base.html" %}
+{% load static from staticfiles %}
+
+{% block title %}Authors{% endblock title %}
+{% block page_title %}Authors{% endblock page_title %}
+
+{% block body %}
+
+    <h3>Authors</h3>
+    <div class="row" data-equalizer data-equalize-on="medium">
+       
+        {% for author in author_list %}
+            <div class="medium-3 columns {% if forloop.last %}end{% endif %}">
+                <div class="{% if journal_settings.general.enable_editorial_images %}editorial-team{% endif %} callout" data-equalizer-watch>
+                   
+                    {% if journal_settings.general.enable_editorial_images %}
+                        <img class="thumbnail editorial-image" src="{% if author.profile_image %}{{ author.profile_image.url }}{% else %}{% static "common/img/icons/users.png" %}{% endif %}"
+                             alt="Photo of Uranus.">
+                    {% endif %}
+                   
+                    <strong>{{ author.full_name }}</strong><br/>
+                    <i>
+                        <small>{{ author.affiliation }}</small>
+                    </i>
+                    <br/>
+                    
+                    {% if user.enable_public_profile %}
+                        <p>
+                            <small><a href="{% url 'core_public_profile' author.uuid %}">View
+                                Profile</a></small>
+                        </p>
+                    {% endif %}
+
+                    {% include "elements/journal/editorial_social_content.html" with user=author %}
+                   
+                </div>
+            </div>
+            
+        {% endfor %}
+
+    </div>
+
+{% endblock body %}

--- a/src/themes/default/templates/journal/authors.html
+++ b/src/themes/default/templates/journal/authors.html
@@ -8,6 +8,7 @@
 
     <h3>Authors</h3>
     <div class="row">
+
         {% for author in author_list %}
             <div class="col-md-3 row-eq-height">
                 <div class="card" style="width: 20rem;">
@@ -18,16 +19,21 @@
                         <p>
                             <small>{{ author.affiliation }}</small>
                         </p>
+                        
                         {% if author.enable_public_profile %}
                             <p>
-                                <small><a href="{% url 'core_public_profile' author.uuid %}">View Profile</a>
+                                <small>
+                                    <a href="{% url 'core_public_profile' author.uuid %}">View Profile</a>
                                 </small>
-                            </p>{% endif %}
+                            </p>
+                        {% endif %}
+                        
                         {% include "elements/journal/editorial_social_content.html" with user=author %}
                     </div>
                 </div>
             </div>
         {% endfor %}
+        
     </div>
 
 {% endblock body %}

--- a/src/themes/material/templates/journal/authors.html
+++ b/src/themes/material/templates/journal/authors.html
@@ -10,6 +10,7 @@
     <div class="row">
        
         {% for author in author_list %}
+
             <div class="col s12 m3">
                 <div class="card editorial-card">
                     <div class="card-image">
@@ -21,15 +22,21 @@
                         <p>
                             <small>{{ author.affiliation }}</small>
                         </p>
+
                         {% if author.enable_public_profile %}
+
                             <p>
-                                <small><a href="{% url 'core_public_profile' author.uuid %}">View Profile</a>
+                                <small>
+                                    <a href="{% url 'core_public_profile' author.uuid %}">View Profile</a>
                                 </small>
                             </p>
+
                         {% endif %}
 
                         <p>
+
                            {% include "elements/journal/editorial_social_content.html" with user=author %}
+                           
                         </p>
 
                     </div>

--- a/src/themes/material/templates/journal/authors.html
+++ b/src/themes/material/templates/journal/authors.html
@@ -1,0 +1,43 @@
+{% extends "core/base.html" %}
+{% load static from staticfiles %}
+
+{% block title %}Authors{% endblock title %}
+{% block page_title %}Authors{% endblock page_title %}
+
+{% block body %}
+
+    <h3>Authors</h3>
+    <div class="row">
+       
+        {% for author in author_list %}
+            <div class="col s12 m3">
+                <div class="card editorial-card">
+                    <div class="card-image">
+                         <img src="{% if author.profile_image %}{{ author.profile_image.url }}{% else %}{% static "common/img/icons/users.png" %}{% endif %}"
+                         alt="Card image cap">
+                    </div>
+                    <div class="card-content" style="min-height: 190px;">
+                         <span class="card-title small-card-title">{{ author.full_name }}</span>
+                        <p>
+                            <small>{{ author.affiliation }}</small>
+                        </p>
+                        {% if author.enable_public_profile %}
+                            <p>
+                                <small><a href="{% url 'core_public_profile' author.uuid %}">View Profile</a>
+                                </small>
+                            </p>
+                        {% endif %}
+
+                        <p>
+                           {% include "elements/journal/editorial_social_content.html" with user=author %}
+                        </p>
+
+                    </div>
+                </div>
+            </div>
+                       
+        {% endfor %}
+
+    </div>
+
+{% endblock body %}


### PR DESCRIPTION
I was missing these in my initial PR. remedying that now with styles that match the editorial_team.html for both those themes. Also, made the default template file a little more legible with white space. 