### PR TITLE
Fix wrong type for dc:date on OAI

### DIFF
--- a/src/templates/common/apis/OAI_record.xml
+++ b/src/templates/common/apis/OAI_record.xml
@@ -16,7 +16,7 @@
       <dc:date>
     <dc:day>{{ article.date_published|date:"d" }}</dc:day>
     <dc:month>{{ article.date_published|date:"m" }}</dc:month>
-    <dc:year>{{ article.date_published|date:"yy" }}</dc:year>
+    <dc:year>{{ article.date_published|date:"Y" }}</dc:year>
       </dc:date>
       <dc:type>info:eu-repo/semantics/article</dc:type>
       {% if article.issue %}<dc:volume>{{ article.issue.volume }}</dc:volume>

--- a/src/templates/common/apis/OAI_record.xml
+++ b/src/templates/common/apis/OAI_record.xml
@@ -13,11 +13,7 @@
       <dc:creator>{{author.last_name}}, {{author.first_name}}</dc:creator>
       {% endfor %}
       <dc:description>{{article.abstract|striptags}}</dc:description>
-      <dc:date>
-    <dc:day>{{ article.date_published|date:"d" }}</dc:day>
-    <dc:month>{{ article.date_published|date:"m" }}</dc:month>
-    <dc:year>{{ article.date_published|date:"Y" }}</dc:year>
-      </dc:date>
+      <date>{{article.date_published|date:"c"}}</date>
       <dc:type>info:eu-repo/semantics/article</dc:type>
       {% if article.issue %}<dc:volume>{{ article.issue.volume }}</dc:volume>
       <dc:issue>{{ article.issue.issue }}</dc:issue>{% endif %}

--- a/src/templates/common/apis/OAI_record_header.xml
+++ b/src/templates/common/apis/OAI_record_header.xml
@@ -1,4 +1,4 @@
 <header>
   <identifier>id:{{ article.pk }}</identifier>
-  <datestamp>{{article.date_published}}</datestamp>
+  <datestamp>{{article.date_published|date:"c"}}</datestamp>
 </header>


### PR DESCRIPTION
- Fixes a bug where the publication year was wrong.
- Changes the <dc:date> to an ISO 8601 date
closes #2012 