### PR TITLE
Fix cross-device move on save_file_to_article

### DIFF
--- a/src/core/files.py
+++ b/src/core/files.py
@@ -166,7 +166,10 @@ def save_file_to_article(file_to_handle, article, owner, label=None, description
         save_file_to_disk(file_to_handle, filename, folder_structure)
         file_mime = file_path_mime(os.path.join(folder_structure, filename))
     else:
-        os.rename(os.path.join(folder_structure, original_filename), os.path.join(folder_structure, filename))
+        shutil.move(
+            os.path.join(folder_structure, original_filename),
+            os.path.join(folder_structure, filename)
+        )
         file_mime = guess_mime(filename)
 
     from core import models

--- a/src/core/files.py
+++ b/src/core/files.py
@@ -168,7 +168,7 @@ def save_file_to_article(file_to_handle, article, owner, label=None, description
     else:
         shutil.move(
             os.path.join(folder_structure, original_filename),
-            os.path.join(folder_structure, filename)
+            os.path.join(folder_structure, filename),
         )
         file_mime = guess_mime(filename)
 


### PR DESCRIPTION
A fix for installs that use different devices to store article/journal files
On python 3 `shutil.move` handles moving files across devices by falling back to `.copy` and `.remove` when necessary