### PR TITLE
1842 admi dash load

### DIFF
--- a/src/repository/logic.py
+++ b/src/repository/logic.py
@@ -334,17 +334,17 @@ def delete_file(request, preprint):
         )
 
 
-def subject_article_pks(request):
+def subject_article_pks(user):
     prepint_pks = []
     # TODO: Update this implementation
-    for subject in request.user.preprint_subjects():
+    for subject in user.preprint_subjects():
         for preprint in subject.preprints.all():
             prepint_pks.append(preprint.pk)
 
     return prepint_pks
 
 
-def get_unpublished_preprints(request):
+def get_unpublished_preprints(request, user_subject_pks):
     unpublished_preprints = models.Preprint.objects.filter(
         date_published__isnull=True,
         date_submitted__isnull=False,
@@ -357,10 +357,10 @@ def get_unpublished_preprints(request):
     if request.user.is_staff:
         return unpublished_preprints
     else:
-        return unpublished_preprints.filter(pk__in=subject_article_pks(request))
+        return unpublished_preprints.filter(pk__in=user_subject_pks)
 
 
-def get_published_preprints(request):
+def get_published_preprints(request, user_subject_pks):
     published_preprints = models.Preprint.objects.filter(
         date_published__isnull=False,
         date_submitted__isnull=False).prefetch_related(
@@ -370,7 +370,7 @@ def get_published_preprints(request):
     if request.user.is_staff:
         return published_preprints
     else:
-        return published_preprints.filter(pk__in=subject_article_pks(request))
+        return published_preprints.filter(pk__in=user_subject_pks)
 
 
 def get_preprint_if_id(preprint_id):

--- a/src/repository/views.py
+++ b/src/repository/views.py
@@ -698,8 +698,15 @@ def preprints_manager(request):
     :param request: HttpRequest
     :return: HttpResponse or HttpRedirect
     """
-    unpublished_preprints = repository_logic.get_unpublished_preprints(request)
-    published_preprints = repository_logic.get_published_preprints(request)
+    user_subject_pks = repository_logic.subject_article_pks(request.user)
+    unpublished_preprints = repository_logic.get_unpublished_preprints(
+        request,
+        user_subject_pks,
+    )
+    published_preprints = repository_logic.get_published_preprints(
+        request,
+        user_subject_pks,
+    )
     incomplete_preprints = models.Preprint.objects.filter(
         date_published__isnull=True,
         date_submitted__isnull=True,

--- a/src/templates/admin/repository/manager.html
+++ b/src/templates/admin/repository/manager.html
@@ -1,7 +1,7 @@
 {% extends "admin/core/base.html" %}
 
 {% block title-section %}Preprint Manager{% endblock %}
-{% block title-sub %}Management interface for {{ request.press.name }} preprints{% endblock %}
+{% block title-sub %}Management interface for {{ request.repository.name }}]}{% endblock %}
 
 {% block breadcrumbs %}
     <li><a href="{% url 'core_manager_index' %}">Press Manager</a></li>
@@ -22,7 +22,6 @@
                             <th>ID</th>
                             <th>Title</th>
                             <th>Date Submitted</th>
-                            <th>First Author</th>
                         </tr>
                         </thead>
                         <tbody>
@@ -33,7 +32,6 @@
                                     <a href="{% url 'repository_manager_article' preprint.pk %}">{{ preprint.title|safe }}</a>
                                 </td>
                                 <td>{{ preprint.date_submitted }}</td>
-                                <td>{{ preprint.authors.0.full_name }}</td>
                             </tr>
                         {% endfor %}
                         </tbody>
@@ -95,9 +93,6 @@
                             <th>ID</th>
                             <th>Title</th>
                             <th>Date Published</th>
-                            <th>First Author</th>
-                            <th>Views</th>
-                            <th>Downloads</th>
                         </tr>
                         </thead>
                         <tbody>
@@ -108,9 +103,6 @@
                                     <a href="{% url 'repository_manager_article' preprint.pk %}">{{ preprint.title|safe }}</a>
                                 </td>
                                 <td>{{ preprint.date_published }}</td>
-                                <td>{{ preprint.authors.0.full_name }}</td>
-                                <td>{{ preprint.views.count }}</td>
-                                <td>{{ preprint.downloads.count }}</td>
                             </tr>
                         {% endfor %}
                         </tbody>

--- a/src/templates/admin/repository/manager.html
+++ b/src/templates/admin/repository/manager.html
@@ -1,7 +1,7 @@
 {% extends "admin/core/base.html" %}
 
 {% block title-section %}Preprint Manager{% endblock %}
-{% block title-sub %}Management interface for {{ request.repository.name }}]}{% endblock %}
+{% block title-sub %}Management interface for {{ request.repository.name }}{% endblock %}
 
 {% block breadcrumbs %}
     <li><a href="{% url 'core_manager_index' %}">Press Manager</a></li>


### PR DESCRIPTION
This PR:

- Removes the First Author from New and Published Preprints
- Removes the Views and Downloads from Published Preprints
- Reduces the number of queries from 2480 to 15.

The solution is just a suggestion, instead we could limit the number of Published preprints to say 100 and add a search option.

Comments welcome @justingonder @hardyoyo @tingletech