### PR TITLE
fix articles links and search box when using non standard ports

### DIFF
--- a/src/themes/default/templates/core/nav.html
+++ b/src/themes/default/templates/core/nav.html
@@ -120,7 +120,7 @@
                     &nbsp;</i>Register</a></li>
             {% endif %}
         </ul>
-        <form method="POST" action="{% journal_url 'search' %}" class="form-inline mt-2 mt-md-0">
+        <form method="POST" action="{% url 'search' %}" class="form-inline mt-2 mt-md-0">
             {% csrf_token %}
             <input class="form-control mr-sm-2" type="text" placeholder="Search" name="article_search">
             <button class="btn btn-outline-success my-2 my-sm-0" type="submit">Search</button>

--- a/src/themes/default/templates/elements/article_listing.html
+++ b/src/themes/default/templates/elements/article_listing.html
@@ -7,7 +7,7 @@
             {% if not journal.disable_article_images %}
                 <div class="col-md-2">
                     <a href="
-                            {% if article.is_remote %}{{ article.remote_url }}{% else %}{{ article.url }}{% endif %}">
+                            {% if article.is_remote %}{{ article.remote_url }}{% else %}{{ article.local_url }}{% endif %}">
                         {% if article.thumbnail_image_file %}
                             <img src="{% url 'article_file_download' 'id' article.id article.thumbnail_image_file.id %}"
                                  alt="{{ article.title|striptags|escape }}" class="article-thumbnail">
@@ -22,7 +22,7 @@
                 </div>
             {% endif %}
             <div class="col article-block">
-                <a href="{% if article.is_remote %}{{ article.remote_url }}{% else %}{{ article.url }}{% endif %}">
+                <a href="{% if article.is_remote %}{{ article.remote_url }}{% else %}{{ article.local_url }}{% endif %}">
                     <h4 class="card-title">{{ article.title|safe }}{% if article.is_remote %}&nbsp;
                         <i class="fa fa-external-link small-icon-text"></i>{% endif %}</h4>
                 </a>

--- a/src/themes/material/templates/elements/article_listing.html
+++ b/src/themes/material/templates/elements/article_listing.html
@@ -18,7 +18,7 @@
         </div>
 	{% endif %}
 	<div class="col m{% if not journal.disable_article_images %}10{% else %}12{% endif %}">
-            <a href="{% if article.is_remote %}{{ article.remote_url }}{% else %}{{ article.url }}{% endif %}">
+            <a href="{% if article.is_remote %}{{ article.remote_url }}{% else %}{{ article.local_url }}{% endif %}">
                 <h5 class="article-title">{{ article.title|safe }}</h5>
             </a>
             <p>{% for author in article.frozen_authors.all %}{% if forloop.last %}


### PR DESCRIPTION
when using a non standard port the article view links in the default and material themes are missing the port number resulting in a 404
same for the search box in the default theme 

