### PR TITLE
#1680 fixes bug

### DIFF
--- a/src/core/models.py
+++ b/src/core/models.py
@@ -400,7 +400,10 @@ class Account(AbstractBaseUser, PermissionsMixin):
 
     def snapshot_self(self, article):
         try:
-            order = submission_models.ArticleAuthorOrder.objects.get(article=article, author=self).order
+            order = submission_models.ArticleAuthorOrder.objects.get(
+                article=article,
+                author=self,
+            ).order
         except submission_models.ArticleAuthorOrder.DoesNotExist:
             order = 1
 
@@ -419,6 +422,7 @@ class Account(AbstractBaseUser, PermissionsMixin):
 
         if frozen_author:
             for k, v in frozen_dict.items():
+                frozen_dict['order'] = frozen_author.order
                 setattr(frozen_author, k, v)
                 frozen_author.save()
         else:
@@ -426,7 +430,10 @@ class Account(AbstractBaseUser, PermissionsMixin):
 
     def frozen_author(self, article):
         try:
-            return submission_models.FrozenAuthor.objects.get(article=article, author=self)
+            return submission_models.FrozenAuthor.objects.get(
+                article=article,
+                author=self,
+            )
         except submission_models.FrozenAuthor.DoesNotExist:
             return None
 


### PR DESCRIPTION
- Reformats some code for PEP8
- When a FrozenAuthor is found we now set the frozen_record['order'] variable to be the FAs current order to maintain order.