### PR TITLE
Update privacy-policy URL in registration pages

### DIFF
--- a/src/themes/OLH/templates/core/accounts/register.html
+++ b/src/themes/OLH/templates/core/accounts/register.html
@@ -75,8 +75,13 @@
                             <div class="large-12 columns">
                                 {{ form.are_you_a_robot|foundation }}
                                 <br/>
-                                <p>{% trans "By registering an account you agree to our" %} <a
-                                        href="/site/privacy/">{% trans "Privacy Policy" %}</a>.</p>
+                                <p>{% trans "By registering an account you agree to our" %}
+                                  {% if journal_settings.general.privacy_policy_url %}
+                                    <a href="{{ journal_settings.general.privacy_policy_url }}">{% trans "Privacy Policy" %}</a>
+                                  {% else %}
+                                    <a href="{% url 'cms_page' "privacy" %}">{% trans "Privacy Policy" %}</a>
+                                  {% endif %}
+                                </p>
                             </div>
                         </div>
                         <p>

--- a/src/themes/material/templates/core/accounts/register.html
+++ b/src/themes/material/templates/core/accounts/register.html
@@ -27,7 +27,13 @@
                     <form method="POST">
                         {% csrf_token %}
                         {% materialize_form form=form %}
-                        <p>{% trans "By registering an account you agree to our" %} <a href="/site/privacy/">{% trans "Privacy Policy" %}</a>.</p>
+                        <p>{% trans "By registering an account you agree to our" %}
+                          {% if journal_settings.general.privacy_policy_url %}
+                            <a href="{{ journal_settings.general.privacy_policy_url }}">{% trans "Privacy Policy" %}</a>
+                          {% else %}
+                            <a href="{% url 'cms_page' "privacy" %}">{% trans "Privacy Policy" %}</a>
+                          {% endif %}
+                        </p>
                         <button type="submit"
                                 class="btn btn-primary float-right">{% trans "Register" %}</button>
                     </form>


### PR DESCRIPTION
The logic to load custom journal privacy policy URLs was missing on this page