### PR TITLE
Fix bad function signature

### DIFF
--- a/src/journal/logic.py
+++ b/src/journal/logic.py
@@ -520,8 +520,8 @@ def send_email(user, form, request, article):
         subject,
         user.email,
         message,
-        cc=form.cleaned_data['cc'],
         log_dict=log_dict,
+        cc=form.cleaned_data['cc'],
     )
 
 

--- a/src/utils/notify_helpers.py
+++ b/src/utils/notify_helpers.py
@@ -28,7 +28,10 @@ def send_email_with_body_from_setting_template(request, template, subject, to, c
     notify.notification(**notify_contents)
 
 
-def send_email_with_body_from_user(request, subject, to, body, cc=None, log_dict=None):
+def send_email_with_body_from_user(
+        request, subject, to, body,
+        log_dict=None, cc=None,
+):
     notify_contents = {
         'subject': subject,
         'to': to,


### PR DESCRIPTION
v1.3.10-RC-1 changed the signature of send `send_email_with_body_from_user` and some callers were now sending the log_dict as the CC field.