### PR TITLE
Correct Pending Updates table heading

### DIFF
--- a/src/templates/admin/repository/article.html
+++ b/src/templates/admin/repository/article.html
@@ -261,7 +261,7 @@
                         <th>Filename</th>
                         <th>Uploaded</th>
                         <th>Download</th>
-                        <th>Delete</th>
+                        <th>Manage</th>
                     </tr>
                     </thead>
                     <tbody>


### PR DESCRIPTION
The heading 'delete' in the Pending Updates table is incorrect as the actions in that column are 'Manage' not 'Delete.' Changing heading to 'Manage.'