### PR TITLE
1.3.3 minor fixes

### DIFF
--- a/src/core/middleware.py
+++ b/src/core/middleware.py
@@ -108,6 +108,7 @@ class SiteSettingsMiddleware(object):
             request.journal = None
             request.site_type = press
             request.model_content_type = ContentType.objects.get_for_model(press)
+            request.press_base_url = press.site_url()
         else:
             raise Http404()
 

--- a/src/core/model_utils.py
+++ b/src/core/model_utils.py
@@ -45,5 +45,5 @@ class AbstractSiteModel(models.Model):
         return logic.build_url(
             netloc=self.domain,
             scheme=self.SCHEMES[self.is_secure],
-            path=path,
+            path=path or "",
         )


### PR DESCRIPTION
- Fixes relative emails sent for settings stored in the Press as attributes
- Fixes a bad url on the press base template when calling press.site_url with `path=None`