### PR TITLE
Updates the homepage of the material theme.

### DIFF
--- a/src/repository/admin.py
+++ b/src/repository/admin.py
@@ -27,6 +27,8 @@ class PreprintAdmin(admin.ModelAdmin):
     raw_id_fields = ('repository', 'owner', 'subject', )
     filter_horizontal = ('keywords',)
 
+    save_as = True
+
 
 class VersionAdmin(admin.ModelAdmin):
     list_display = ('pk', 'preprint', 'version', 'date_time')

--- a/src/repository/views.py
+++ b/src/repository/views.py
@@ -40,7 +40,7 @@ def repository_home(request):
         repository=request.repository,
         date_published__lte=timezone.now(),
         stage=models.STAGE_PREPRINT_PUBLISHED
-    )
+    )[:6]
     subjects = models.Subject.objects.filter(
         repository=request.repository,
     ).prefetch_related(

--- a/src/static/common/css/repo.css
+++ b/src/static/common/css/repo.css
@@ -70,7 +70,7 @@ nav, nav .nav-wrapper i, nav a.button-collapse, nav a.button-collapse i {
 }
 
 .preprint-home-card {
-    min-height: 180px;
+    min-height: 100%;
 }
 
 .no-padding-top {
@@ -112,4 +112,13 @@ h5 {
     max-height: 400px;
     overflow-y: paged-y;
     overflow-x: hidden;
+}
+
+.eq-height-col {
+    margin-bottom: 20px;
+}
+
+.homepage-hr {
+    margin-top: 2rem;
+    margin-bottom: 2rem;
 }

--- a/src/static/common/js/material-eq-height.js
+++ b/src/static/common/js/material-eq-height.js
@@ -1,0 +1,11 @@
+$(document).ready(function(){
+
+    var tallest_div = 0;
+        $('.eq-height-row .eq-height-col').each(function(){
+                if($(this).height() > tallest_div){
+                tallest_div = $(this).height();
+        }
+    });
+    $('.eq-height-row .eq-height-col').height(tallest_div - 20);
+
+});

--- a/src/themes/material/templates/repository/elements/preprint_home_listing.html
+++ b/src/themes/material/templates/repository/elements/preprint_home_listing.html
@@ -1,7 +1,7 @@
 <div class="section">
-    <div class="row">
+    <div class="row eq-height-row">
         {% for preprint in preprints %}
-            <div class="col m4">
+            <div class="col m4 s12 eq-height-col">
                 <div class="card preprint-home-card">
                     <div class="card-content">
                         <p>

--- a/src/themes/material/templates/repository/home.html
+++ b/src/themes/material/templates/repository/home.html
@@ -1,5 +1,6 @@
 {% extends "repository/base.html" %}
 {% load i18n %}
+{% load static from staticfiles %}
 
 {% block title %}{{ request.repository.name }}{% endblock %}
 
@@ -19,6 +20,13 @@
                 <input id="icon_prefix" type="text" class="validate">
                 <label for="icon_prefix">Search {{ request.repository.object_name_plural }}</label>
             </form>
+        </div>
+
+        <div class="input-field col s10 offset-m1 spacer">
+            <hr class="homepage-hr" />
+        </div>
+
+         <div class="input-field col s12 m6 offset-m3 spacer">
 
             <div class="center spacer">
                 <a class="btn waves-effect waves-light"
@@ -38,4 +46,8 @@
         {% include "repository/elements/preprint_home_listing.html" with preprints=preprints %}
         {% endif %}
     </div>
+{% endblock %}
+
+{% block js %}
+    <script src="{% static "common/js/material-eq-height.js" %}"></script>
 {% endblock %}


### PR DESCRIPTION
- Adds an HR to seperate the Search from Submit sections
- Limits the homepage preprints to 6 (maybe should be a setting in future releases)
- Adds some common JS to make material rows and cols equal height. This exists already for BS and Foundation.