### PR TITLE
1136 performance improvements

### DIFF
--- a/src/journal/models.py
+++ b/src/journal/models.py
@@ -531,7 +531,7 @@ class Issue(models.Model):
 
     def structure(self):
         # This method is very inefficient and is not used in core anymore
-        # Kept for backwards compatibility with external themes
+        # Kept for backwards compatibility with 3rd party themes
         logger.warning(
             "Using 'Issue.structure' will be deprecated as of Janeway 1.4"
         )

--- a/src/journal/models.py
+++ b/src/journal/models.py
@@ -530,6 +530,11 @@ class Issue(models.Model):
         return sorted(ordered_list, key=itemgetter('order'))
 
     def structure(self):
+        # This method is very inefficient and is not used in core anymore
+        # Kept for backwards compatibility with external themes
+        logger.warning(
+            "Using 'Issue.structure' will be deprecated as of Janeway 1.4"
+        )
         structure = collections.OrderedDict()
 
         sections = self.all_sections

--- a/src/journal/views.py
+++ b/src/journal/views.py
@@ -172,8 +172,10 @@ def current_issue(request, show_sidebar=True):
 
 @has_journal
 def issue(request, issue_id, show_sidebar=True):
-    """ Renders a specific issue in the journal.
+    """ Renders a specific issue/collection in the journal.
 
+    It also returns all the other issues/collections in the journal
+    for building a navigation menu
     :param request: the request associated with this call
     :param issue_id: the ID of the issue to render
     :param show_sidebar: whether or not to show the sidebar of issues
@@ -183,20 +185,21 @@ def issue(request, issue_id, show_sidebar=True):
         models.Issue.objects.prefetch_related('editors'),
         pk=issue_id,
         journal=request.journal,
-        issue_type='Issue',
         date__lte=timezone.now(),
     )
     articles = issue_object.articles.all().order_by(
         'section',
-        'page_numbers').prefetch_related(
+        'page_numbers',
+    ).prefetch_related(
         'authors', 'frozenauthor_set',
-        'manuscript_files').select_related(
+        'manuscript_files'
+    ).select_related(
         'section',
     )
 
     issue_objects = models.Issue.objects.filter(
         journal=request.journal,
-        issue_type='Issue',
+        issue_type=issue_object.issue_type,
     )
 
     editors = models.IssueEditor.objects.filter(
@@ -235,29 +238,14 @@ def collections(request):
 @has_journal
 def collection(request, collection_id, show_sidebar=True):
     """
-    Displays a single collection.
+    A proxy view for an issue of type `Collection`.
     :param request: request object
     :param collection_id: primary key of an Issue object
     :param show_sidebar: boolean
     :return: a rendered template
     """
 
-    collection = get_object_or_404(models.Issue, journal=request.journal, issue_type='Collection', pk=collection_id)
-    collections = models.Issue.objects.filter(journal=request.journal, issue_type='Collection')
-
-    articles = collection.articles.all().order_by(
-        'section', 'page_numbers').prefetch_related('authors', 'manuscript_files').select_related('section')
-
-    template = 'journal/issue.html'
-    context = {
-        'issue': collection,
-        'issues': collections,
-        'structure': collection.structure(),
-        'show_sidebar': show_sidebar,
-        'collection': True,
-    }
-
-    return render(request, template, context)
+    return issue(request, collection_id, show_sidebar)
 
 
 @article_exists

--- a/src/journal/views.py
+++ b/src/journal/views.py
@@ -220,7 +220,8 @@ def issue(request, issue_id, show_sidebar=True):
     context = {
         'issue': issue_object,
         'issues': issue_objects,
-        'structure': issue_object.structure(),
+        'structure': issue_object.structure,
+        'articles': articles,
         'editors': editors,
         'show_sidebar': show_sidebar,
     }

--- a/src/journal/views.py
+++ b/src/journal/views.py
@@ -16,7 +16,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.contrib.staticfiles.templatetags.staticfiles import static
 from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
 from django.urls import reverse
-from django.db.models import Q, Count
+from django.db.models import Q, Count, OuterRef, Subquery, Value
 from django.http import Http404, HttpResponse
 from django.shortcuts import render, get_object_or_404, redirect
 from django.utils import timezone
@@ -187,15 +187,26 @@ def issue(request, issue_id, show_sidebar=True):
         journal=request.journal,
         date__lte=timezone.now(),
     )
