### PR TITLE
[XSLT] Render pub-id URLs as hyperlinks

### DIFF
--- a/src/transform/xsl/default.xsl
+++ b/src/transform/xsl/default.xsl
@@ -2311,12 +2311,21 @@
   <!-- misc stuff -->
 
   <xsl:template match="pub-id" mode="nscitation">
-    <xsl:text> [</xsl:text>
-    <xsl:value-of select="@pub-id-type"/>
-
-    <xsl:text>: </xsl:text>
-    <xsl:apply-templates/>
-    <xsl:text>]</xsl:text>
+    <xsl:choose>
+      <xsl:when test="starts-with(current(), 'http')">
+        <xsl:text>DOI:&#160;</xsl:text>
+	<a href="{current()}" target="_blank">
+        <xsl:apply-templates/>
+        </a>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:text> [</xsl:text>
+        <xsl:value-of select="@pub-id-type"/>
+        <xsl:text>: </xsl:text>
+        <xsl:apply-templates/>
+        <xsl:text>]</xsl:text>
+      </xsl:otherwise>
+    </xsl:choose>
   </xsl:template>
 
   <xsl:template match="annotation" mode="nscitation">

--- a/src/transform/xsl/default.xsl
+++ b/src/transform/xsl/default.xsl
@@ -2313,8 +2313,9 @@
   <xsl:template match="pub-id" mode="nscitation">
     <xsl:choose>
       <xsl:when test="starts-with(current(), 'http')">
-        <xsl:text>DOI:&#160;</xsl:text>
-	<a href="{current()}" target="_blank">
+        <xsl:value-of select="@pub-id-type"/>
+        <xsl:text>:&#160;</xsl:text>
+        <a href="{current()}" target="_blank">
         <xsl:apply-templates/>
         </a>
       </xsl:when>


### PR DESCRIPTION
This is the recommendation from crossref. With this change,
we render pub-ids of pub-id-type doi as a hyperlink when they are
in URL format. Otherwise, we preserve the legacy format of
doi: [shoulder/id]