### PR TITLE
Optional about block on submissions page

### DIFF
--- a/src/core/logic.py
+++ b/src/core/logic.py
@@ -178,6 +178,13 @@ def get_settings_to_edit(group, journal):
                  journal,
              )
              },
+            {'name': 'display_about_on_submissions',
+             'object': setting_handler.get_setting(
+                 'general',
+                 'display_about_on_submissions',
+                 journal
+             )
+             },
             {'name': 'submission_intro_text',
              'object': setting_handler.get_setting(
                  'general',

--- a/src/themes/OLH/templates/journal/submissions.html
+++ b/src/themes/OLH/templates/journal/submissions.html
@@ -33,7 +33,7 @@
                 </div>
                 {% endif %}
                 <hr />
-                {% if journal_settings.general.journal_description %}
+                {% if journal_settings.general.display_about_on_submissions and journal_settings.general.journal_description %}
                 <h3>{% trans 'About' %} {{ request.journal.name }}</h3>
                 {{ journal_settings.general.journal_description|safe }}
                 <hr />

--- a/src/themes/default/templates/journal/submissions.html
+++ b/src/themes/default/templates/journal/submissions.html
@@ -32,7 +32,7 @@
                 </div>
                 {% endif %}
                 <hr />
-                {% if journal_settings.general.journal_description %}
+                {% if journal_settings.general.display_about_on_submissions and journal_settings.general.journal_description %}
                 <h2>{% trans 'About' %} {{ request.journal.name }}</h2>
                 {{ journal_settings.general.journal_description|safe }}
                 <hr />

--- a/src/themes/material/templates/journal/submissions.html
+++ b/src/themes/material/templates/journal/submissions.html
@@ -37,7 +37,7 @@
                     {% endif %}
                     <div class="divider spacer"></div>
 
-                    {% if journal_settings.general.journal_description %}
+                    {% if journal_settings.general.display_about_on_submissions and journal_settings.general.journal_description %}
                     <span class="card-title">{% trans 'About' %} {{ request.journal.name }}</span>
                     {{ journal_settings.general.journal_description|safe }}
                     <div class="divider spacer"></div>

--- a/src/utils/install/journal_defaults.json
+++ b/src/utils/install/journal_defaults.json
@@ -2656,6 +2656,21 @@
     },
     {
         "group": {
+            "name": "general"
+        },
+        "setting": {
+            "description": "If enabled, the journal about block will be rendered in the submissions page",
+            "is_translatable": false,
+            "name": "display_about_on_submissions",
+            "pretty_name": "Display 'About' on submissions",
+            "type": "boolean"
+        },
+        "value": {
+            "default": "on"
+        }
+    },
+    {
+        "group": {
             "name": "article"
         },
         "setting": {


### PR DESCRIPTION
Since this setting is used also in the homepage element, editors can't leave it  blank in order to remove it from the submissions page but not the front page.
I added a bool setting to control this instead.