### PR TITLE
#1285 guest editors now display, optionally, on the article page.

### DIFF
--- a/src/core/logic.py
+++ b/src/core/logic.py
@@ -318,6 +318,7 @@ def get_settings_to_edit(group, journal):
     elif group == 'article':
         article_settings = [
             'suppress_how_to_cite',
+            'display_guest_editors',
         ]
         settings = process_setting_list(article_settings, 'article', journal)
         setting_group = 'article'

--- a/src/templates/common/elements/guest_editors.html
+++ b/src/templates/common/elements/guest_editors.html
@@ -1,0 +1,8 @@
+{% if issue.editors.all %}
+    <p>
+    {% if small %}<small>{% endif %}
+        <strong>Editors: </strong>
+        {% for editor in issue.issueeditor_set.all %}{{ editor.account.full_name }} ({{ editor.role }}){% if not forloop.last %}, {% endif %}{% endfor %}
+    {% if small %}</small>{% endif %}
+    </p>
+{% endif %}

--- a/src/themes/OLH/templates/elements/journal/article_issue_list.html
+++ b/src/themes/OLH/templates/elements/journal/article_issue_list.html
@@ -3,13 +3,18 @@
 <h3>{% if issue_length > 1 %}Issues{% else %}Issue{% endif %}</h3>
 {% endwith %}
 <ul>
+    {% if article.primary_issue %}
+        <li>
+            <a href="{% url 'journal_issue' article.primary_issue.pk %}">{{ article.primary_issue.display_title }}</a>
+            {% if journal_settings.article.display_guest_editors %}
+            <br />
+            {% include "common/elements/guest_editors.html" with issue=article.primary_issue small="small" %}
+            {% endif %}
+        </li>
+    {% endif %}
     {% for issue in article.issues_list %}
-        <li><a href="{% url 'journal_issue' issue.pk %}">{{ issue.display_title }}</a></li>
+        {% if not issue == article.primary_issue %}<li><a href="{% url 'journal_issue' issue.pk %}">{{ issue.display_title }}</a></li>{% endif %}
     {% empty %}
-        {% if article.primary_issue %}
-            <li><a href="{% url 'journal_issue' issue.pk %}">{{ article.primary_issue.display_title }}</a></li>
-        {% else %}
         <li>This article is not a part of any issues.</li>
-        {% endif %}
     {% endfor %}
 </ul>

--- a/src/themes/OLH/templates/elements/journal/issue_top.html
+++ b/src/themes/OLH/templates/elements/journal/issue_top.html
@@ -21,9 +21,5 @@
         {% if issue.issue_description %}<p>{{ issue.issue_description|safe }}</p>{% endif %}
     {% endif %}
 
-    {% if issue.editors.all %}
-    <p>
-        <strong>Editors: </strong> {% for editor in issue.issueeditor_set.all %}{{ editor.account.full_name }} ({{ editor.role }}){% if not forloop.last %}, {% endif %}{% endfor %}
-    </p>
-    {% endif %}
+    {% include "common/elements/guest_editors.html" %}
 </div>

--- a/src/themes/default/templates/elements/journal/article_issue_list.html
+++ b/src/themes/default/templates/elements/journal/article_issue_list.html
@@ -1,15 +1,19 @@
-
 {% with issue_length=article.issues_list|length %}
-<h4>{% if issue_length > 1 %}Issues{% else %}Issue{% endif %}</h4>
+    <h4>{% if issue_length > 1 %}Issues{% else %}Issue{% endif %}</h4>
 {% endwith %}
 <ul>
+    {% if article.primary_issue %}
+        <li>
+            <a href="{% url 'journal_issue' article.primary_issue.pk %}">{{ article.primary_issue.display_title }}</a>
+            {% if journal_settings.article.display_guest_editors %}
+                <br/>
+                {% include "common/elements/guest_editors.html" with issue=article.primary_issue small="small" %}
+            {% endif %}
+        </li>
+    {% endif %}
     {% for issue in article.issues_list %}
-        <li><a href="{% url 'journal_issue' issue.pk %}">{{ issue.display_title }}</a></li>
-    {% empty %}
-        {% if article.primary_issue %}
-            <li><a href="{% url 'journal_issue' issue.pk %}">{{ article.primary_issue.display_title }}</a></li>
-        {% else %}
+        {% if not issue == article.primary_issue %}<li><a href="{% url 'journal_issue' issue.pk %}">{{ issue.display_title }}</a></li>{% endif %}
+        {% empty %}
         <li>This article is not a part of any issues.</li>
-        {% endif %}
     {% endfor %}
 </ul>

--- a/src/themes/default/templates/elements/journal/issue_top.html
+++ b/src/themes/default/templates/elements/journal/issue_top.html
@@ -14,9 +14,5 @@
     <h2 class="em">{{ issue.display_title }}</h2>
     {% if issue.issue_description %}<p>{{ issue.issue_description|safe }}</p>{% endif %}
 {% endif %}
-{% if issue.editors.all %}
-    <p>
-        <strong>Editors: </strong> {% for editor in issue.issueeditor_set.all %}{{ editor.account.full_name }} ({{ editor.role }}){% if not forloop.last %}, {% endif %}{% endfor %}
-    </p>
-{% endif %}
+{% include "common/elements/guest_editors.html" %}
 <br/>

--- a/src/themes/material/templates/elements/journal/issue_top.html
+++ b/src/themes/material/templates/elements/journal/issue_top.html
@@ -17,9 +17,5 @@
     {% if issue.issue_description %}<p>{{ issue.issue_description|safe }}</p>{% endif %}
 {% endif %}
 
-{% if issue.editors.all %}
-    <p>
-        <strong>Editors: </strong> {% for editor in issue.issueeditor_set.all %}{{ editor.account.full_name }} ({{ editor.role }}){% if not forloop.last %}, {% endif %}{% endfor %}
-    </p>
-{% endif %}
+{% include "common/elements/guest_editors.html" %}
 <br/>

--- a/src/utils/install/journal_defaults.json
+++ b/src/utils/install/journal_defaults.json
@@ -2700,7 +2700,7 @@
             "name": "article"
         },
         "setting": {
-            "description": "If enabled guest editors will display on the article page.",
+            "description": "If enabled guest editors will display on the article page for primary issues.",
             "is_translatable": false,
             "name": "display_guest_editors",
             "pretty_name": "Display Guest Editors",

--- a/src/utils/install/journal_defaults.json
+++ b/src/utils/install/journal_defaults.json
@@ -2694,5 +2694,20 @@
         "group": {
             "name": "email_subject"
         }
+    },
+    {
+        "group": {
+            "name": "article"
+        },
+        "setting": {
+            "description": "If enabled guest editors will display on the article page.",
+            "is_translatable": false,
+            "name": "display_guest_editors",
+            "pretty_name": "Display Guest Editors",
+            "type": "boolean"
+        },
+        "value": {
+            "default": ""
+        }
     }
 ]


### PR DESCRIPTION
- Adds a new setting to the Article group, display_guest_editors
- Displays a primary issue's guest editors if it has any

Closes #1285 