### PR TITLE
Bump django version for CVE-2019-19844

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ boto==2.46.1
 bs4==0.0.1
 colorlog==3.1.4
 chardet==3.0.4
-Django==1.11.23
+Django==1.11.27
 -e git+https://github.com/GabrielUlici/django-bootstrap4@d230ec23d9f8f08c1505e0679ce0c6dba8090f0a#egg=django_bootstrap4
 -e git+https://github.com/BirkbeckCTP/django-foundation-form.git#egg=foundationform
 django-debug-toolbar==1.8


### PR DESCRIPTION
https://github.com/BirkbeckCTP/janeway/network/alert/requirements.txt/Django/open