### PR TITLE
Fixes migration 0019 for postgres

### DIFF
--- a/src/core/migrations/0019_adds_DomainAlias_journal_FK.py
+++ b/src/core/migrations/0019_adds_DomainAlias_journal_FK.py
@@ -34,6 +34,7 @@ def sitesectomy(*args, **kwargs):
             pass
 
 class Migration(migrations.Migration):
+    atomic = False
 
     dependencies = [
         ('journal', '0017_file_fields_for_the_last_time'),


### PR DESCRIPTION
The custom SQL can't be reverted with django.db.backends.postgresql as the whole migration runs within an atomic block.