### PR TITLE
Improvements to the peer review assignment workflow in one-click mode.

### DIFF
--- a/src/review/logic.py
+++ b/src/review/logic.py
@@ -378,6 +378,7 @@ def handle_reviewer_form(request, new_reviewer_form):
     account.save()
     account.add_account_role('reviewer', request.journal)
     messages.add_message(request, messages.INFO, 'A new account has been created.')
+    return account
 
 
 def get_enrollable_users(request):

--- a/src/review/logic.py
+++ b/src/review/logic.py
@@ -305,7 +305,7 @@ def get_access_code(request):
     return access_code
 
 
-def quick_assign(request, article):
+def quick_assign(request, article, reviewer_user=None):
     errors = []
     try:
         default_review_form_id = setting_handler.get_setting('general',
@@ -329,8 +329,11 @@ def quick_assign(request, article):
     except BaseException:
         errors.append('This journal does not have either default visibilty or default due.')
 
-    user_id = request.POST.get('quick_assign')
-    user = core_models.Account.objects.get(pk=user_id)
+    if not reviewer_user:
+        user_id = request.POST.get('quick_assign')
+        user = core_models.Account.objects.get(pk=user_id)
+    else:
+        user = reviewer_user
 
     if user not in request.journal.users_with_role('reviewer'):
         errors.append('This user is not a reviewer for this journal.')

--- a/src/review/logic.py
+++ b/src/review/logic.py
@@ -326,7 +326,7 @@ def quick_assign(request, article, reviewer_user=None):
         default_due = setting_handler.get_setting('general',
                                                   'default_review_days',
                                                   request.journal).value
-    except BaseException:
+    except Exception:
         errors.append('This journal does not have either default visibilty or default due.')
 
     if not reviewer_user:

--- a/src/review/views.py
+++ b/src/review/views.py
@@ -1042,7 +1042,7 @@ def add_review_assignment(request, article_id):
             try:
                 user = core_models.Account.objects.get(email=new_reviewer_form.data['email'])
                 user.add_account_role('reviewer', request.journal)
-            except:
+            except core_models.Account.DoesNotExist:
                 user = None
 
             if user:
@@ -1065,7 +1065,7 @@ def add_review_assignment(request, article_id):
             try:
                 user = core_models.Account.objects.get(email=new_reviewer_form.data['email'])
                 user.add_account_role('reviewer', request.journal)
-            except:
+            except core_models.Account.DoesNotExist:
                 user = None
 
             if user:

--- a/src/review/views.py
+++ b/src/review/views.py
@@ -1035,6 +1035,29 @@ def add_review_assignment(request, article_id):
         if 'quick_assign' in request.POST:
             logic.quick_assign(request, article)
             return redirect(reverse('review_in_review', kwargs={'article_id': article_id}))
+        elif 'add_and_assign' in request.POST:
+            # first check whether the user exists
+            new_reviewer_form = core_forms.QuickUserForm(request.POST)
+
+            try:
+                user = core_models.Account.objects.get(email=new_reviewer_form.data['email'])
+                user.add_account_role('reviewer', request.journal)
+            except:
+                user = None
+
+            if user:
+                logic.quick_assign(request, article, reviewer_user=user)
+                return redirect(reverse('review_in_review', kwargs={'article_id': article_id}))
+
+            valid = new_reviewer_form.is_valid()
+
+            if valid:
+                acc = logic.handle_reviewer_form(request, new_reviewer_form)
+                logic.quick_assign(request, article, reviewer_user=acc)
+                return redirect(reverse('review_in_review', kwargs={'article_id': article_id}))
+            else:
+                modal = 'reviewer'
+
         elif 'assign' in request.POST:
             # first check whether the user exists
             new_reviewer_form = core_forms.QuickUserForm(request.POST)
@@ -1055,6 +1078,7 @@ def add_review_assignment(request, article_id):
                 return redirect(reverse('review_add_review_assignment', kwargs={'article_id': article.pk}) + '?' + parse.urlencode({'user': new_reviewer_form.data['email'], 'id': str(acc.pk)}))
             else:
                 modal = 'reviewer'
+
         elif 'enrollusers' in request.POST:
             user_ids = request.POST.getlist('user_id')
             users = core_models.Account.objects.filter(pk__in=user_ids)

--- a/src/templates/admin/review/add_review_assignment.html
+++ b/src/templates/admin/review/add_review_assignment.html
@@ -122,6 +122,7 @@
                         {% csrf_token %}
                         {{ new_reviewer_form|foundation }}
                         <button type="submit" class="button success" name="assign" id="assign">Add Reviewer</button>
+                        <button type="submit" class="button success" name="add_and_assign" id="assign">Add Reviewer and Assign with Defaults</button>
                     </form>
                 </div>
             </div>

--- a/src/templates/admin/review/add_review_assignment.html
+++ b/src/templates/admin/review/add_review_assignment.html
@@ -181,4 +181,34 @@
         {% include "admin/elements/open_modal.html" with target=modal %}
     {% endif %}
     {% include "elements/datatables.html" with target="#enrolluser" %}
+
+    <script lang="javascript">
+    function getQueryStrings()
+    {
+        let vars = [], hash;
+        let hashes = window.location.href.slice(window.location.href.indexOf('?') + 1).split('&');
+        for(let i = 0; i < hashes.length; i++)
+        {
+            hash = hashes[i].split('=');
+            vars.push(hash[0]);
+            vars[hash[0]] = hash[1].split('#')[0];
+        }
+        return vars;
+    }
+
+    // populate the query box when ready
+    $( document ).ready(function() {
+        let urls = getQueryStrings();
+        let user = urls["user"];
+        let user_id = urls["id"];
+
+        if (user !== '') {
+            $('#reviewers').DataTable().search(decodeURIComponent(user)).draw();
+
+            if (user_id !== '') {
+                $("input[value=" + decodeURIComponent(user_id) + "]").attr('checked', 'checked');
+            }
+        }
+    });
+    </script>
 {% endblock js %}

--- a/src/utils/install/journal_defaults.json
+++ b/src/utils/install/journal_defaults.json
@@ -1346,7 +1346,7 @@
             "type": "boolean"
         },
         "value": {
-            "default": ""
+            "default": "on"
         }
     },
     {


### PR DESCRIPTION
Now:

1. You can enter an email + acc. Doesn't matter if they already exist or aren't enrolled or anything. It finds existing users. Tries to enroll them if not enrolled. Or creates the account.

2. Then when you return to the enrollment page, some on_ready JS does an auto datatables search for the account you just entered, and then ticks the checkbox for you

Closes #1968