### PR TITLE
Exclude empty collections

### DIFF
--- a/src/journal/views.py
+++ b/src/journal/views.py
@@ -330,6 +330,9 @@ def collections(request, issue_type_code="collection"):
         journal=request.journal,
         issue_type=issue_type,
         date__lte=timezone.now(),
+    ).exclude(
+        # This has to be an .exclude because.filter won't do an INNER join
+        articles__isnull=True,
     )
 
     template = 'journal/collections.html'


### PR DESCRIPTION
Noted after migrating the OLH journal.

Collections are createdin advance of receiving any articles, which leads to them being rendered as empty collections on the site