### PR TITLE
Update Lando configs to use MySQL instead of Postgres

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -14,7 +14,7 @@ services:
       - grep '^deb ' /etc/apt/sources.list | perl -pe 's/deb /deb-src /' >> /etc/apt/sources.list
       - apt-get update -qq && apt-get install -y python3-lxml pylint libxml2-dev libxslt1-dev python3-dev zlib1g-dev lib32z1-dev libffi-dev libssl-dev libjpeg-dev libmariadb-dev-compat libmariadb-dev mysql-client && apt-get build-dep -y lxml
     build:
-      - cd /app && pip install Cython && pip install -r requirements.txt &&  pip install -r dev-requirements.txt
+      - cd /app && pip install --upgrade pip && pip install Cython && pip install -r requirements.txt &&  pip install -r dev-requirements.txt
     scanner: true
     overrides:
       ports:
@@ -38,7 +38,7 @@ tooling:
     cmd: python
   manage:
     service: appserver
-    cmd: cd /app/src && python manage.py
+    cmd: cd /app && python src/manage.py
   mysql:
     service: db
     cmd: mysql -u root

--- a/.lando.yml
+++ b/.lando.yml
@@ -8,13 +8,13 @@ env_file:
 
 services:
   appserver:
-    type: python:3.5.9
+    type: python:3.6.8
     command: python /app/src/manage.py runserver 0.0.0.0:8000 -v 3
     build_as_root:
       - grep '^deb ' /etc/apt/sources.list | perl -pe 's/deb /deb-src /' >> /etc/apt/sources.list
-      - apt-get update -qq && apt-get install -y python3-lxml pylint libxml2-dev libxslt1-dev python3-dev zlib1g-dev lib32z1-dev libffi-dev libssl-dev libjpeg-dev && apt-get build-dep -y lxml
+      - apt-get update -qq && apt-get install -y python3-lxml pylint libxml2-dev libxslt1-dev python3-dev zlib1g-dev lib32z1-dev libffi-dev libssl-dev libjpeg-dev libmariadb-dev-compat libmariadb-dev mysql-client && apt-get build-dep -y lxml
     build:
-      - cd /app && pip install --upgrade pip && pip install Cython && pip install psycopg2 && pip install -r requirements.txt &&  pip install -r dev-requirements.txt
+      - cd /app && pip install Cython && pip install -r requirements.txt &&  pip install -r dev-requirements.txt
     scanner: true
     overrides:
       ports:
@@ -25,11 +25,11 @@ services:
     moreHttpPorts:
       - '8000'
   db:
-    type: postgres:10
+    type: mysql
     portforward: true
     creds:
-      user: postgres
-      password: 
+      user: dba
+      password: password
       database: janeway
 
 tooling:
@@ -39,9 +39,9 @@ tooling:
   manage:
     service: appserver
     cmd: cd /app/src && python manage.py
-  psql:
+  mysql:
     service: db
-    cmd: psql -U postgres
+    cmd: mysql -u root
   'db-import <file>':
     service: :host
     description: Imports a dump file into a database service

--- a/dockerfiles/lando_defaults.env
+++ b/dockerfiles/lando_defaults.env
@@ -13,10 +13,10 @@
 ###############################################################################
 # Database
 
-DB_VENDOR=postgres
+DB_VENDOR=mysql
 DB_NAME=janeway
-DB_USER=postgres
-DB_PASSWORD=
+DB_USER=dba
+DB_PASSWORD=password
 DB_HOST=db.janeway.internal
-DB_PORT=5432
+DB_PORT=3306
 

--- a/dockerfiles/lando_defaults.env
+++ b/dockerfiles/lando_defaults.env
@@ -15,8 +15,8 @@
 
 DB_VENDOR=mysql
 DB_NAME=janeway
-DB_USER=dba
-DB_PASSWORD=password
+DB_USER=root
+DB_PASSWORD=
 DB_HOST=db.janeway.internal
 DB_PORT=3306
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,7 +40,7 @@ python-dateutil==2.6.0
 python-magic==0.4.13
 python-docx==0.8.6
 raven==6.0.0 # TODO: Optional for sentry
-requests==2.20.0
+requests==2.25.1
 six==1.10.0
 sqlparse==0.2.3
 ua-parser==0.7.2


### PR DESCRIPTION
- update Python version to a more modern 3.6.8
- install all dependencies for using MySQL with Janeway
- configure a MySQL database for the Lando dev environment
- adjust all default configuration environment variables