### PR TITLE
Bump python to 3.5:latest on base docker image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,7 @@ install:	## Run the install_janeway command inside a container
 	touch db/janeway.sqlite3
 	bash -c "make command CMD=install_janeway"
 rebuild:	## Rebuild the Janeway docker image.
+	docker pull birkbeckctp/janeway-base:latest
 	docker-compose build --no-cache janeway-web
 shell:		## Runs the janeway-web service and starts an interactive bash process instead of the webserver
 	docker-compose run --entrypoint=/bin/bash --rm janeway-web

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -1,11 +1,11 @@
-FROM birkbeckctp/janeway-base
+FROM birkbeckctp/janeway-base:latest
 ADD . /vol/janeway
 WORKDIR /vol/janeway
 RUN apt-get update
 RUN apt-get install -y pylint
 RUN pip3 install -r requirements.txt --src /tmp/src
 RUN pip3 install -r dev-requirements.txt --src /tmp/src
-RUN pip3 install -e lib/* || true
+RUN if ! [ -n "$(ls -A /lib)" ]; then pip3 install -e lib/*; fi
 RUN cp src/core/janeway_global_settings.py src/core/settings.py
 
 EXPOSE 8000

--- a/dockerfiles/Dockerfile.base
+++ b/dockerfiles/Dockerfile.base
@@ -1,4 +1,4 @@
-FROM python:3.5.4
+FROM python:3.5
 ADD ./dockerfiles/janeway.sqlite3 /db/janeway.sqlite3
 RUN curl https://raw.githubusercontent.com/BirkbeckCTP/janeway/master/requirements.txt > /tmp/requirements.txt
 RUN pip3 install -r /tmp/requirements.txt


### PR DESCRIPTION
The python:3.5.4 docker image is now stale. I've changed the docker files to use the latest python:3.5 image instead. (it also upgrades pip to the latest version).