### PR TITLE
journal link via press determined on DEBUG in settings.

### DIFF
--- a/src/press/models.py
+++ b/src/press/models.py
@@ -142,10 +142,9 @@ class Press(AbstractSiteModel):
         request = logic.get_current_request()
         if settings.DEBUG:
             port = request.get_port()
+            _path += path
         else:
             port = None
-        if path is not None:
-            _path += path
 
         return logic.build_url(
             netloc=self.domain,

--- a/src/press/models.py
+++ b/src/press/models.py
@@ -140,7 +140,7 @@ class Press(AbstractSiteModel):
 
         _path = journal.code
         request = logic.get_current_request()
-        if request:
+        if settings.DEBUG:
             port = request.get_port()
         else:
             port = None

--- a/src/press/models.py
+++ b/src/press/models.py
@@ -139,12 +139,12 @@ class Press(AbstractSiteModel):
         """ Returns a Journal's path mode url relative to its press """
 
         _path = journal.code
-        request = logic.get_current_request()
         if settings.DEBUG:
-            port = request.get_port()
-            _path += path
+            port = logic.get_current_request().get_port()
         else:
             port = None
+        if path is not None:
+            _path += path
 
         return logic.build_url(
             netloc=self.domain,

--- a/src/themes/OLH/templates/journal/homepage_elements/journals.html
+++ b/src/themes/OLH/templates/journal/homepage_elements/journals.html
@@ -19,12 +19,12 @@
 
                     {% else %}
 
-                        <a href="{{current_journal.site_url}}"
+                        <a href="{{ current_journal.site_url }}"
                            class="box-link"></a>
                         <img src="{% if current_journal.default_cover_image %}{{ current_journal.default_cover_image.url }}{% endif %}" alt="{% if current_journal.name != " " and current_journal.name != "" %}{{ current_journal.name }}{% else %}Unnamed Journal{% endif %}"></img>
                         </a>
                         <div class="content">
-                            <h3><a href="{{current_journal.site_url}}"/>{% if current_journal.name != " " and current_journal.name != "" %}
+                            <h3><a href="{{ current_journal.site_url }}"/>{% if current_journal.name != " " and current_journal.name != "" %}
                                 {{ current_journal.name }}{% else %}{% trans "Unnamed Journal" %}{% endif %}</a></h3>
                         </div>
                     {% endif %}

--- a/src/themes/OLH/templates/journal/homepage_elements/journals.html
+++ b/src/themes/OLH/templates/journal/homepage_elements/journals.html
@@ -19,12 +19,12 @@
 
                     {% else %}
 
-                        <a href="http{% if request.port == "443" %}s{% endif %}://{{ current_journal.domain }}{% if request.port != "80" and request.port != "443" %}:{{ request.port }}{% endif %}"
+                        <a href="{{current_journal.site_url}}"
                            class="box-link"></a>
                         <img src="{% if current_journal.default_cover_image %}{{ current_journal.default_cover_image.url }}{% endif %}" alt="{% if current_journal.name != " " and current_journal.name != "" %}{{ current_journal.name }}{% else %}Unnamed Journal{% endif %}"></img>
                         </a>
                         <div class="content">
-                            <h3><a href="http{% if request.port == "443" %}s{% endif %}://{{ current_journal.domain }}{% if request.port != "80" and request.port != "443" %}:{{ request.port }}{% endif %}"/>{% if current_journal.name != " " and current_journal.name != "" %}
+                            <h3><a href="{{current_journal.site_url}}"/>{% if current_journal.name != " " and current_journal.name != "" %}
                                 {{ current_journal.name }}{% else %}{% trans "Unnamed Journal" %}{% endif %}</a></h3>
                         </div>
                     {% endif %}

--- a/src/themes/OLH/templates/press/press_journals.html
+++ b/src/themes/OLH/templates/press/press_journals.html
@@ -24,7 +24,7 @@
                                             {% if current_journal.is_remote %}
                                             <a href="{{ current_journal.remote_view_url }}">
                                             {% else %}
-                                            <a href="{{ current_journal.full_url }}">
+                                            <a href="{{ current_journal.site_url }}">
                                             {% endif %}
                                                 <img src="{% if current_journal.default_cover_image %}{{ current_journal.default_cover_image.url }}{% endif %}"
                                                      alt="{% if current_journal.name != " " and current_journal.name != "" %}{{ current_journal.name }}{% else %}Unnamed Journal{% endif %}">

--- a/src/themes/default/templates/journal/homepage_elements/journals.html
+++ b/src/themes/default/templates/journal/homepage_elements/journals.html
@@ -12,8 +12,7 @@
                     {% if current_journal.is_remote %}
                         <a href="{{ current_journal.remote_view_url }}">
                     {% else %}
-                        <a href="http{% if request.port == "443" %}s{% endif %}://
-                                {{ current_journal.domain }}{% if request.port != "80" and request.port != "443" %}:{{ request.port }}{% endif %}">
+                        <a href="{{current_journal.site_url}}">
                     {% endif %}
                     <h7 class="card-title">{{ current_journal.name }}</h7>
                     </a>

--- a/src/themes/default/templates/journal/homepage_elements/journals.html
+++ b/src/themes/default/templates/journal/homepage_elements/journals.html
@@ -12,7 +12,7 @@
                     {% if current_journal.is_remote %}
                         <a href="{{ current_journal.remote_view_url }}">
                     {% else %}
-                        <a href="{{current_journal.site_url}}">
+                        <a href="{{ current_journal.site_url }}">
                     {% endif %}
                     <h7 class="card-title">{{ current_journal.name }}</h7>
                     </a>

--- a/src/themes/material/templates/journal/homepage_elements/journals.html
+++ b/src/themes/material/templates/journal/homepage_elements/journals.html
@@ -15,7 +15,7 @@
                     {% if current_journal.is_remote %}
                         <a href="{{ current_journal.remote_view_url }}">
                     {% else %}
-                        <a href="{{current_journal.site_url}}">
+                        <a href="{{ current_journal.site_url }}">
                     {% endif %}
                     <h7 class="card-title">{{ current_journal.name }}</h7>
                     </a>

--- a/src/themes/material/templates/journal/homepage_elements/journals.html
+++ b/src/themes/material/templates/journal/homepage_elements/journals.html
@@ -15,7 +15,7 @@
                     {% if current_journal.is_remote %}
                         <a href="{{ current_journal.remote_view_url }}">
                     {% else %}
-                        <a href="http{% if request.port == "443" %}s{% endif %}://{{ current_journal.domain }}{% if request.port != "80" and request.port != "443" %}:{{ request.port }}{% endif %}">
+                        <a href="{{current_journal.site_url}}">
                     {% endif %}
                     <h7 class="card-title">{{ current_journal.name }}</h7>
                     </a>


### PR DESCRIPTION
remove deprecated `full_url` for `site_url`. remove port handling in template of press_journals in OLH.
BTW, I noticed no `/templates/press/press_journals.html` for default or material themes.