### PR TITLE
use method to unlink file from article, not delete file

### DIFF
--- a/src/review/views.py
+++ b/src/review/views.py
@@ -1488,7 +1488,7 @@ def do_revisions(request, article_id, revision_id):
         if 'delete' in request.POST:
             file_id = request.POST.get('delete')
             file = get_object_or_404(core_models.File, pk=file_id)
-            file.delete()
+            files.delete_file(revision_request.article, file)
             logic.log_revision_event('File {0} ({1}) deleted.'.format(file.id, file.original_filename), request.user,
                                      revision_request)
             return redirect(reverse('do_revisions', kwargs={'article_id': article_id, 'revision_id': revision_id}))


### PR DESCRIPTION
use files.delete_file(article,file) instead of file.delete() from core.files.py to unset file from article when author is performing a revision. 
file is still available in document manager.