### PR TITLE
Fixes timeout errors during prepub

### DIFF
--- a/src/core/janeway_global_settings.py
+++ b/src/core/janeway_global_settings.py
@@ -465,6 +465,9 @@ WORKFLOW_PLUGINS = {}
 
 SILENT_IMPORT_CACHE = False
 
+# Default timeout for outgoing HTTP connections
+HTTP_TIMEOUT_SECONDS = 5
+
 # New XML galleys will be associated with this stylesheet by default when they
 # are first uploaded
 DEFAULT_XSL_FILE_LABEL = 'Janeway default (1.3.8)'


### PR DESCRIPTION
I've also added a timeout in the new DOI status poll view.
We should probably hunt down all the other outgoing http requests and set the timeout to `settings.HTTP_TIMEOUT_SECONDS`