### PR TITLE
bump requests to 2.25.1 to make current pip happy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -40,7 +40,7 @@ python-dateutil==2.6.0
 python-magic==0.4.13
 python-docx==0.8.6
 raven==6.0.0 # TODO: Optional for sentry
-requests==2.20.0
+requests==2.25.1
 six==1.10.0
 sqlparse==0.2.3
 ua-parser==0.7.2


### PR DESCRIPTION
As documented on [HackerNews](https://news.ycombinator.com/item?id=25145396) the Pip package manager for Python recently had its dependency algorithm tweaked. This lead to a situation where the current requirements.txt file could not be used with the latest version of pip without the load of dependencies failing. This change bumps up the version for the requests package to a version that keeps the current pip happy. Tests pass with this version of the library.