### PR TITLE
How to cite page numbers

### DIFF
--- a/src/submission/models.py
+++ b/src/submission/models.py
@@ -538,6 +538,9 @@ class Article(models.Model):
         if self.issue:
             issue_str = "%s(%s)" % (issue.volume, issue.issue)
         doi_str = ""
+        pages_str = ""
+        if self.page_numbers:
+            pages_str = " p.{0}.".format(self.page_numbers)
         doi = self.get_doi()
         if doi:
             doi_str = ('doi: <a href="https://doi.org/{0}">'
@@ -550,6 +553,7 @@ class Article(models.Model):
             "journal_str": journal_str,
             "issue_str": issue_str,
             "doi_str": doi_str,
+            "pages_str": pages_str,
         }
         return render_to_string(template, context)
 

--- a/src/templates/common/elements/how_to_cite.html
+++ b/src/templates/common/elements/how_to_cite.html
@@ -2,5 +2,6 @@
     {{ author_str }},
     {{ year_str }} “{{ title }}”,
     {{ journal_str|safe }} {{ issue_str }}.
+    {{ pages_str|safe }}
     {{ doi_str|safe }}
 </p>

--- a/src/utils/importers/shared.py
+++ b/src/utils/importers/shared.py
@@ -596,11 +596,15 @@ def set_article_keywords(article, soup_object):
         'content',
     ))
     if keyword_string:
-        for word in keyword_string.split(";"):
+        for i, word in enumerate(keyword_string.split(";")):
             if word:
                 keyword, created = submission_models.Keyword.objects \
                     .get_or_create(word=word.lstrip())
-                article.keywords.add(keyword)
+                submission_models.KeywordArticle.objects.update_or_create(
+                    article=article,
+                    keyword=keyword,
+                    defaults = {"order": i},
+                )
 
 
 def set_article_galleys(domain, galleys, article, url, user):


### PR DESCRIPTION
Adds page numbers to the "how to cite" block when they are available
Also a  fix to the shared importer when handling the new KeywordArticle model