-    issue_articles = issue_object.articles.all().order_by(
-        'section',
-        'page_numbers',
-    ).prefetch_related(
+    section_order_subquery = models.SectionOrdering.objects.filter(
+        section=OuterRef("section__pk"),
+        issue=Value(issue_object.pk),
+    ).values_list("order")
+
+    article_order_subquery = models.ArticleOrdering.objects.filter(
+        section=OuterRef("section__pk"),
+        article=OuterRef("pk"),
+        issue=Value(issue_object.pk),
+    ).values_list("order")
+
+    issue_articles = issue_object.articles.all().prefetch_related(
         'authors', 'frozenauthor_set',
-        'manuscript_files'
+        'manuscript_files',
     ).select_related(
         'section',
-    )
+    ).annotate(
+        section_order=Subquery(section_order_subquery),
+        article_order=Subquery(article_order_subquery),
+    ).order_by("section_order", "article_order")
 
     page = request.GET.get("page", 1)
     paginator = Paginator(issue_articles, 50)

--- a/src/journal/views.py
+++ b/src/journal/views.py
@@ -220,7 +220,7 @@ def issue(request, issue_id, show_sidebar=True):
     context = {
         'issue': issue_object,
         'issues': issue_objects,
-        'structure': issue_object.structure,
+        'structure': issue_object.structure, # for backwards compatibility
         'articles': articles,
         'editors': editors,
         'show_sidebar': show_sidebar,

--- a/src/journal/views.py
+++ b/src/journal/views.py
@@ -187,7 +187,7 @@ def issue(request, issue_id, show_sidebar=True):
         journal=request.journal,
         date__lte=timezone.now(),
     )
