### PR TITLE
add capfirst builtin to repository list navigation in OLH and Material theme repository nav templates

### DIFF
--- a/src/themes/OLH/templates/repository/nav.html
+++ b/src/themes/OLH/templates/repository/nav.html
@@ -2,7 +2,7 @@
     <ul class="menu vertical medium-horizontal" data-responsive-menu="drilldown medium-dropdown">
         <li><a href="{% url 'website_index' %}">Home</a></li>
         <li><a href="{% url 'repository_about' %}">About</a></li>
-        <li><a href="{% url 'repository_list' %}">{{ request.repository.object_name_plural }}</a></li>
+        <li><a href="{% url 'repository_list' %}">{{ request.repository.object_name_plural | capfirst }}</a></li>
         <li><a href="{% url 'repository_submit' %}">Submit {{ request.repository.object_name }}</a></li>
     </ul>
 </div>

--- a/src/themes/material/templates/repository/nav.html
+++ b/src/themes/material/templates/repository/nav.html
@@ -17,7 +17,7 @@
         <ul class="right hide-on-med-and-down">
             <li><a href="{% url 'website_index' %}">{% trans "Home" %}</a></li>
             <li><a href="{% url 'repository_about' %}">{% trans "About" %}</a>
-            <li><a href="{% url 'repository_list' %}">{{ request.repository.object_name_plural }}</a></li>
+            <li><a href="{% url 'repository_list' %}">{{ request.repository.object_name_plural | capfirst }}</a></li>
             <li><a href="{% url 'repository_submit' %}">{% trans "Submit" %}</a></li>
 
             {% hook 'nav_block' %}


### PR DESCRIPTION
- closes #1742