### PR TITLE
validate email setting value

### DIFF
--- a/src/core/tests/test_app.py
+++ b/src/core/tests/test_app.py
@@ -4,6 +4,7 @@ __license__ = "AGPL v3"
 __maintainer__ = "Birkbeck Centre for Technology and Publishing"
 
 import datetime
+from mock import patch
 
 from django.test import TestCase, override_settings
 from django.urls import reverse
@@ -80,6 +81,15 @@ class CoreTests(TestCase):
         self.assertFalse(
             missing,
             msg="Found emails that don't have a subject setting")
+
+    @patch.object(models.Setting, 'validate')
+    def test_setting_validation(self, mock_method):
+        from utils import setting_handler
+        setting_handler.save_setting(
+            'email', 'editor_assignment', self.journal_one, 'test'
+        )
+        mock_method.assert_called()
+
 
 
     def setUp(self):

--- a/src/core/tests/test_validators.py
+++ b/src/core/tests/test_validators.py
@@ -41,3 +41,19 @@ class TestValidators(TestCase):
 
         with self.assertRaises(ValidationError):
             validator(file_)
+
+    def test_invalid_email_setting(self):
+        test_value = "{% if val %} This template is missing an endif"
+        with self.assertRaises(ValidationError):
+            validators.validate_email_setting(test_value)
+
+    def test_invalid_email_setting(self):
+        test_value = "{% if val %} This template is valid {% endif %}"
+        try:
+            validators.validate_email_setting(test_value)
+        except ValidationError as e:
+            error = error
+        else:
+            error = None
+        self.assertIsNone(error)
+

--- a/src/core/tests/test_validators.py
+++ b/src/core/tests/test_validators.py
@@ -47,7 +47,7 @@ class TestValidators(TestCase):
         with self.assertRaises(ValidationError):
             validators.validate_email_setting(test_value)
 
-    def test_invalid_email_setting(self):
+    def test_valid_email_setting(self):
         test_value = "{% if val %} This template is valid {% endif %}"
         try:
             validators.validate_email_setting(test_value)

--- a/src/core/validators.py
+++ b/src/core/validators.py
@@ -2,6 +2,8 @@ import mimetypes
 import os.path
 
 from django.core.exceptions import ValidationError
+from django.template import Template
+from django.template.exceptions import TemplateSyntaxError
 from django.utils.translation import gettext_lazy as _
 
 class FileTypeValidator(object):
@@ -45,3 +47,10 @@ class FileTypeValidator(object):
             )
 
             raise ValidationError(message, code="invalidi_mimetype")
+
+
+def validate_email_setting(value):
+    try:
+        template = Template(value)
+    except TemplateSyntaxError as error:
+        raise ValidationError(str(error))

--- a/src/core/views.py
+++ b/src/core/views.py
@@ -704,8 +704,7 @@ def edit_setting(request, setting_group, setting_name):
             messages.add_message( request, messages.ERROR, error)
         else:
             cache.clear()
-
-        return redirect(reverse('core_settings_index'))
+            return redirect(reverse('core_settings_index'))
 
     template = 'core/manager/settings/edit_setting.html'
     context = {

--- a/src/core/views.py
+++ b/src/core/views.py
@@ -1691,12 +1691,14 @@ def edit_email_template(request, template_code, subject=False):
 
     if request.POST:
         value = request.POST.get('value')
-        template_value.value = value
-        template_value.save()
-
-        cache.clear()
-
-        return redirect(reverse('core_email_templates'))
+        try:
+            template_value.value = value
+            template_value.save()
+        except ValidationError as error:
+            messages.add_message( request, messages.ERROR, error)
+        else:
+            cache.clear()
+            return redirect(reverse('core_email_templates'))
 
     template = 'core/manager/email/edit_email_template.html'
     context = {

--- a/src/core/views.py
+++ b/src/core/views.py
@@ -697,9 +697,13 @@ def edit_setting(request, setting_group, setting_name):
         if request.FILES:
             value = logic.handle_file(request, setting_value, request.FILES['value'])
 
-        setting_value = setting_handler.save_setting(
-            setting_group, setting_name, request.journal, value)
-        cache.clear()
+        try:
+            setting_value = setting_handler.save_setting(
+                setting_group, setting_name, request.journal, value)
+        except ValidationError as error:
+            messages.add_message( request, messages.ERROR, error)
+        else:
+            cache.clear()
 
         return redirect(reverse('core_settings_index'))
 


### PR DESCRIPTION
closes #1722 

This just addresses the current problem, which is good for patching 1.3.8, but moving forward we might want to transition this view to use a proper form and have the validation logic 