### PR TITLE
Pin django-hijack for 1.11 compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -46,6 +46,6 @@ sqlparse==0.2.3
 ua-parser==0.7.2
 user-agents==1.0.1
 -e git+https://github.com/BirkbeckCTP/django-materialize.git@bcfbfd9150887328dddce965674c84b2b6e6b785#egg=django_materialize
-django-hijack
+django-hijack==2.1.10
 geoip2==3.0.0 # Newer versions require python >= 3.6
 maxminddb==1.5.4


### PR DESCRIPTION
Latest version breaks backwards compatibility with 1.11:
https://github.com/django-hijack/django-hijack/issues/223