### PR TITLE
Handle migrating non-string values (i.e.: NULL)

### DIFF
--- a/src/core/migrations/0039_fix_reviewer_url.py
+++ b/src/core/migrations/0039_fix_reviewer_url.py
@@ -13,8 +13,9 @@ def replace_template(apps, schema_editor):
     settings = SettingValueTranslation.objects.all()
 
     for setting in settings:
-        setting.value = re.sub(REGEX, OUTPUT, setting.value)
-        setting.save()
+        if isinstance(setting.value, str):
+            setting.value = re.sub(REGEX, OUTPUT, setting.value)
+            setting.save()
 
 
 class Migration(migrations.Migration):


### PR DESCRIPTION
Fixes a problem with core 0039
I found this to only be a problem on the demo site, so might be only an issue with mysql or perhaps something to do with how settings were handled in a different version. Anyways, good to have