### PR TITLE
#1838: Refactor core 0042 migration

### DIFF
--- a/src/core/migrations/0042_auto_20200825_1051.py
+++ b/src/core/migrations/0042_auto_20200825_1051.py
@@ -13,7 +13,7 @@ def lower_all_usernames(apps, schema_editor):
     handled = set()
 
     for account in accounts:
-        if account.pk in handled:
+        if account.username.lower() in handled:
             continue
         try:
             with transaction.atomic():
@@ -64,7 +64,7 @@ def handle_unique_username_violation(same_accounts, apps):
     for acc in same_accounts:
         if acc != real_account:
             merge_models(acc, real_account)
-            merged.add(acc.pk)
+            merged.add(acc.username.lower())
     real_account.username = real_account.username.lower()
     real_account.save()
     return merged

--- a/src/core/migrations/0042_auto_20200825_1051.py
+++ b/src/core/migrations/0042_auto_20200825_1051.py
@@ -10,56 +10,64 @@ from core.model_utils import merge_models
 def lower_all_usernames(apps, schema_editor):
     Account = apps.get_model('core', 'Account')
     accounts = Account.objects.all()
+    handled = set()
 
     for account in accounts:
+        if account.pk in handled:
+            continue
         try:
             with transaction.atomic():
                 account.username = account.username.lower()
                 account.save()
         except IntegrityError:
-            handle_unique_username_violation(account, apps)
+            same_accounts = Account.objects.filter(username__iexact=account.username)
+            handled |= handle_unique_username_violation(same_accounts, apps)
 
-def handle_unique_username_violation(account, apps):
+def handle_unique_username_violation(same_accounts, apps):
     AccountRole = apps.get_model('core', 'Accountrole')
     Account = apps.get_model('core', 'Account')
-    same_accounts = Account.objects.filter(username__iexact=account.username)
+    real_account = None
+
     # Try checking if one has logged in
     has_logged_in = same_accounts.filter(last_login__isnull=False)
     if has_logged_in.count == 1:
-        if has_logged_in[0] != account:
-            with transaction.atomic():
-                return merge_models(account, has_logged_in[0])
+        real_account = has_logged_in[0]
 
-    # Try checking if one account has a non-author role:
-    account_roles_ids = AccountRole.objects.filter(
-        user__in=same_accounts,
-    ).exclude(
-        role__slug="author"
-    ).values_list("user", flat=True)
-    if len(set(account_roles_ids)) == 1:
-        has_role = Account.objects.get(id=account_roles_ids[0])
-        if has_role != account:
-            with transaction.atomic():
-                return merge_models(account, has_role)
+    if real_account is None:
+        # Try checking if one account has a non-author role:
+        account_roles_ids = AccountRole.objects.filter(
+            user__in=same_accounts,
+        ).exclude(
+            role__slug="author"
+        ).values_list("user", flat=True)
+        if len(set(account_roles_ids)) == 1:
+            real_account = Account.objects.get(id=account_roles_ids[0])
 
-    # Try checking if one account is author
-    authors = []
-    for acc in same_accounts:
-        if acc.article_set.exists():
-            authors.append(acc)
-    if len(authors) >2:
-        raise Exception(
-            "Can't workout the real user for username %s" % account.username)
-    elif len(authors) == 1:
-        real_author = authors[0]
-    else:
+    if real_account is None:
+        # Try checking if one account is author
+        authors = []
+        for acc in same_accounts:
+            if acc.article_set.exists():
+                authors.append(acc)
+        if len(authors) >2:
+            raise Exception(
+                "Can't workout the real user for username %s" % acc.username)
+        elif len(authors) == 1:
+            real_account = authors[0]
+
+    if real_account is None:
         # At this point no account is an author, has a role or logged in
         # Declare any of them the real author
-        real_author = account
+        real_account = same_accounts[0]
 
+    merged = set()
     for acc in same_accounts:
-        if acc != real_author:
-            merge_models(acc, real_author)
+        if acc != real_account:
+            merge_models(acc, real_account)
+            merged.add(acc.pk)
+    real_account.username = real_account.username.lower()
+    real_account.save()
+    return merged
 
 
 


### PR DESCRIPTION
Simplifies the logic for handling duplicate usernames and fixes a bug were if the first username of a matching set was mixed case the operation was ignored