### PR TITLE
Fixes wrong group by on subquery

### DIFF
--- a/src/review/logic.py
+++ b/src/review/logic.py
@@ -48,8 +48,10 @@ def get_reviewer_candidates(article, user=None):
     active_reviews_count = models.ReviewAssignment.objects.filter(
         is_complete=False,
         reviewer=OuterRef("id"),
+    ).values(
+        "reviewer_id",
     ).annotate(
-        rev_count=Count("pk"),
+        rev_count=Count("reviewer_id"),
     ).values("rev_count")
 
     rating_average = models.ReviewerRating.objects.filter(


### PR DESCRIPTION
closes #1646 
It looks convoluted, but without calling values on the column we want to group by, the default behaviour is to group by the wrong column, leading to multiple rows being returned from the subquery. Sometimes I wish I could just write SQL...