### PR TITLE
Fix info-bar covering issue cover

### DIFF
--- a/src/themes/OLH/assets/scss/app.scss
+++ b/src/themes/OLH/assets/scss/app.scss
@@ -537,7 +537,7 @@ div.caption span.label {
 
   &.issue {
     .info-bar {
-      position: absolute;
+      position: relative;
       bottom: 0;
       left: 0;
       width: 100%;


### PR DESCRIPTION
I played around with the opacity, but it makes the Issue details barely readable and highly dependent on the choice of cover image.I think making the info-bar relative to the image is a better choice

Result:
![image](https://user-images.githubusercontent.com/10760678/83611816-6a397e00-a579-11ea-8ca1-223ef116bc49.png)

![image](https://user-images.githubusercontent.com/10760678/83611845-732a4f80-a579-11ea-95b6-2b21ba6b2bf2.png)
