### PR TITLE
#1921 adds new peer review setting for the upload box description.

### DIFF
--- a/src/core/logic.py
+++ b/src/core/logic.py
@@ -285,7 +285,11 @@ def get_settings_to_edit(group, journal):
             {
                 'name': 'reviewer_form_download',
                 'object': setting_handler.get_setting('general', 'reviewer_form_download', journal),
-            }
+            },
+            {
+                'name': 'peer_review_upload_text',
+                'object': setting_handler.get_setting('general', 'peer_review_upload_text', journal),
+            },
         ]
         setting_group = 'general'
 

--- a/src/templates/admin/review/review_form.html
+++ b/src/templates/admin/review/review_form.html
@@ -122,8 +122,7 @@
                     </div>
                     <div class="content">
                         <div class="large-12 columns">
-                            <p>You may upload a file in lieu of completing the review form. Please
-                                ensure you've covered all of the required fields below.</p>
+                            {{ journal_settings.general.peer_review_upload_text|safe }}
                                 {% csrf_token %}
                                 {% if assignment.review_file %}Current file: {{ assignment.review_file }}{% endif %}
                                 <input type="file" id="review_file"

--- a/src/utils/install/journal_defaults.json
+++ b/src/utils/install/journal_defaults.json
@@ -2739,5 +2739,20 @@
         "value": {
             "default": ""
         }
+    },
+    {
+        "group": {
+            "name": "general"
+        },
+        "setting": {
+            "description": "Changes the generic text above the File Upload box on the Peer Review form page.",
+            "is_translatable": true,
+            "name": "peer_review_upload_text",
+            "pretty_name": "Peer Review Upload Text",
+            "type": "rich-text"
+        },
+        "value": {
+            "default": "<p>You may upload a file in lieu of completing the review form. Please ensure you've covered all of the required fields below.</p>"
+        }
     }
 ]


### PR DESCRIPTION
- Adds a new setting `peer_review_upload_text`
- Setting is displayed on the Review Settings page
- Displays text above the Upload File box on the Peer reviewer form page

Closes #1921