### PR TITLE
Automatically give author role to assigned authors

### DIFF
--- a/src/submission/logic.py
+++ b/src/submission/logic.py
@@ -22,15 +22,21 @@ def add_self_as_author(user, article):
     return add_user_as_author(user, article)
 
 
-def add_user_as_author(user, article):
-    new_author = user
-    article.authors.add(new_author)
+def add_user_as_author(user, article, give_role=True):
+    """ Assigns the given user as an author of the paper
+    :param user: An instance of core.models.Account
+    :param article: An instance of submission.models.Article
+    :param give_role: If true, the user is given the author role in the journal
+    """
+    if give_role:
+        user.add_account_tole("author", article.journal)
+    article.authors.add(user)
     models.ArticleAuthorOrder.objects.get_or_create(
         article=article,
-        author=new_author,
+        author=user,
         defaults={'order': article.next_author_sort()},
     )
-    return new_author
+    return user
 
 
 def check_author_exists(email):

--- a/src/submission/logic.py
+++ b/src/submission/logic.py
@@ -29,7 +29,7 @@ def add_user_as_author(user, article, give_role=True):
     :param give_role: If true, the user is given the author role in the journal
     """
     if give_role:
-        user.add_account_tole("author", article.journal)
+        user.add_account_role("author", article.journal)
     article.authors.add(user)
     models.ArticleAuthorOrder.objects.get_or_create(
         article=article,

--- a/src/submission/tests.py
+++ b/src/submission/tests.py
@@ -18,6 +18,7 @@ from utils.install import update_xsl_files, update_settings
 
 # Create your tests here.
 class SubmissionTests(TestCase):
+    fixtures = ["src/utils/install/roles.json"]
 
     def test_new_journals_has_submission_configuration(self):
         if not self.journal_one.submissionconfiguration:


### PR DESCRIPTION
 - Handles missing author role logic in `logic.add_user_as_author` (controlled via `kwarg`)
 - Removes the various pieces of logic for adding paper authors from the `submit_authors` view and calls `logic.add_user_as_author` instead.