### PR TITLE
[preprints] Preprint api

### DIFF
--- a/src/api/serializers.py
+++ b/src/api/serializers.py
@@ -3,6 +3,7 @@ from rest_framework import serializers
 from core import models as core_models
 from journal import models as journal_models
 from submission import models as submission_models
+from repository import models as repository_models
 
 
 class LicenceSerializer(serializers.HyperlinkedModelSerializer):
@@ -60,6 +61,47 @@ class ArticleSerializer(serializers.HyperlinkedModelSerializer):
     galleys = GalleySerializer(
         source='galley_set',
         many=True
+    )
+
+
+class PreprintAuthorSerializer(serializers.HyperlinkedModelSerializer):
+
+    class Meta:
+        model = repository_models.Author
+        fields = ('first_name', 'middle_name', 'last_name', 'affiliation', 'orcid',)
+
+
+class PreprintSubjectSerializer(serializers.HyperlinkedModelSerializer):
+
+    class Meta:
+        model = repository_models.Subject
+        fields = ('name',)
+
+class PreprintSerializer(serializers.HyperlinkedModelSerializer):
+
+    class Meta:
+        model = repository_models.Preprint
+        fields = ('pk', 'title', 'abstract', 'license', 'keywords', 'section',
+                  'date_submitted', 'date_accepted', 'date_published',
+                  'doi', 'preprint_doi', 'authors', 'subject',
+ )
+
+    authors = PreprintAuthorSerializer(
+        many=True,
+        read_only=True,
+    )
+    license = LicenceSerializer()
+    keywords = KeywordsSerializer(
+        many=True,
+        read_only=True,
+    )
+    section = serializers.ReadOnlyField(
+        read_only=True,
+        source='section.name'
+    )
+    subject = PreprintSubjectSerializer(
+        many=True,
+        read_only=True,
     )
 
 

--- a/src/api/serializers.py
+++ b/src/api/serializers.py
@@ -81,10 +81,9 @@ class PreprintSerializer(serializers.HyperlinkedModelSerializer):
 
     class Meta:
         model = repository_models.Preprint
-        fields = ('pk', 'title', 'abstract', 'license', 'keywords', 'section',
+        fields = ('pk', 'title', 'abstract', 'license', 'keywords', 
                   'date_submitted', 'date_accepted', 'date_published',
-                  'doi', 'preprint_doi', 'authors', 'subject',
- )
+                  'doi', 'preprint_doi', 'authors', 'subject',)
 
     authors = PreprintAuthorSerializer(
         many=True,
@@ -94,10 +93,6 @@ class PreprintSerializer(serializers.HyperlinkedModelSerializer):
     keywords = KeywordsSerializer(
         many=True,
         read_only=True,
-    )
-    section = serializers.ReadOnlyField(
-        read_only=True,
-        source='section.name'
     )
     subject = PreprintSubjectSerializer(
         many=True,

--- a/src/api/urls.py
+++ b/src/api/urls.py
@@ -9,6 +9,7 @@ router.register(r'accountrole', views.AccountRoleViewSet)
 router.register(r'journals', views.JournalViewSet, 'journal')
 router.register(r'issues', views.IssueViewSet, 'issue')
 router.register(r'articles', views.ArticleViewSet, 'article')
+router.register(r'preprints', views.PreprintViewSet, 'preprint')
 router.register(r'licences', views.LicenceViewSet, 'licence')
 router.register(r'keywords', views.KeywordsViewSet, 'keywords')
 

--- a/src/api/views.py
+++ b/src/api/views.py
@@ -11,6 +11,7 @@ from rest_framework import permissions
 from api import serializers, permissions as api_permissions
 from core import models as core_models
 from submission import models as submission_models
+from repository import models as repository_models
 
 
 @api_view(['GET'])
@@ -103,6 +104,20 @@ class ArticleViewSet(viewsets.ModelViewSet):
                                                                 date_published__lte=timezone.now())
 
         return queryset
+
+
+class PreprintViewSet(viewsets.ModelViewSet):
+    """
+    API Endpoint for preprints.
+    """
+    pass
+    serializer_class = serializers.PreprintSerializer
+    http_method_names = ['get']
+
+    def get_queryset(self):
+        return repository_models.Preprint.objects.filter(repository=self.request.repository,
+                                                         date_published__lte=timezone.now(),
+                                                         stage=repository_models.STAGE_PREPRINT_PUBLISHED)
 
 
 def oai(request):


### PR DESCRIPTION
eartharxiv asked for an api, and since I had the dev server still running, I took a stab at adding a (very slow) `/api/preprints/` that serializes the metadata for the preprints including (authors, subjects, keywords)