### PR TITLE
Display article sub. date on issue manager

### DIFF
--- a/src/templates/admin/elements/issue/table_of_contents.html
+++ b/src/templates/admin/elements/issue/table_of_contents.html
@@ -23,6 +23,7 @@
                         <tr>
                             <th width="5%">ID</th>
                             <th width="30%">Title</th>
+                            <th>Date Submitted</th>
                             <th width="15%">Authors</th>
                             <th width="10%">Section</th>
                             <th width="10%">DOI</th>
@@ -37,6 +38,7 @@
                                 <td>
                                     <a href="{% url 'manage_archive_article' article.pk %}">{{ article.title|safe }}</a>
                                 </td>
+                                <td>{{ article.date_submitted }}</td>
                                 <td>{{ article.author_list }}</td>
                                 <td>{{ article.section.name }}</td>
                                 <td>{{ article.get_doi }}</td>

--- a/src/templates/admin/journal/manage/issue_add_article.html
+++ b/src/templates/admin/journal/manage/issue_add_article.html
@@ -52,6 +52,7 @@
                         <tr>
                             <th>ID</th>
                             <th>Title</th>
+                            <th>Date Submitted</th>
                             <th>Authors</th>
                             <th>Section</th>
                             <th>DOI</th>
@@ -65,6 +66,7 @@
                         <tr id="articles-{{ dict.article.pk }}">
                             <td>{{ article.id }}</td>
                             <td>{{ article.title|safe }}</td>
+                            <td>{{ article.date_submitted }}</td>
                             <td>{{ article.author_list }}</td>
                             <td>{{ article.section.name }}</td>
                             <td>{{ article.get_doi }}</td>


### PR DESCRIPTION
This adds a column to the issue ToC and add_article interface in the issue manager so that editors can sort by the article date submitted.

This is particularly helpful when using the [archive plugin](https://github.com/dSHARP-CMU/archive_plugin) when you need to select between multiple article versions with the same title.