### PR TITLE
Swapped around the make galley button. Closes #1360.

### DIFF
--- a/src/templates/admin/production/assigned_article.html
+++ b/src/templates/admin/production/assigned_article.html
@@ -135,7 +135,8 @@
                                 <a href="{% url 'article_file_download' 'id' article.pk file.pk %}"><i
                                         class="fa fa-download">&nbsp;</i></a>{% endif %}
                             </td>
-                            <td>{% hook 'conversion_buttons' %}</td>
+                            <td><a href="{% url 'article_file_make_galley' article.pk file.pk %}?return={{ request.path|urlencode }}"><i
+                                    class="fa fa-share-square-o">&nbsp;</i></a>{% hook 'conversion_buttons' %}</td>
                         </tr>
                     {% endfor %}
                     {% for file in data_files %}
@@ -152,9 +153,7 @@
                                 <a href="{% url 'article_file_download' 'id' article.pk file.pk %}"><i
                                         class="fa fa-download">&nbsp;</i></a>{% endif %}
                             </td>
-                            <td>{% if can_view_file_flag %}<a
-                                    href="{% url 'article_file_make_galley' article.pk file.pk %}?return={{ request.path|urlencode }}"><i
-                                    class="fa fa-share-square-o">&nbsp;</i></a>{% endif %}
+                            <td>
                             </td>
                         </tr>
                     {% endfor %}
@@ -172,7 +171,8 @@
                                 <a href="{% url 'article_file_download' 'id' article.pk file.pk %}"><i
                                         class="fa fa-download">&nbsp;</i></a>{% endif %}
                             </td>
-                            <td>{% hook 'conversion_buttons' %}</td>
+                            <td><a href="{% url 'article_file_make_galley' article.pk file.pk %}?return={{ request.path|urlencode }}"><i
+                                    class="fa fa-share-square-o">&nbsp;</i></a>{% hook 'conversion_buttons' %}</td>
                         </tr>
                     {% endfor %}
                 </table>


### PR DESCRIPTION
These buttons were the wrong way round. Data/Images should not have it and all other file types should.