### PR TITLE
review form preview

### DIFF
--- a/src/review/forms.py
+++ b/src/review/forms.py
@@ -13,6 +13,7 @@ from review import models
 from review.logic import render_choices
 from core import models as core_models
 from utils import setting_handler
+from utils.forms import FakeModelForm
 
 
 class DraftDecisionForm(forms.ModelForm):
@@ -58,6 +59,13 @@ class ReviewerDecisionForm(forms.ModelForm):
     class Meta:
         model = models.ReviewAssignment
         fields = ('decision', 'comments_for_editor')
+
+
+class FakeReviewerDecisionForm(FakeModelForm, ReviewerDecisionForm):
+
+    def __init__(self, *args, **kwargs):
+        kwargs["disable_fields"] = True
+        super().__init__(*args, **kwargs)
 
 
 class ReplacementFileDetails(forms.ModelForm):

--- a/src/review/views.py
+++ b/src/review/views.py
@@ -908,6 +908,10 @@ def notify_reviewer(request, article_id, review_id):
     review = get_object_or_404(models.ReviewAssignment, pk=review_id)
 
     email_content = logic.get_reviewer_notification(request, article, request.user, review)
+    review_form = forms.FakeReviewerDecisionForm(instance=review)
+
+    if 'review_file' in request.GET:
+        return logic.serve_review_file(review)
 
     if request.POST:
         email_content = request.POST.get('content_email')
@@ -934,6 +938,8 @@ def notify_reviewer(request, article_id, review_id):
         'article': article,
         'review': review,
         'email_content': email_content,
+        'review_form': review_form,
+        'assignment': review,
     }
 
     return render(request, template, context)

--- a/src/templates/admin/review/notify_reviewer.html
+++ b/src/templates/admin/review/notify_reviewer.html
@@ -36,13 +36,41 @@
                         <label for="attachment"><p>Attachment (You can select multiple files): </p></label>
                         <input type="file" name="attachment" multiple>
                     </div>
-                    <div class="card-divider">
-                        <div class="button-group">
-                            <button type="submit" class="button success" name="send"><i
-                                    class="fa fa-envelope-o">&nbsp;</i>Send
-                            </button>
-                            <button type="submit" class="button warning" name="skip"><i class="fa fa-step-forward">&nbsp;</i>Skip
-                            </button>
+                    <div>
+                      <div class="columns">
+                        <ul class="accordion" data-accordion data-allow-all-closed="true">
+                          <li class="accordion-item is-active" data-accordion-item>
+                            <a href="#" class="accordion-title">Review Form Preview</a>
+                            <div class="accordion-content" data-tab-content aria-hidden="true", display="none">
+                                <div class="card-divider">
+                                    <h4> Inline Form </h4>
+                                     {{ review_form }}
+                                </div>
+                                 {% if journal_settings.general.reviewer_form_download %}
+                                 <div class="card-divider">
+                                    <h4>Downloadable Form</h4>
+                                    <p>The Reviewer can also download a
+                                      <a class="" href="{% url 'review_notify_reviewer' assignment.article.pk assignment.pk %}{% if access_code %}?access_code={{ access_code }}&review_file=True{% else %}?review_file=True{% endif %}">
+                                          review File
+                                      </a>
+                                    </p>
+                                </div>
+                                {% endif %}
+
+                            </div>
+                          </li>
+                        </ul>
+                      </div>
+                    </div>
+                    <div class="card">
+                        <div class="card-divider">
+                            <div class="button-group">
+                                <button type="submit" class="button success" name="send"><i
+                                        class="fa fa-envelope-o">&nbsp;</i>Send
+                                </button>
+                                <button type="submit" class="button warning" name="skip"><i class="fa fa-step-forward">&nbsp;</i>Skip
+                                </button>
+                            </div>
                         </div>
                     </div>
                 </form>

--- a/src/utils/forms.py
+++ b/src/utils/forms.py
@@ -1,0 +1,25 @@
+from django.forms import ModelForm
+
+class FakeModelForm(ModelForm):
+	""" A form that can't be saved
+	
+	Usefull for rendering a sample form
+	"""
+
+	def __init__(self, *args, disable_fields=False, **kwargs):
+		super().__init__(*args, **kwargs)
+		self.disable_fields = disable_fields
+		if disable_fields is True:
+			for field in self.fields:
+				self.fields[field].widget.attrs["readonly"] = True
+
+	def save(self, *args, **kwargs):
+		raise NotImplementedError("FakeModelForm can't be saved")
+
+	def clean(self, *args, **kwargs):
+		if self.disable_fields is True:
+			raise NotImplementedError(
+				"FakeModelForm can't be cleaned: disable_fields is True",
+			)
+		return super().clean(*args, **kwargs)
+

--- a/src/utils/tests.py
+++ b/src/utils/tests.py
@@ -9,6 +9,7 @@ from django.core import mail
 from django.contrib.contenttypes.models import ContentType
 
 from utils import merge_settings, transactional_emails
+from utils.forms import FakeModelForm
 from utils.testing import helpers
 from journal import models as journal_models
 from review import models as review_models
@@ -126,3 +127,18 @@ class TestMergeSettings(TestCase):
         result = merge_settings(base, overrides)
 
         self.assertDictEqual(expected, result)
+
+class TestForms(TestCase):
+
+    def test_fake_model_form(self):
+
+        class FakeTestForm(FakeModelForm):
+            class Meta:
+                model = journal_models.Journal
+                exclude = tuple()
+
+        form = FakeTestForm()
+
+        with self.assertRaises(NotImplementedError):
+            form.save()
+


### PR DESCRIPTION
Closes #848 
Adds a preview of the inline review form as well as a link to download the file within a foundation accordion:

![image](https://user-images.githubusercontent.com/10760678/52723033-afacf300-2fa4-11e9-8471-1b9347de403e.png)
