### PR TITLE
Better CSS selector for subjects' <ul>

### DIFF
--- a/src/themes/material/assets/mat.css
+++ b/src/themes/material/assets/mat.css
@@ -213,6 +213,6 @@ h5 {
   }
   
   /* Show the nested list when the user clicks on the caret/arrow (with JavaScript) */
-  .active {
+  #subjects .tree .active {
     display: block;
   }

--- a/src/themes/material/templates/repository/list_subjects.html
+++ b/src/themes/material/templates/repository/list_subjects.html
@@ -8,7 +8,7 @@
     <div class="row">
         <h1>{{ request.repository.name }} Subjects</h1>
         <p>Select a subject to view {{ request.repository.object_name_plural }} in that subject.</p>
-        <ul class="tree">
+        <ul id="subjects" class="tree">
         {% include "repository/elements/subject_tree.html" with subjects=top_level_subjects %}
         </ul>
     </div>


### PR DESCRIPTION
closes #2029 

I can't verify that this works well with the subjects, not sure if this feature was ever completed.
It does however resolve the larger problem with the dropdowns as per #2029 