### PR TITLE
[preprints] Preprint remodel metadata edit bug

### DIFF
--- a/src/repository/models.py
+++ b/src/repository/models.py
@@ -889,6 +889,7 @@ class VersionQueue(models.Model):
     def approve(self):
         self.date_decision = timezone.now()
         self.approved = True
+        current_version = None
 
         # Update the current version to have the Preprint's current title
         # and abstract.
@@ -896,13 +897,17 @@ class VersionQueue(models.Model):
             current_version = self.preprint.current_version
             current_version.title = self.preprint.title
             current_version.abstract = self.preprint.abstract
+            this_file = self.preprint.current_version.file
+        # no version yet
+        else:
+            this_file = self.preprint.submission_file
 
         # Create a new PreprintVersion, this will now be the current_version.
         # If the current VersionQueue has no file (in the case of Metadata
         # updates) use the preprint's current version's file.
         PreprintVersion.objects.create(
             preprint=self.preprint,
-            file=self.file if self.file else self.preprint.current_version.file,
+            file=self.file if self.file else this_file,
             version=self.preprint.next_version_number(),
             moderated_version=self,
         )

--- a/src/repository/models.py
+++ b/src/repository/models.py
@@ -892,9 +892,10 @@ class VersionQueue(models.Model):
 
         # Update the current version to have the Preprint's current title
         # and abstract.
-        current_version = self.preprint.current_version
-        current_version.title = self.preprint.title
-        current_version.abstract = self.preprint.abstract
+        if self.preprint.current_version is not None:
+            current_version = self.preprint.current_version
+            current_version.title = self.preprint.title
+            current_version.abstract = self.preprint.abstract
 
         # Create a new PreprintVersion, this will now be the current_version.
         # If the current VersionQueue has no file (in the case of Metadata
@@ -913,7 +914,8 @@ class VersionQueue(models.Model):
         if self.abstract:
             self.preprint.abstract = self.abstract
 
-        current_version.save()
+        if current_version is not None:
+            current_version.save()
         self.preprint.save()
         self.save()
 

--- a/src/templates/admin/elements/repository/version_detail.html
+++ b/src/templates/admin/elements/repository/version_detail.html
@@ -21,7 +21,9 @@
                     <p><strong>Abstract</strong></p>
                     <p>{{ version.preprint.abstract|safe|linebreaksbr }}</p>
                     <p><strong>File</strong></p>
+                    {% if version.preprint.current_version.file %}
                     <p><a href="{% url 'repository_file_download' version.preprint.id version.preprint.current_version.file.id %}"><i class="fa fa-download"></i> Download</a></p>
+                    {% endif %}
                 </div>
             </div>
             <div class="large-6 columns">

--- a/src/templates/admin/repository/article.html
+++ b/src/templates/admin/repository/article.html
@@ -270,10 +270,16 @@
                             <td>Update ID: {{ update.pk }}</td>
                             <td>{{ update.get_update_type_display }} (Pending)</td>
                             <td>{{ update.date_submitted }}</td>
+                            {% if update.file %}
                             <td>{{ update.file.original_filename }}</td>
                             <td>{{ update.file.uploaded }}</td>
                             <td><a href="{% url 'repository_download_file' preprint.pk update.file.pk %}"><i
                                     class="fa fa-download"></i></a></td>
+                            {% else %}
+                            <td>n/a</td>
+                            <td>n/a</td>
+                            <td>n/a</td>
+                            {% endif %}
                             <td>
                                 <a href="{% url 'version_queue' %}">Manage</a>
                             </td>

--- a/src/templates/admin/repository/version_queue.html
+++ b/src/templates/admin/repository/version_queue.html
@@ -23,6 +23,7 @@
                     <thead>
                         <tr>
                             <th>ID</th>
+                            <th>{{ request.repository.object_name }} ID</th>
                             <th>{{ request.repository.object_name }}</th>
                             <th>Requester</th>
                             <th>Requested</th>
@@ -36,6 +37,7 @@
                     {% for version in version_queue %}
                         <tr>
                             <td>{{ version.pk }}</td>
+                            <td>{{ version.preprint.id }}</td>
                             <td>{{ version.preprint.title|safe }} {% if version.preprint in duplicates %}<span data-tooltip aria-haspopup="true" class="has-tip" data-disable-hover="false" tabindex="1" title="This {{ request.repository.object_name }} has multiple requests in queue."><i class="fa fa-info-circle"></i></span>{% endif %}</td>
                             <td>{{ version.preprint.owner }}</td>
                             <td>{{ version.date_submitted }}</td>


### PR DESCRIPTION
 ----

fixes some errors on `preprints-remodel` that were keeping us from pushing the latest changes.

Justin reported on https://github.com/BirkbeckCTP/janeway/issues/1873#issuecomment-741984981

I think we have not pushed code to prod since before  #1891 ?

yea, our prod is running c1e628c5c92bec288580278d4e544fa8b941a66e right now


---

I kept getting different errors between dev and localhost, after some false leads, turned out it was because debug mode made the error manifest differently.  Tried `path` and `host` modes and different versions of python before I figured out it was debug mode that was making me not be able to reproduce the same exact errors.



