### PR TITLE
Collections to render in a vertical stack (material)

### DIFF
--- a/src/themes/material/templates/journal/collections.html
+++ b/src/themes/material/templates/journal/collections.html
@@ -10,31 +10,32 @@
 
     <div class="row">
         {% for collection in collections %}
-             <div class="col m12 l6">
-                <div class="card horizontal">
+             <div class="col s12 m6 l4">
+                <div class="card large" style="height:550px">
                     <div class="card-image">
-                        {% if collection.cover_image or journal.default_cover_image %}<img class="issue_image" src="{% if collection.cover_image %}{{ collection.cover_image.url }}{% else %}{{ journal.default_cover_image.url }}{% endif %}" alt="{{ collection.issue_title }}" class="img-fluid">{% endif %}
+                        {% if collection.cover_image or journal.default_cover_image %}
+                        <img 
+                            class="issue_image"
+                            src="{% if collection.cover_image %}{{ collection.cover_image.url }}{% else %}{{ journal.default_cover_image.url }}{% endif %}"
+                            alt="{{ collection.issue_title }}" class="img-fluid"
+                            onerror="if (this.src !='{% static 'common/img/sample/article-small.jpg' %}') this.src='{% static 'common/img/sample/article-small.jpg' %}'"
+                        >
+                        {% endif %}
+                            <a href="{% url 'journal_collection' collection.id %}" class="carousel-text-wrapper card-title" style="width:100%">{{ collection.issue_title }}</a>
                     </div>
-                    <div class="card-stacked">
                         <div class="card-content">
-                            <span class="card-title">{{ collection.issue_title }}</span>
                             <p>Published: {{ collection.date|date:"d/m/y" }}</p>
                             {% if collection.short_description %}
                             <p>{{ collection.short_description|safe }}</p>
                             {% else %}
                             <p>{{ collection.issue_description|safe }}</p>
                             {% endif %}
-                    </div>
+                        </div>
                         <div class="card-action">
                             <a href="{% url 'journal_collection' collection.id %}">{% trans "View Collection" %}</a>
                         </div>
-                    </div>
                 </div>
             </div>
-          {% if forloop.counter|divisibleby:2 %}
-      </div>
-      <div class="row">
-          {% endif %}
         {% empty %}
             <h4>{% trans "There are no collections to display" %}</h4>
         {% endfor %}


### PR DESCRIPTION
- Layout is now  more similar to that of OLH theme
- The default image will be rendered when a collection image is not available
- The title is now rendered within the image to avoid having long titles push the description into overflow
https://gfycat.com/weirdpoisedgreendarnerdragonfly
