### PR TITLE
Stop overriding frozen author records at publication time

### DIFF
--- a/src/core/models.py
+++ b/src/core/models.py
@@ -397,15 +397,7 @@ class Account(AbstractBaseUser, PermissionsMixin):
 
         return False
 
-    def snapshot_self(self, article):
-        try:
-            order = submission_models.ArticleAuthorOrder.objects.get(
-                article=article,
-                author=self,
-            ).order
-        except submission_models.ArticleAuthorOrder.DoesNotExist:
-            order = 1
-
+    def snapshot_self(self, article, force_update=True):
         frozen_dict = {
             'article': article,
             'author': self,
@@ -419,11 +411,7 @@ class Account(AbstractBaseUser, PermissionsMixin):
 
         frozen_author = self.frozen_author(article)
 
-        if frozen_author:
-            # We prioritize the frozen_author.order because after a submission
-            # is complete backend reordering tools use FrozenAuthor.order over
-            # ArticleAuthorOrder.
-            frozen_dict['order'] = frozen_author.order
+        if frozen_author and force_update:
             for k, v in frozen_dict.items():
                 setattr(frozen_author, k, v)
             frozen_author.save()

--- a/src/journal/views.py
+++ b/src/journal/views.py
@@ -971,7 +971,7 @@ def publish_article(request, article_id):
 
         if 'publish' in request.POST:
             article.stage = submission_models.STAGE_PUBLISHED
-            article.snapshot_authors(article)
+            article.snapshot_authors(force_update=False)
             article.close_core_workflow_objects()
 
             if not article.date_published:

--- a/src/review/views.py
+++ b/src/review/views.py
@@ -1414,7 +1414,7 @@ def review_decision(request, article_id, decision):
 
         if decision == 'accept':
             article.accept_article(stage=submission_models.STAGE_EDITOR_COPYEDITING)
-            article.snapshot_authors(article)
+            article.snapshot_authors(article, force_update=False)
             event_logic.Events.raise_event(event_logic.Events.ON_ARTICLE_ACCEPTED, task_object=article, **kwargs)
 
             workflow_kwargs = {'handshake_url': 'review_home',

--- a/src/submission/logic.py
+++ b/src/submission/logic.py
@@ -3,6 +3,7 @@ __author__ = "Martin Paul Eve & Andy Byers"
 __license__ = "AGPL v3"
 __maintainer__ = "Birkbeck Centre for Technology and Publishing"
 
+import warnings
 
 from bs4 import BeautifulSoup
 
@@ -17,6 +18,11 @@ from submission import models
 
 
 def add_self_as_author(user, article):
+    warnings.warn("'add_self_as_author' is deprecated and will be removed")
+    return add_user_as_author(user, article)
+
+
+def add_user_as_author(user, article):
     new_author = user
     article.authors.add(new_author)
     models.ArticleAuthorOrder.objects.get_or_create(

--- a/src/submission/tests.py
+++ b/src/submission/tests.py
@@ -148,7 +148,7 @@ class SubmissionTests(TestCase):
             title="Test article: a test article",
         )
         author, _ = self.create_authors()
-        logic.add_self_as_author(author, article)
+        logic.add_user_as_author(author, article)
 
         article.snapshot_authors()
         frozen = article.frozen_authors().all()[0]
@@ -165,8 +165,8 @@ class SubmissionTests(TestCase):
             title="Test article: a test article",
         )
         author_1, author_2 = self.create_authors()
-        logic.add_self_as_author(author_1, article)
-        logic.add_self_as_author(author_2, article)
+        logic.add_user_as_author(author_1, article)
+        logic.add_user_as_author(author_2, article)
 
         article.snapshot_authors()
         frozen = article.frozen_authors().all()
@@ -182,7 +182,7 @@ class SubmissionTests(TestCase):
             title="Test article: a test article",
         )
         author, _ = self.create_authors()
-        logic.add_self_as_author(author, article)
+        logic.add_user_as_author(author, article)
 
         article.snapshot_authors()
         frozen = article.frozen_authors().all()[0]
@@ -202,7 +202,7 @@ class SubmissionTests(TestCase):
             title="Test article: a test article",
         )
         author, _ = self.create_authors()
-        logic.add_self_as_author(author, article)
+        logic.add_user_as_author(author, article)
 
         article.snapshot_authors()
         new_department = "New department"
@@ -221,8 +221,8 @@ class SubmissionTests(TestCase):
             title="Test article: a test article",
         )
         author_1, author_2 = self.create_authors()
