### PR TITLE
Fix regex escaping during search term split

### DIFF
--- a/src/journal/views.py
+++ b/src/journal/views.py
@@ -1775,13 +1775,13 @@ def search(request):
         return redir
     from itertools import chain
     if search_term:
+        escaped = re.escape(search_term)
         # checks titles, keywords and subtitles first,
         # then matches author based on below regex split search term.
-        escaped = re.escape(search_term)
+        split_term = [re.escape(word) for word in search_term.split(" ")]
+        split_term.append(escaped)
         search_regex = "^({})$".format(
-            "|".join({name for name in set(
-                chain(escaped.split(" "),(escaped,))
-            )})
+            "|".join({name for name in split_term})
         )
         articles = submission_models.Article.objects.filter(
                     (


### PR DESCRIPTION
Closes #1946

search: the sniper irish short
before this pr = `'^(short\\|the\\|irish\\|the\\ sniper\\ irish\\ short\\ story|story|sniper\\)`
after this pr = `'^(short|the|irish|the\\ sniper\\ irish\\ short\\ story|story|sniper)`