### PR TITLE
[Preprints] minor template bugs - fix escaping for custom_js and broken download link

### DIFF
--- a/src/themes/material/templates/core/base.html
+++ b/src/themes/material/templates/core/base.html
@@ -89,7 +89,7 @@
 
 {% if request.repository and request.repository.custom_js_code %}
 <script>
-  {{ request.repository.custom_js_code }}
+  {{ request.repository.custom_js_code|safe }}
 </script>
 {% endif %}
 

--- a/src/themes/material/templates/repository/base.html
+++ b/src/themes/material/templates/repository/base.html
@@ -61,7 +61,7 @@
 {% block js %}{% endblock %}
 {% if request.repository.custom_js_code %}
 <script>
-  {{ request.repository.custom_js_code }}
+  {{ request.repository.custom_js_code|safe }}
 </script>
 {% endif %}
 </body>

--- a/src/themes/material/templates/repository/preprint.html
+++ b/src/themes/material/templates/repository/preprint.html
@@ -46,7 +46,7 @@
                 {% else %}
                     <div class="preprint-content">
                         <p>This {{ request.repository.object_name }} has no visible version.</p>
-                        <a href="" class="waves-effect waves-light btn">Download {{ request.repository.object_name }} <span class="fa fa-download"></span> </a>
+                        <a href="{% url 'repository_file_download' preprint.id preprint.current_version.file.id %}" class="waves-effect waves-light btn">Download {{ request.repository.object_name }} <span class="fa fa-download"></span> </a>
                     </div>
                 {% endif %}
             </div>


### PR DESCRIPTION
I added an un-related commit that fixes a broken download link in the preprint template