### PR TITLE
Bumps Django due to security vulnerability.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ boto==2.46.1
 bs4==0.0.1
 colorlog==3.1.4
 chardet==3.0.4
-Django==1.11.20
+Django==1.11.21
 -e git+https://github.com/GabrielUlici/django-bootstrap4@d230ec23d9f8f08c1505e0679ce0c6dba8090f0a#egg=django_bootstrap4
 -e git+https://github.com/BirkbeckCTP/django-foundation-form.git#egg=foundationform
 django-debug-toolbar==1.8


### PR DESCRIPTION
@mauromsl can you review this and move the 1.3.5 tag up?