### PR TITLE
2337 issue volume zero

### DIFF
--- a/src/journal/models.py
+++ b/src/journal/models.py
@@ -507,13 +507,14 @@ class Issue(models.Model):
     @property
     def pretty_issue_identifier(self):
         journal = self.journal
+        volume = issue = year = ''
 
-        volume = ugettext("Volume") + " {}".format(
-            self.volume) if journal.display_issue_volume else ""
-        issue = ugettext("Issue") + " {}".format(
-            self.issue) if journal.display_issue_number else ""
-        year = "{}".format(
-            self.date.year) if journal.display_issue_year else ""
+        if journal.display_issue_volume and self.volume:
+            volume = ugettext("Volume") + " {}".format(self.volume)
+        if journal.display_issue_number and self.issue and self.issue != "0":
+            issue = ugettext("Issue") + " {}".format(self.issue)
+        if journal.display_issue_year and self.date:
+            year = "{}".format(self.date.year)
 
         parts = [volume, issue, year]
 

--- a/src/submission/models.py
+++ b/src/submission/models.py
@@ -538,9 +538,15 @@ class Article(models.Model):
             year_str = "({:%Y})".format(self.date_published)
         journal_str = "<i>%s</i>" % self.journal.name
         issue_str = ""
-        issue = self.issue
-        if self.issue:
-            issue_str = "%s(%s)" % (issue.volume, issue.issue)
+        issue = self. issue
+        if issue:
+            if issue.volume:
+                if issue.issue and issue.issue != "0":
+                    issue_str = "%s(%s)" % (issue.volume, issue.issue)
+                else:
+                    issue_str = str(issue.volume)
+            elif issue.issue and issue.issue != "0":
+                    issue_str = str(issue.issue)
         doi_str = ""
         pages_str = ""
         if self.page_numbers:

--- a/src/submission/tests.py
+++ b/src/submission/tests.py
@@ -104,6 +104,36 @@ class SubmissionTests(TestCase):
         """.format(article.get_doi())
         self.assertHTMLEqual(expected, article.how_to_cite)
 
+    def test_article_how_to_cite(self):
+        issue = journal_models.Issue.objects.create(
+                journal=self.journal_one,
+                issue="0",
+                volume=1,
+        )
+        article = models.Article.objects.create(
+            journal = self.journal_one,
+            title="Test article: a test article",
+            primary_issue=issue,
+            date_published=dateparser.parse("2020-01-01"),
+            page_numbers = "2-4"
+        )
+        author = models.FrozenAuthor.objects.create(
+            article=article,
+            first_name="Mauro",
+            middle_name="Middle",
+            last_name="Sanchez",
+        )
+        id_logic.generate_crossref_doi_with_pattern(article)
+
+        expected = """
+        <p>
+         Sanchez M. M.,
+        (2020) “Test article: a test article”,
+        <i>Janeway JS</i> 1, p.2-4.
+        doi: <a href="https://doi.org/{0}">https://doi.org/{0}</a></p>
+        """.format(article.get_doi())
+        self.assertHTMLEqual(expected, article.how_to_cite)
+
     def test_custom_article_how_to_cite(self):
         issue = journal_models.Issue.objects.create(journal=self.journal_one)
         journal_models.Issue


### PR DESCRIPTION
When the issue volume/number is set to zero, avoid displaying it.

It doesn't make the fields optional yet as per #2337, but I'm not sure defaulting to zero when a value is not provided makes a lot of sense. what do you think @ajrbyers 