### PR TITLE
Pin psycopg2-binary to ~2.8.0

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -14,7 +14,7 @@ services:
       - grep '^deb ' /etc/apt/sources.list | perl -pe 's/deb /deb-src /' >> /etc/apt/sources.list
       - apt-get update -qq && apt-get install -y python3-lxml pylint libxml2-dev libxslt1-dev python3-dev zlib1g-dev lib32z1-dev libffi-dev libssl-dev libjpeg-dev && apt-get build-dep -y lxml
     build:
-      - cd /app && pip install --upgrade pip && pip install Cython && pip install psycopg2 && pip install -r requirements.txt &&  pip install -r dev-requirements.txt
+      - cd /app && pip install --upgrade pip && pip install Cython && pip install psycopg2-binary~=2.8.0 && pip install -r requirements.txt &&  pip install -r dev-requirements.txt
     scanner: true
     overrides:
       ports:

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,7 @@ mock
 mysqlclient==1.3.12
 pdfkit
 Pillow==7.1.0
-psycopg2-binary
+psycopg2-binary~=2.8.0
 pyasn1==0.1.9
 pycparser==2.14
 PyJWT==1.6.1


### PR DESCRIPTION
Django 1.11.x fails to connect to PostgreSQL databases when using psycopg2 2.9 onwards, due to a failing timezone-related assertion.

This also moves from psycopg2 to psycopg2-binary for Lando, which should have no external effect.

Closes #2274.