### PR TITLE
Fix edit accepted assignment

### DIFF
--- a/src/review/forms.py
+++ b/src/review/forms.py
@@ -54,6 +54,10 @@ class ReviewAssignmentForm(forms.ModelForm):
             form = models.ReviewForm.objects.get(pk=default_form)
             self.fields['form'].initial = form
 
+        if self.instance.date_accepted:
+            self.fields['form'].required = False
+            self.fields['review_type'].required = False
+
 
 class ReviewerDecisionForm(forms.ModelForm):
 


### PR DESCRIPTION
The frontend allows editing part of the review assignment form when it is accepted, but the form itself still has those fields set as required leading to the review assignment not getting updated and the user receiving no feedback on the error