### PR TITLE
#1642 Adds an option backend kwarg to ArticleInfo form.

### DIFF
--- a/src/submission/forms.py
+++ b/src/submission/forms.py
@@ -86,7 +86,7 @@ class ArticleInfo(KeywordModelForm):
         elements = kwargs.pop('additional_fields', None)
         submission_summary = kwargs.pop('submission_summary', None)
         journal = kwargs.pop('journal', None)
-        self.backend = kwargs.pop('backend', False)
+        self.pop_disabled_fields = kwargs.pop('pop_disabled_fields', True)
 
         super(ArticleInfo, self).__init__(*args, **kwargs)
         if 'instance' in kwargs:
@@ -115,7 +115,7 @@ class ArticleInfo(KeywordModelForm):
                 self.fields['non_specialist_summary'].required = True
 
             # Pop fields based on journal.submissionconfiguration
-            if journal and not self.backend:
+            if journal and self.pop_disabled_fields:
                 if not journal.submissionconfiguration.subtitle:
                     self.fields.pop('subtitle')
 
@@ -190,7 +190,7 @@ class ArticleInfo(KeywordModelForm):
                     except models.FieldAnswer.DoesNotExist:
                         field_answer = models.FieldAnswer.objects.create(article=article, field=field, answer=answer)
 
-            if not self.backend:
+            if self.pop_disabled_fields:
                 request.journal.submissionconfiguration.handle_defaults(article)
 
         if commit:

--- a/src/submission/forms.py
+++ b/src/submission/forms.py
@@ -83,6 +83,16 @@ class ArticleInfo(KeywordModelForm):
         }
 
     def __init__(self, *args, **kwargs):
+        """
+        Initialises the ArticleInfo form.
+        :param kwargs:  elements: queryest of Field objects.
+                        submission_sumary: boolean, detmines if this field
+                        is on or off.
+                        journal: Journal object.
+                        pop_disabled_fields: boolean, if False we do not pop
+                        fields that are disabled by SubmissionConfiguration
+                        or overwrite their saving.
+        """
         elements = kwargs.pop('additional_fields', None)
         submission_summary = kwargs.pop('submission_summary', None)
         journal = kwargs.pop('journal', None)

--- a/src/submission/forms.py
+++ b/src/submission/forms.py
@@ -4,6 +4,7 @@ __license__ = "AGPL v3"
 __maintainer__ = "Birkbeck Centre for Technology and Publishing"
 
 from django import forms
+from django.conf import settings
 from django.utils.translation import ugettext_lazy as _
 
 from submission import models
@@ -12,7 +13,6 @@ from identifiers import models as ident_models
 from review.forms import render_choices
 from utils.forms import KeywordModelForm
 from utils import setting_handler
-
 
 
 class PublisherNoteForm(forms.ModelForm):
@@ -318,7 +318,9 @@ class ConfiguratorForm(forms.ModelForm):
 
     def __init__(self, *args, **kwargs):
         super(ConfiguratorForm, self).__init__(*args, **kwargs)
-        self.fields['default_section'].queryset = models.Section.objects.language().fallbacks('en').filter(
+        self.fields['default_section'].queryset = models.Section.objects.language().fallbacks(
+            settings.LANGUAGE_CODE,
+        ).filter(
             journal=self.instance.journal,
         )
         self.fields[

--- a/src/submission/views.py
+++ b/src/submission/views.py
@@ -497,7 +497,7 @@ def edit_metadata(request, article_id):
     info_form = forms.ArticleInfo(
         instance=article,
         submission_summary=submission_summary,
-        backend=True,
+        pop_disabled_fields=False,
     )
     frozen_author, modal = None, None
     return_param = request.GET.get('return')
@@ -532,7 +532,7 @@ def edit_metadata(request, article_id):
                 request.POST,
                 instance=article,
                 submission_summary=submission_summary,
-                backend=True,
+                pop_disabled_fields=False,
             )
 
             if info_form.is_valid():


### PR DESCRIPTION
- Adds an optional boolean kwarg `backend` to `submission.forms.ArticleInfo`.
- If set to True this will stop the form from over-writing metadata with the defaults set in the submission configuration tool.

Closes #1642 