### PR TITLE
#1706: Fix settings reverted when disabling submissions

### DIFF
--- a/src/core/views.py
+++ b/src/core/views.py
@@ -764,8 +764,12 @@ def edit_settings_group(request, group):
         else:
             attr_form = forms.JournalAttributeForm(request.POST, request.FILES, instance=journal)
 
-        if edit_form.is_valid() and attr_form.is_valid():
+        if edit_form.is_valid():
             edit_form.save(group=setting_group, journal=journal)
+
+        if group == 'journal' and attr_form.is_valid():
+            # Evaluate this form for this group only, otherwise booleans
+            # will all get set to False
             attr_form.save()
             logic.handle_default_thumbnail(request, journal, attr_form)
             logic.handle_press_override_image(request, journal, attr_form)


### PR DESCRIPTION
closes #1706 
Its just a patch for v.1.3.8-RC-8, the real solution should be #1708