### PR TITLE
2315 bugfix

### DIFF
--- a/src/review/views.py
+++ b/src/review/views.py
@@ -380,6 +380,10 @@ def in_review(request, article_id):
 
     if request.POST:
 
+        if 'move_to_review' in request.POST and article.stage == submission_models.STAGE_UNASSIGNED:
+            article.stage = submission_models.STAGE_UNDER_REVIEW
+            article.save()
+
         if 'new_review_round' in request.POST:
 
             # Complete all existing review assignments.
@@ -411,6 +415,7 @@ def in_review(request, article_id):
         'article': article,
         'review_rounds': review_rounds,
         'revisions_requests': revisions_requests,
+        'review_stages': submission_models.REVIEW_STAGES,
     }
 
     return render(request, template, context)

--- a/src/security/decorators.py
+++ b/src/security/decorators.py
@@ -741,12 +741,32 @@ def article_decision_not_made(func):
             article_object = review_models.ReviewAssignment.objects.get(pk=kwargs['review_id'],
                                                                         article__journal=request.journal).article
 
-        if article_object.stage == models.STAGE_ASSIGNED or article_object.stage == models.STAGE_UNDER_REVIEW\
-                or article_object.stage == models.STAGE_UNDER_REVISION:
+        if article_object.stage in models.REVIEW_STAGES:
             return func(request, *args, **kwargs)
+        elif article_object.stage == models.STAGE_UNASSIGNED:
+            messages.add_message(
+                request,
+                messages.INFO,
+                'This article is not in a review stage.',
+            )
+            return redirect(
+                reverse(
+                    'review_in_review',
+                    kwargs={'article_id': article_object.pk},
+                )
+            )
         else:
-            messages.add_message(request, messages.WARNING, 'This article has already been accepted or declined.')
-            return redirect(reverse('review_in_review', kwargs={'article_id': article_object.pk}))
+            messages.add_message(
+                request,
+                messages.WARNING,
+                'This article is no longer under review.',
+            )
+            return redirect(
+                reverse(
+                    'review_in_review',
+                    kwargs={'article_id': article_object.pk},
+                )
+            )
 
     return wrapper
 

--- a/src/static/admin/css/admin.css
+++ b/src/static/admin/css/admin.css
@@ -331,7 +331,7 @@ th {
 .bs-callout {
     padding: 20px;
     border: 1px solid #eee;
-    border-left-width: 5px;
+    border-left-width: 8px;
     border-radius: 3px;
     margin-bottom: 10px;
 }

--- a/src/templates/admin/elements/article_jump.html
+++ b/src/templates/admin/elements/article_jump.html
@@ -7,12 +7,11 @@
     <div class="small expanded button-group">
         <a class="button" href="{% url 'review_unassigned_article' article.pk %}">Editor Assignment</a>
         {% for stage in article.workflow_stages %}
-            <a class="button"
+
+            <a class="button{% if stage.element.element_name == 'review' and article.stage == 'Unassigned' %} disabled{% endif %}"
                href="{% url stage.element.jump_url article.pk %}">{{ stage.element.element_name|capfirst }}</a>
         {% endfor %}
         <button class="button" type="button" data-toggle="more-dropdown">Logs, Documents and More</button>
-
-
 
     </div>
 {% endif %}

--- a/src/templates/admin/review/home.html
+++ b/src/templates/admin/review/home.html
@@ -42,8 +42,7 @@
                             <td><a href="{% url 'review_in_review' article.pk %}">{{ article.title }}</a></td>
                             <td>{{ article.date_submitted }}</td>
                             <td>{{ article.correspondence_author.full_name }}</td>
-                            <td>{% for editor in article.editors %}{{ editor.editor.full_name }}
-                                {% if not forloop.last %}, {% endif %}{% endfor %}</td>
+                            <td>{% for editor in article.editors %}{{ editor.editor.full_name }}{% if not forloop.last %}, {% endif %}{% endfor %}</td>
                             <td>{{ article.section.name }}</td>
                             <td>{% if article.projected_issue %}{{ article.projected_issue.display_title }}{% else %}
                                 None{% endif %}</td>

--- a/src/templates/admin/review/in_review.html
+++ b/src/templates/admin/review/in_review.html
@@ -17,6 +17,16 @@
     <div class="row expanded">
         <div class="large-8 columns">
             <div class="box">
+                {% if article.stage == 'Unassigned' %}
+                    <div class="bs-callout bs-callout-danger">
+                        <form method="POST">
+                            {% csrf_token %}
+                            <p><i class="fa fa-exclamation-triangle">&nbsp;</i>{% trans 'This article is not yet in the review stage.' %}</p>
+                            <button name="move_to_review" class="small success button">Move to Review</button>
+                        </form>
+                    </div>
+                {% endif %}
+
                 <ul class="tabs" data-tabs id="round-tabs">
                     {% for round in review_rounds %}
                         <li class="tabs-title {% if forloop.first %} is-active{% endif %}"><a

--- a/src/templates/admin/review/in_review.html
+++ b/src/templates/admin/review/in_review.html
@@ -22,7 +22,7 @@
                         <form method="POST">
                             {% csrf_token %}
                             <p><i class="fa fa-exclamation-triangle">&nbsp;</i>{% trans 'This article is not yet in the review stage.' %}</p>
-                            <button name="move_to_review" class="small success button">Move to Review</button>
+                            <button name="move_to_review" class="small success button no-bottom-margin">Move to Review</button>
                         </form>
                     </div>
                 {% endif %}

--- a/src/templates/admin/review/in_review.html
+++ b/src/templates/admin/review/in_review.html
@@ -21,8 +21,16 @@
                     <div class="bs-callout bs-callout-danger">
                         <form method="POST">
                             {% csrf_token %}
-                            <p><i class="fa fa-exclamation-triangle">&nbsp;</i>{% trans 'This article is not yet in the review stage.' %}</p>
-                            <button name="move_to_review" class="small success button no-bottom-margin">Move to Review</button>
+                            <p><i class="fa fa-exclamation-triangle">&nbsp;</i>{% trans 'This article is not yet in the review stage' %}.</p>
+                            {% if not article.editor_list %}
+                                <p>{% trans 'Before you can move this paper into review you need to' %} <a
+                                        href="{% url 'review_unassigned_article' article.pk %}">{% trans 'assign an editor' %}</a>.
+                                </p>
+                            {% else %}
+                                <button name="move_to_review" class="small success button no-bottom-margin">Move to
+                                    Review
+                                </button>
+                            {% endif %}
                         </form>
                     </div>
                 {% endif %}


### PR DESCRIPTION
- Disabled the review header link when an article is unassigned
- If somehow an editor makes it review there is now a callout warning (image below), this only works for articles in the Unassigned stage.
- Warning messages are now improved

Closes #2315 

![image](https://user-images.githubusercontent.com/8321378/128518726-18cef016-7a9f-4e57-a6ef-1e384e2b4748.png)
