### PR TITLE
Hotfix PUBD-209 section editors should be able to download assigned files

### DIFF
--- a/src/security/logic.py
+++ b/src/security/logic.py
@@ -15,6 +15,11 @@ def can_edit_file(request, user, file_object, article):
     if user.is_staff or user.is_editor(request) or file_object.owner == user:
         return True
 
+    # allow section editors to edit files of articles assigned to them
+    if user.is_section_editor(request) and file_object.article:
+        if user in file_object.article.section_editors():
+            return True
+
     # allow file editing when the user is a production manager and the piece is in production
     try:
         production_assigned = production_models.ProductionAssignment.objects.get(article=article,)
@@ -75,6 +80,11 @@ def can_view_file(request, user, file_object):
 
     if user.is_staff or user.is_editor(request) or file_object.owner == user:
         return True
+
+    # allow section editors to view files of articles assigned to them
+    if user.is_section_editor(request) and file_object.article:
+        if user in file_object.article.section_editors():
+            return True
 
     # allow file editing when the user is the proofing manager for this article
     try:

--- a/src/security/logic.py
+++ b/src/security/logic.py
@@ -16,9 +16,8 @@ def can_edit_file(request, user, file_object, article):
         return True
 
     # allow section editors to edit files of articles assigned to them
-    if user.is_section_editor(request) and file_object.article:
-        if user in file_object.article.section_editors():
-            return True
+    if user.is_section_editor(request) and user in article.section_editors():
+        return True
 
     # allow file editing when the user is a production manager and the piece is in production
     try:

--- a/src/templates/admin/journal/file_history.html
+++ b/src/templates/admin/journal/file_history.html
@@ -50,7 +50,7 @@
                 {% can_edit_file file article as can_edit_file_flag %}
                 {% can_view_file file as can_view_file_flag %}
                 {% for file_history in file.history.all %}
-                    {% can_view_file file_history as can_view_historic_file_flag %}
+                    {% can_view_file_history file_history article as can_view_historic_file_flag %}
                     <tr>
                         <td>{{ file_history.pk }}</td>
                         <td>{{ file_history.label }} ({{ file_history.history_seq }})</td>


### PR DESCRIPTION
Backports the three commits from https://github.com/BirkbeckCTP/janeway/pull/1925 to the preprint-remodel branch, which is due to be merged soon, but we happen to have preprint-remodel deployed to production, and would feel more comfortable using an official branch than a bespoke one.