### PR TITLE
Stops tampering XML during XSL transform

### DIFF
--- a/src/core/files.py
+++ b/src/core/files.py
@@ -323,17 +323,14 @@ def render_xml(file_to_render, article, xsl_file=None):
         )
         return ""
 
-    with open(path, "rb") as xml_file_contents:
-        xml = BeautifulSoup(xml_file_contents, "lxml-xml")
+    return transform_with_xsl(path, xsl_path)
 
-        transform = etree.XSLT(etree.parse(xsl_path))
+def transform_with_xsl(xml_path, xsl_path):
+    xml_dom = etree.parse(xml_path)
+    xsl_transform = etree.XSLT(etree.parse(xsl_path))
+    transformed_dom = xsl_transform(xml_dom)
 
-        # remove the <?xml version="1.0" encoding="utf-8"?> line (or similar) if it exists
-        regex = re.compile(r'<\?xml version="1.0" encoding=".+"\?>')
-        xml_string = str(xml)
-        xml_string = re.sub(regex, '', xml_string, count=1)
-
-        return transform(etree.XML(xml_string))
+    return transformed_dom
 
 
 def serve_any_file(request, file_to_serve, public=False, hide_name=False,

--- a/src/core/files.py
+++ b/src/core/files.py
@@ -328,7 +328,12 @@ def render_xml(file_to_render, article, xsl_file=None):
 def transform_with_xsl(xml_path, xsl_path):
     xml_dom = etree.parse(xml_path)
     xsl_transform = etree.XSLT(etree.parse(xsl_path))
-    transformed_dom = xsl_transform(xml_dom)
+    try:
+        transformed_dom = xsl_transform(xml_dom)
+    except Exception as err:
+        for xsl_error in xsl_transform.error_log:
+            logger.error(xsl_error)
+        raise
 
     return transformed_dom
 


### PR DESCRIPTION
When we parse the XML galleys into a python unicode string, the processing instructions get corrupted (never terminate) which leads to an error when later transforming the galley via XSL.

Checking on the acta repo, I believe we souped the xml to do this:
```
xml = BeautifulSoup(xml_file_contents, ["lxml", "xml"])

        if galley:
            elements = {
                'graphic': 'xlink:href'
            }

            # iterate over all found elements
            for element, attribute in elements.items():
                images = xml.findAll(element)
                # iterate over all found elements of each type in the elements dictionary
                for image in images:
                    image['xlink:href'] = "/article/{0}/galley/{1}/figure/{2}".format(
                        article.pk,
                        galley.pk,
                        os.path.basename(image['xlink:href']))
```

But that code was later removed in this commit:
```
commit 584382dd5bf1c2ce095b526112d9227f6f544f1e
Author: Martin Eve <martin@martineve.com>
Date:   Sun Feb 26 16:13:39 2017 +0000

    Add TEI rendering
    
    Rewrite encoding stripper
```

With this PR I removed the code that does the tampering which allows processing instructions to be correctly parsed again by etree.

An alternative approach would be to leave the code that removes the XML prolog in, but encode the python unicode object back before reconstructing and transforming via XSL, but I don't think there is a reason to strip the prolog anymore