-        logic.add_self_as_author(author_1, article)
-        logic.add_self_as_author(author_2, article)
+        logic.add_user_as_author(author_1, article)
+        logic.add_user_as_author(author_2, article)
         no_order_author = Account.objects.create(
             email="no_order@t.t",
             first_name="no order",

--- a/src/submission/tests.py
+++ b/src/submission/tests.py
@@ -8,10 +8,11 @@ from mock import Mock
 from django.http import Http404
 from django.test import TestCase
 
+from core.models import Account
 from identifiers import logic as id_logic
 from identifiers import logic as id_logic
 from journal import models as journal_models
-from submission import decorators, models
+from submission import decorators, models, logic
 from utils.install import update_xsl_files, update_settings
 
 
@@ -35,6 +36,31 @@ class SubmissionTests(TestCase):
         update_settings(journal_one, management_command=False)
 
         return journal_one
+
+    @staticmethod
+    def create_authors():
+        author_1_data = {
+            'is_active': True,
+            'password': 'this_is_a_password',
+            'salutation': 'Prof.',
+            'first_name': 'Martin',
+            'last_name': 'Eve',
+            'department': 'English & Humanities',
+            'institution': 'Birkbeck, University of London',
+        }
+        author_2_data = {
+            'is_active': True,
+            'password': 'this_is_a_password',
+            'salutation': 'Sr.',
+            'first_name': 'Mauro',
+            'last_name': 'Sanchez',
+            'department': 'English & Humanities',
+            'institution': 'Birkbeck, University of London',
+        }
+        author_1 = Account.objects.create(email="1@t.t", **author_1_data)
+        author_2 = Account.objects.create(email="2@t.t", **author_1_data)
+
+        return author_1, author_2
 
     def setUp(self):
         """
@@ -115,3 +141,99 @@ class SubmissionTests(TestCase):
             Http404, msg="Funding pages available when they shouldn't"
         ):
             decorated(request)
+
+    def test_snapshot_author_metadata_correctly(self):
+        article = models.Article.objects.create(
+            journal = self.journal_one,
+            title="Test article: a test article",
+        )
+        author, _ = self.create_authors()
+        logic.add_self_as_author(author, article)
+
+        article.snapshot_authors()
+        frozen = article.frozen_authors().all()[0]
+        keys = {'first_name', 'last_name', 'department', 'institution'}
+
+        self.assertDictEqual(
+            {k: getattr(author, k) for k in keys},
+            {k: getattr(frozen, k) for k in keys},
+        )
+
+    def test_snapshot_author_order_correctly(self):
+        article = models.Article.objects.create(
+            journal = self.journal_one,
+            title="Test article: a test article",
+        )
+        author_1, author_2 = self.create_authors()
+        logic.add_self_as_author(author_1, article)
+        logic.add_self_as_author(author_2, article)
+
+        article.snapshot_authors()
+        frozen = article.frozen_authors().all()
+        self.assertListEqual(
+            [author_1, author_2],
+            [f.author for f in article.frozen_authors().order_by("order")],
+            msg="Authors frozen in the wrong order",
+        )
+
+    def test_snapshot_author_metadata_do_not_override(self):
+        article = models.Article.objects.create(
+            journal = self.journal_one,
+            title="Test article: a test article",
+        )
+        author, _ = self.create_authors()
+        logic.add_self_as_author(author, article)
+
+        article.snapshot_authors()
+        frozen = article.frozen_authors().all()[0]
+        new_department = "New department"
+        frozen.department = new_department
+        frozen.save()
+        article.snapshot_authors(force_update=False)
+
+        self.assertEqual(
+            frozen.department, new_department,
+            msg="Frozen author edits have been overriden by snapshot_authors",
+        )
+
+    def test_snapshot_author_metadata_override(self):
+        article = models.Article.objects.create(
+            journal = self.journal_one,
+            title="Test article: a test article",
+        )
+        author, _ = self.create_authors()
+        logic.add_self_as_author(author, article)
+
+        article.snapshot_authors()
+        new_department = "New department"
+        article.frozen_authors().update(department=new_department)
+        article.snapshot_authors(force_update=True)
+        frozen = article.frozen_authors().all()[0]
+
+        self.assertEqual(
+            frozen.department, author.department,
+            msg="Frozen author edits have been overriden by snapshot_authors",
+        )
+
+    def test_snapshot_author_order_author_added_later(self):
+        article = models.Article.objects.create(
+            journal = self.journal_one,
+            title="Test article: a test article",
+        )
+        author_1, author_2 = self.create_authors()
+        logic.add_self_as_author(author_1, article)
+        logic.add_self_as_author(author_2, article)
+        no_order_author = Account.objects.create(
+            email="no_order@t.t",
+            first_name="no order",
+            last_name="no order",
+        )
+        article.authors.add(no_order_author)
+
+        article.snapshot_authors()
+        frozen = article.frozen_authors().all()
+        self.assertListEqual(
+            [author_1, author_2, no_order_author],
+            [f.author for f in article.frozen_authors().order_by("order")],
+            msg="Authors frozen in the wrong order",
+        )

--- a/src/submission/views.py
+++ b/src/submission/views.py
@@ -55,7 +55,7 @@ def start(request, type=None):
                 preprint_models.Preprint.objects.create(article=new_article)
 
             if setting_handler.get_setting('general', 'user_automatically_author', request.journal).processed_value:
-                logic.add_self_as_author(request.user, new_article)
+                logic.add_user_as_author(request.user, new_article)
 
             return redirect(reverse('submit_info', kwargs={'article_id': new_article.pk}))
 
@@ -200,7 +200,7 @@ def submit_authors(request, article_id):
     error, modal = None, None
 
     if request.GET.get('add_self', None) == 'True':
-        new_author = logic.add_self_as_author(request.user, article)
+        new_author = logic.add_user_as_author(request.user, article)
         messages.add_message(request, messages.SUCCESS, '%s added to the article' % new_author.full_name())
         return redirect(reverse('submit_authors', kwargs={'article_id': article_id}))
 


### PR DESCRIPTION
Fixes a couple of problems:
 - Frozen author metadata was being overridden when calling `article.snapshot_authors`. There is now a `force_update` flag to control this behaviour.
 - Refactored the function to iterate the authors in `article.snapshot_authors` so that authors without an `ArticleAuthorOrder` record are not ignored