### PR TITLE
Improvements to render error handling on XML galleys

### DIFF
--- a/src/core/models.py
+++ b/src/core/models.py
@@ -861,10 +861,11 @@ class Galley(models.Model):
     def __str__(self):
         return "{0} ({1})".format(self.id, self.label)
 
-    def render(self):
+    def render(self, recover=False):
         return files.render_xml(
-                self.file, self.article,
-                xsl_path=self.xsl_file.file.path
+            self.file, self.article,
+            xsl_path=self.xsl_file.file.path,
+            recover=recover,
         )
 
     def render_crossref(self):
@@ -917,11 +918,11 @@ class Galley(models.Model):
         """
         return self.has_missing_image_files(show_all=True)
 
-    def file_content(self, dont_render=False):
+    def file_content(self, dont_render=False, recover=False):
         if self.file.mime_type == "text/html" or dont_render:
             return self.file.get_file(self.article)
         elif self.file.mime_type in files.XML_MIMETYPES:
-            return self.render()
+            return self.render(recover=recover)
 
     def path(self):
         url = reverse('article_download_galley',

--- a/src/journal/logic.py
+++ b/src/journal/logic.py
@@ -137,7 +137,7 @@ def get_best_galley(article, galleys):
     return None
 
 
-def get_galley_content(article, galleys):
+def get_galley_content(article, galleys, recover=False):
     """
     Gets the best galley and returns its content
     :param article: Article object
@@ -146,7 +146,7 @@ def get_galley_content(article, galleys):
     """
     galley = get_best_galley(article, galleys)
     if galley:
-        return galley.file_content()
+        return galley.file_content(recover=recover)
     else:
         return ''
 

--- a/src/journal/views.py
+++ b/src/journal/views.py
@@ -343,7 +343,7 @@ def article(request, identifier_type, identifier):
 
     # check if there is a galley file attached that needs rendering
     if article_object.stage == submission_models.STAGE_PUBLISHED:
-        content = get_galley_content(article_object, galleys)
+        content = get_galley_content(article_object, galleys, recover=True)
     else:
         article_object.abstract = "<p><strong>This is an accepted article with a DOI pre-assigned " \
                                   "that is not yet published.</strong></p>" + article_object.abstract
@@ -875,7 +875,7 @@ def publish_article(request, article_id):
             return redirect(
                 '{0}?m=issue'.format(
                     reverse(
-                        'publish_article', 
+                        'publish_article',
                         kwargs={'article_id': article.pk},
                     )
                 )
@@ -886,7 +886,7 @@ def publish_article(request, article_id):
             return redirect(
                 '{0}?m=issue'.format(
                     reverse(
-                        'publish_article', 
+                        'publish_article',
                         kwargs={'article_id': article.pk},
                     )
                 )
@@ -906,7 +906,7 @@ def publish_article(request, article_id):
 
         if 'pubdate' in request.POST:
             date_set, pubdate_errors = logic.handle_set_pubdate(
-                request, 
+                request,
                 article,
             )
             if not pubdate_errors:
@@ -932,7 +932,7 @@ def publish_article(request, article_id):
             logic.set_render_galley(request, article)
             return redirect(
                 reverse(
-                    'publish_article', 
+                    'publish_article',
                     kwargs={'article_id': article.pk},
                 )
             )
@@ -943,7 +943,7 @@ def publish_article(request, article_id):
             return redirect(
                 "{0}{1}".format(
                     reverse(
-                        'publish_article', 
+                        'publish_article',
                         kwargs={'article_id': article.pk},
                     ),
                     "?m=article_image",

--- a/src/production/views.py
+++ b/src/production/views.py
@@ -383,8 +383,18 @@ def preview_galley(request, article_id, galley_id):
         article=article,
     )
 
+    article_content = ""
     if galley.type == 'xml' or galley.type == 'html':
         template = 'proofing/preview/rendered.html'
+        try:
+            article_content = galley.file_content()
+        except Exception as e:
+            messages.add_message(
+                request,
+                messages.ERROR,
+                'Errors found rendering this galley',
+            )
+            article_content  = "Errors found rendering this galley: \n%s" % e
     elif galley.type == 'epub':
         template = 'proofing/preview/epub.html'
     else:
@@ -392,7 +402,8 @@ def preview_galley(request, article_id, galley_id):
 
     context = {
         'galley': galley,
-        'article': article
+        'article': article,
+        'article_content': article_content,
     }
 
     return render(request, template, context)

--- a/src/templates/admin/proofing/preview/rendered.html
+++ b/src/templates/admin/proofing/preview/rendered.html
@@ -41,7 +41,7 @@
 
                                 <h2>Article</h2>
                                 <div itemprop="articleBody">
-                                    {{ galley.file_content|safe }}
+                                    {{ article_content|safe }}
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
 - On article view, gets the best render possible for the syntax errors given on the source XML
 - On article preview view, shows only the rendering errors.
closes #1623