### PR TITLE
Fixes XSLT links to mixed-citation elements from inline citations

### DIFF
--- a/src/transform/xsl/default.xsl
+++ b/src/transform/xsl/default.xsl
@@ -2098,6 +2098,26 @@
     </em>
   </xsl:template>
 
+  <xsl:template match="ext-link" mode="nscitation">
+    <a>
+      <xsl:attribute name="href">
+        <xsl:choose>
+            <xsl:when test="starts-with(@xlink:href, 'www.')">
+              <xsl:value-of select="concat('http://', @xlink:href)"/>
+            </xsl:when>
+            <xsl:when test="starts-with(@xlink:href, 'doi:')">
+              <xsl:value-of select="concat('http://dx.doi.org/', substring-after(@xlink:href, 'doi:'))"/>
+            </xsl:when>
+            <xsl:otherwise>
+              <xsl:value-of select="@xlink:href"/>
+            </xsl:otherwise>
+        </xsl:choose>
+      </xsl:attribute>
+      <xsl:attribute name="target"><xsl:value-of select="'_blank'"/></xsl:attribute>
+      <xsl:apply-templates/>
+    </a>
+  </xsl:template>
+
   <xsl:template match="source" mode="book">
     <xsl:choose>
 

--- a/src/transform/xsl/default.xsl
+++ b/src/transform/xsl/default.xsl
@@ -1561,9 +1561,13 @@
   </xsl:template>
 
   <xsl:template match="mixed-citation">
+    <p id="{parent::*/@id}">
       <!-- Render each mixed-citation as-is https://jats.nlm.nih.gov/archiving/tag-library/1.1/element/mixed-citation.html -->
-      <!-- Only exception is that we want titles <source> in italics -->
+      <!-- Only exceptions are that we want titles <source> in italics and hyperlinked uris elements-->
       <xsl:apply-templates select="source | node()" mode="nscitation"/>
+      <xsl:apply-templates select="ext-link"/>
+      <xsl:apply-templates select="uri"/>
+    </p>
   </xsl:template>
 
 


### PR DESCRIPTION
closes #1650 
Bonus Track: Renders child uri elements of mixed-citation tags as hyperlinks