### PR TITLE
Removes duplicate Identifiers block in article archive view

### DIFF
--- a/src/templates/admin/elements/metadata.html
+++ b/src/templates/admin/elements/metadata.html
@@ -232,9 +232,9 @@
                         {% endfor %}
                     </td>
                 {% else %}
-                    <td>Example DOI Based on Pattern</td>
-                    <td>{{ article.render_sample_doi }}</td>
-                    <td></td>
+                    <td>DOI</td>
+                    <td><span class="fa fa-exclamation-triangle"> Article has no DOI</span></td>
+                    <td><a href="{% url 'add_new_identifier' article.pk %}" class="button">Add DOI</a></td>
                 {% endif %}
                 {% endwith %}
             </tr>

--- a/src/templates/admin/elements/metadata.html
+++ b/src/templates/admin/elements/metadata.html
@@ -195,6 +195,7 @@
 
 <div class="title-area">
     <h2>Identifiers</h2>
+    <a class="button" href="{% url 'edit_identifiers' article.pk %}" target="_blank"><i class="fa fa-edit">&nbsp;</i>Edit</a>
 </div>
 {% setting_var request.journal 'use_crossref' as use_crossref %}
 <div class="content">

--- a/src/templates/admin/identifiers/manage_identifier.html
+++ b/src/templates/admin/identifiers/manage_identifier.html
@@ -22,6 +22,8 @@
         <h2>{% if identifier %}Edit Identifier - {{ identifier.pk }}{% else %}Add New Identifier{% endif %}</h2>
         <a class="button" href="{% url 'article_identifiers' article.pk %}"><i class="fa fa-arrow-left">&nbsp;</i>Back</a>
     </div>
+    <p>Dois should be entered on their ID format, not their URL format<p>
+    <p>Example DOI based on pattern for this article: {{ article.render_sample_doi }}</p>
     <form method="POST">
         {% csrf_token %}
         {% include "elements/forms/errors.html" %}

--- a/src/templates/admin/journal/manage/archive_article.html
+++ b/src/templates/admin/journal/manage/archive_article.html
@@ -40,31 +40,7 @@
             </div>
         </div>
     </div>
-    <div class="large-4 columns">
-        <div class="box">
-            <div class="title-area">
-                <h2>Identifiers</h2>
-                <a class="button" href="{% url 'edit_identifiers' article.pk %}" target="_blank"><i class="fa fa-edit">&nbsp;</i>Edit</a>
-            </div>
-            <div class="content">
-                <table class="small scroll">
-                    <tr>
-                        <th>Identifier Type</th>
-                        <th>Identifier</th>
-                        <th>Enabled</th>
-                    </tr>
-                    {% for ident in identifiers %}
-                    <tr>
-                        <td>{{ ident.get_id_type_display }}</td>
-                        <td>{{ ident.identifier }}</td>
-                        <td>{% if ident.enabled %}<i class="fa fa-check"></i>{% else %}<i class="fa fa-times"></i>{% endif %}</td>
-                    </tr>
-                    {% endfor %}
-                </table>
-            </div>
-        </div>
-    </div>
-    <div class="large-8 columns">
+    <div class="large-12 columns">
         <div class="box">
             <div class="title-area">
                 <h2>Galleys</h2>


### PR DESCRIPTION
Bonus Tracks:
 - Adds a more prominent alert and a link if an article has no DOI
 - Adds a sample DOI based on pattern on new DOI view
closes #1764 