### PR TITLE
#2146: Fix broken link to edit email subjects

### DIFF
--- a/src/core/views.py
+++ b/src/core/views.py
@@ -1668,7 +1668,10 @@ def email_templates(request):
     :param request: HttpRequest object
     :return: HttpResponse object
     """
-    template_list = models.Setting.objects.filter(group__name='email')
+    template_list = (
+        (setting, 'subject_%s' % setting.name)
+        for setting in models.Setting.objects.filter(group__name='email')
+    )
 
     template = 'core/manager/email/email_templates.html'
     context = {

--- a/src/templates/admin/core/manager/email/email_templates.html
+++ b/src/templates/admin/core/manager/email/email_templates.html
@@ -28,7 +28,7 @@
                         <th></th>
                     </tr>
                     </thead>
-                    {% for template in template_list %}
+                    {% for template, subject in template_list %}
                         <tr>
                             <td>{{ template.pretty_name }}</td>
                             <td>{{ template.name }}</td>
@@ -36,7 +36,7 @@
                             <td><a class="btn btn-primary btn-round-half" style="width:75px"
                                    href="{% url 'core_edit_setting' 'email' template.name %}?email_template=true">Edit</a></td>
                         <td>
-                            <a href="{% url 'core_edit_setting' 'email_subject' template.name %}?email_template=true">Edit Subject</a>
+                            <a href="{% url 'core_edit_setting' 'email_subject' subject %}?email_template=true">Edit Subject</a>
                         </td>
                         </tr>
                     {% endfor %}


### PR DESCRIPTION
Closes #2146 

The edit email setting link was pointing to the email setting name rather than the subject setting name