### PR TITLE
#1028: Bumps django-summernote (adds relative links)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ django-markdown-deux==1.0.5
 django-settings-export==1.2.1
 -e git+https://github.com/BirkbeckCTP/django-simple-math-captcha@1.11_fix#egg=django-simple-math-captcha
 django-recaptcha2==1.0.3
-django-summernote==0.8.8.1
+django-summernote==0.8.11.1
 djangorestframework==3.6.3
 -e git+https://github.com/BirkbeckCTP/django-dynamicsites@f439c524cf964d957a75fbec4b23ad03a9a5d159#egg=dynamicsites
 -e git+https://github.com/BirkbeckCTP/ebooklib@b7005c57602eeea06358ac569a4cf52c630a32ef#egg=ebooklib


### PR DESCRIPTION
I tested the playground on `django-summernote` 0.8.11 and it does solve this issue, which was solved in summernote itself: https://github.com/summernote/summernote/pull/2933

closes #1028 