### PR TITLE
Make it more clear that the credentials might be wrong

### DIFF
--- a/src/core/forms.py
+++ b/src/core/forms.py
@@ -401,7 +401,7 @@ class LoginForm(forms.Form):
                 "[FAILED_LOGIN:%s][FAILURES: %s]"
                 "" % (self.fields["user_name"], bad_logins),
             )
-        if bad_logins >= 3:
+        if bad_logins > 3:
             self.fields['captcha'] = self.captcha_field
         else:
             self.fields['captcha'] = forms.CharField(widget=forms.HiddenInput(), required=False)

--- a/src/core/views.py
+++ b/src/core/views.py
@@ -60,7 +60,7 @@ def user_login(request):
     else:
         bad_logins = logic.check_for_bad_login_attempts(request)
 
-    if bad_logins >= 5:
+    if bad_logins >= 10:
         messages.info(
                 request,
                 'You have been banned from logging in due to failed attempts.'
@@ -109,9 +109,11 @@ def user_login(request):
                     logic.start_reset_process(request, empty_password_check)
                 else:
 
-                    messages.add_message(request, messages.ERROR,
-                                         'Account not found or account not active. Please ensure'
-                                         ' you have activated your account.')
+                    messages.add_message(
+                        request, messages.ERROR,
+                        'Wrong email/password combination or your'
+                        ' email addressed has not been confirmed yet.',
+                    )
                     util_models.LogEntry.add_entry(types='Authentication',
                                                    description='Failed login attempt for user {0}'.format(
                                                        request.POST.get('user_name')),


### PR DESCRIPTION
With the message we currently have, some users give up on re-trying /resetting their password and contact support thinking their account does not exist.
The new message doesn't reveal any details about the account while pointing out that the password might be wrong. This is relevant particularly for authors that publish papers for more than one journal in a given press.