### PR TITLE
Fixes default SCSS override behaviour

### DIFF
--- a/src/journal/logic.py
+++ b/src/journal/logic.py
@@ -3,12 +3,13 @@ __author__ = "Martin Paul Eve & Andy Byers"
 __license__ = "AGPL v3"
 __maintainer__ = "Birkbeck Centre for Technology and Publishing"
 
+from bs4 import BeautifulSoup
+import csv
+from dateutil import parser as dateparser
+import logging
 from os import listdir, makedirs
 from os.path import isfile, join
 import requests
-from dateutil import parser as dateparser
-from bs4 import BeautifulSoup
-import csv
 from urllib.parse import urlencode
 
 from django.contrib import messages
@@ -58,19 +59,17 @@ def list_scss(journal):
     :param journal: the journal in question
     :return: a list of SCSS files
     """
-    file_paths = []
-    scss_default_override = join(
-            settings.BASE_DIR, 'files', 'styling', 'journals', 'default')
-    scss_path = join(settings.BASE_DIR, 'files', 'styling', 'journals', str(journal.id))
-    for path in [scss_default_override, scss_path]:
-        try:
-            makedirs(scss_path, exist_ok=True)
-            file_paths += [
-                    join(path, f)
-                    for f in listdir(path) if isfile(join(path, f))
-            ]
-        except FileNotFoundError:
-            pass
+    scss_path = join(
+            settings.BASE_DIR, 'files', 'styling', 'journals', str(journal.id))
+    try:
+        makedirs(scss_path, exist_ok=True)
+        file_paths = [
+                join(scss_path, f)
+                for f in listdir(scss_path) if isfile(join(scss_path, f))
+        ]
+    except FileNotFoundError:
+        logging.warning("Failed to load scss from %s" % scss_path)
+        file_paths = []
 
     return file_paths
 

--- a/src/themes/OLH/templates/core/base.html
+++ b/src/themes/OLH/templates/core/base.html
@@ -15,6 +15,7 @@
     <link href="{% static "OLH/css/app.css" %}" rel="stylesheet">
     <link href="{% static "common/css/common.css" %}" rel="stylesheet">
     {% if request.journal %}
+        <link href="{% static "OLH/css/default_override.css" %}" rel="stylesheet">
         <link href="{% static "OLH/css/journal" %}{{ request.journal.id }}_override.css" rel="stylesheet">
     {% endif %}
     <script src="https://use.typekit.net/lff8ikn.js"></script>


### PR DESCRIPTION
Previous implementation of SCSS default override would ignore journal specific overrides.
Now both will be processed correctly and imported in the template in the right order