### PR TITLE
#1497: Fixes a race condition on Account create

### DIFF
--- a/src/core/models.py
+++ b/src/core/models.py
@@ -147,12 +147,11 @@ class Country(models.Model):
 
 
 class AccountQuerySet(models.query.QuerySet):
-    def create(self, *args, **kwargs):
-        # Ensure cleaned fields on create and get_or_create
-        with transaction.atomic():
-            obj = super().create(*args, **kwargs)
+    def create(self, **kwargs):
+            obj = self.model(**kwargs)
             obj.clean()
-            obj.save()
+            self._for_write = True
+            obj.save(force_insert=True, using=self.db)
             return obj
 
 


### PR DESCRIPTION
Some plugins were having trouble with the previous implementation, throwing a two-step transaction was not a good decision.

Now that I think of it, I don't understand why this is the default behavior in django itself