### PR TITLE
Adds section PK to issue articles ordering logic

### DIFF
--- a/src/journal/models.py
+++ b/src/journal/models.py
@@ -622,6 +622,7 @@ class Issue(models.Model):
         ).order_by(
             "section_order",
             "section__sequence",
+            "section__pk",
             "article_order",
         )
 


### PR DESCRIPTION
closes #1307 
closes #1179

If the sections within an issue are lacking or have identical
SectionOrder.order or Section.sequence values, they will now be sorted
by PK, avoiding the repeated sections problem