### PR TITLE
[Preprints] minor tweaks to minor improvements #1834

### DIFF
--- a/src/themes/material/templates/repository/list.html
+++ b/src/themes/material/templates/repository/list.html
@@ -11,7 +11,7 @@
             <h1>{{ request.repository.object_name_plural }}</h1>
             <p>
                 {% if search_term %}
-                    Searching for <em>{{ search_term }}</em>, there are {{ preprints|length }} results.
+                    Search for <em>{{ search_term }}</em> ({{ preprints|length }} results)
                 {% else %}
                     There {% if preprints|length > 1 %}are {{ preprints|length }} {{ request.repository.object_name_plural }} listed.{% elif preprints|length == 1 %}is 1 {{ request.repository.object_name }}{% else %}are 0 {{ request.repository.object_name }} listed.{% endif %}
                 {% endif %}

--- a/src/themes/material/templates/repository/preprint.html
+++ b/src/themes/material/templates/repository/preprint.html
@@ -130,7 +130,7 @@
                         </div>
                         <br/>
                     {% else %}
-                        <p>You must log in to post a comment.</p>
+                        <p>You must <a href="{% url 'core_login' %}">log in</a> to post a comment.</p>
 
                     {% endif %}
                     <div class="divider"></div>

--- a/src/themes/material/templates/repository/preprint.html
+++ b/src/themes/material/templates/repository/preprint.html
@@ -130,7 +130,8 @@
                         </div>
                         <br/>
                     {% else %}
-                        <p>You must login to post a comment.</p>
+                        <p>You must log in to post a comment.</p>
+
                     {% endif %}
                     <div class="divider"></div>
                     <br />


### PR DESCRIPTION
‘login’ should be ‘log in’ in the sentence “You must login to post a comment.”