-    articles = issue_object.articles.all().order_by(
+    issue_articles = issue_object.articles.all().order_by(
         'section',
         'page_numbers',
     ).prefetch_related(
@@ -196,6 +196,16 @@ def issue(request, issue_id, show_sidebar=True):
     ).select_related(
         'section',
     )
+
+    page = request.GET.get("page", 1)
+    paginator = Paginator(issue_articles, 50)
+
+    try:
+        articles = paginator.page(page)
+    except PageNotAnInteger:
+        articles = paginator.page(1)
+    except EmptyPage:
+        articles = paginator.page(paginator.num_pages)
 
     issue_objects = models.Issue.objects.filter(
         journal=request.journal,

--- a/src/journal/views.py
+++ b/src/journal/views.py
@@ -16,7 +16,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.contrib.staticfiles.templatetags.staticfiles import static
 from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
 from django.urls import reverse
-from django.db.models import Q, Count, OuterRef, Subquery, Value
+from django.db.models import Q, Count
 from django.http import Http404, HttpResponse
 from django.shortcuts import render, get_object_or_404, redirect
 from django.utils import timezone
@@ -187,29 +187,9 @@ def issue(request, issue_id, show_sidebar=True):
         journal=request.journal,
         date__lte=timezone.now(),
     )
-    section_order_subquery = models.SectionOrdering.objects.filter(
-        section=OuterRef("section__pk"),
-        issue=Value(issue_object.pk),
-    ).values_list("order")
-
-    article_order_subquery = models.ArticleOrdering.objects.filter(
-        section=OuterRef("section__pk"),
-        article=OuterRef("pk"),
-        issue=Value(issue_object.pk),
-    ).values_list("order")
-
-    issue_articles = issue_object.articles.all().prefetch_related(
-        'authors', 'frozenauthor_set',
-        'manuscript_files',
-    ).select_related(
-        'section',
-    ).annotate(
-        section_order=Subquery(section_order_subquery),
-        article_order=Subquery(article_order_subquery),
-    ).order_by("section_order", "article_order")
 
     page = request.GET.get("page", 1)
-    paginator = Paginator(issue_articles, 50)
+    paginator = Paginator(issue_object.get_sorted_articles(), 50)
 
     try:
         articles = paginator.page(page)

--- a/src/themes/OLH/templates/journal/issue_display.html
+++ b/src/themes/OLH/templates/journal/issue_display.html
@@ -38,6 +38,7 @@
             {% endfor %}
         {% endfor %}
         </div>
+        {% if articles %}
         <div class="pagination-block">
             <ul class="pagination">
                 {% if articles.has_previous %}
@@ -54,6 +55,7 @@
             </ul>
         </div>
     </div>
+    {% endif %}
     {% if show_sidebar %}
         <aside class="large-4 columns" data-sticky-container>
             <div class="sticky" data-sticky data-margin-top="0" data-sticky data-anchor="issue_top">

--- a/src/themes/OLH/templates/journal/issue_display.html
+++ b/src/themes/OLH/templates/journal/issue_display.html
@@ -1,5 +1,6 @@
 {% load staticfiles %}
 {% load i18n %}
+{% load pages %}
 
 <div class="row">
     <div class="large-{% if not show_sidebar %}12{% else %}8 border-right{% endif %} columns" id="issue_top">
@@ -28,12 +29,30 @@
 
 
     <div class="large-{% if not show_sidebar %}12{% else %}8 border-right{% endif %} columns end">
-        {% for section, articles in structure.items %}
+        <div>
+        {% regroup articles by section as grouped_articles %}
+        {% for section, section_articles in grouped_articles %}
             <h4 class="em">{{ section.name }}</h4>
-            {% for article in articles %}
+            {% for article in section_articles %}
                 {% include "elements/journal/box_article.html" with article=article %}
             {% endfor %}
         {% endfor %}
+        </div>
+        <div class="pagination-block">
+            <ul class="pagination">
+                {% if articles.has_previous %}
+                    <li class="arrow"><a href="?page={{ articles.previous_page_number }}">&laquo;</a>
+                    </li>{% endif %}
+                {{ articles.page.page_range }}
+                {% for page in articles|slice_pages:3 %}
+                    <li class="{% if articles.number == page.number %}current{% endif %}"><a
+                            href="?page={{ page.number }}">{{ page.number }}</a></li>
+                {% endfor %}
+                {% if articles.has_next %}
+                    <li class="arrow"><a href="?page={{ articles.next_page_number }}">&raquo;</a>
+                    </li>{% endif %}
+            </ul>
+        </div>
     </div>
     {% if show_sidebar %}
         <aside class="large-4 columns" data-sticky-container>

--- a/src/themes/default/templates/journal/issue_display.html
+++ b/src/themes/default/templates/journal/issue_display.html
@@ -1,5 +1,6 @@
 {% load staticfiles %}
 {% load i18n %}
+{% load pages %}
 
 <div class="row">
     <div class="col-md-{% if not show_sidebar %}12{% else %}8 border-right{% endif %}" id="issue_top">
@@ -18,12 +19,27 @@
         {% endif %}
         <br/>
 
-        {% for section, articles in structure.items %}
+        {% regroup articles by section as grouped_articles %}
+        {% for section, section_articles in grouped_articles %}
             <h3 class="em">{{ section.name }}</h3>
-            {% for article in articles %}
+            {% for article in section_articles %}
                 {% include "elements/article_listing.html" with article=article %}
             {% endfor %}
         {% endfor %}
+        <div class="pagination-block">
+            <ul class="d-flex justify-content-center">
+                {% if articles.has_previous %}
+                    <a href="?page={{ articles.previous_page_number }}" class="btn btn-primary">&laquo;</a>
+                    &nbsp;{% endif %}
+                {{ articles.page.page_range }}
+                {% for page in articles.paginator.page_range %}
+                    <a href="?page={{ page }}" class="btn btn-primary">{{ page }}</a>&nbsp;
+                {% endfor %}
+                {% if articles.has_next %}
+                    <a href="?page={{ articles.next_page_number }}" class="btn btn-primary">&raquo;</a>
+                {% endif %}
+            </ul>
+        </div>
     </div>
 
     {% if show_sidebar %}

--- a/src/themes/default/templates/journal/issue_display.html
+++ b/src/themes/default/templates/journal/issue_display.html
@@ -26,6 +26,7 @@
                 {% include "elements/article_listing.html" with article=article %}
             {% endfor %}
         {% endfor %}
+        {% if articles %}
         <div class="pagination-block">
             <ul class="d-flex justify-content-center">
                 {% if articles.has_previous %}
@@ -40,6 +41,7 @@
                 {% endif %}
             </ul>
         </div>
+        {% endif %}
     </div>
 
     {% if show_sidebar %}

--- a/src/themes/material/templates/journal/issue_display.html
+++ b/src/themes/material/templates/journal/issue_display.html
@@ -27,6 +27,7 @@
                 {% include "elements/article_listing.html" with article=article %}
             {% endfor %}
         {% endfor %}
+        {% if articles %}
         <ul class="pagination">
             {% if articles.has_previous %}
                 <li class="waves-effect"><a href="?page={{ articles.previous_page_number }}">&laquo;</a></li>
@@ -41,6 +42,7 @@
                 </li>
             {% endif %}
         </ul>
+        {% endif %}
     </div>
     {% if show_sidebar %}
         <div class="col m3 offset-m1">

--- a/src/themes/material/templates/journal/issue_display.html
+++ b/src/themes/material/templates/journal/issue_display.html
@@ -1,4 +1,5 @@
 {% load i18n %}
+{% load pages %}
 
 <div class="row">
     <div class="col {% if not show_sidebar %}m12{% else %}m8{% endif %} s12">
@@ -19,12 +20,27 @@
             {% if issue.issue_description %}<p>{{ issue.issue_description|safe }}</p>{% endif %}
         {% endif %}
 
-        {% for section, articles in structure.items %}
+        {% regroup articles by section as grouped_articles %}
+        {% for section, section_articles in grouped_articles %}
             <h4 class="em">{{ section.name }}</h4>
-            {% for article in articles %}
+            {% for article in section_articles %}
                 {% include "elements/article_listing.html" with article=article %}
             {% endfor %}
         {% endfor %}
+        <ul class="pagination">
+            {% if articles.has_previous %}
+                <li class="waves-effect"><a href="?page={{ articles.previous_page_number }}">&laquo;</a></li>
+                &nbsp;{% endif %}
+            {{ articles.page.page_range }}
+            {% for page in articles|slice_pages:3 %}
+                <li class="waves-effect {% if articles.number == page.number %}active{% endif %}"><a href="?page={{ page.number }}">{{ page.number }}</a>&nbsp;
+                </li>
+            {% endfor %}
+            {% if articles.has_next %}
+                <li class="waves-effect"><a href="?page={{ articles.next_page_number }}">&raquo;</a>
+                </li>
+            {% endif %}
+        </ul>
     </div>
     {% if show_sidebar %}
         <div class="col m3 offset-m1">


### PR DESCRIPTION
A few improvements here:
 - Merges Issue and Collection views onto a single view (some optimizations were present on one and not the other)
 - Stops using `Issue.structure` in this view and marks it as deprecated. (We need to preserve the interface for other themes)
  - Adds a new method to `Issue` `get_sorted_articles` which returns all the articles sorted by section and article order, ready to be displayed on the frontend.
  - The articles are paginated when an issue has at least 50 articles