### PR TITLE
Fix wrong offset on footnote relative links

### DIFF
--- a/src/themes/material/assets/mat.css
+++ b/src/themes/material/assets/mat.css
@@ -561,7 +561,7 @@ nav, nav .nav-wrapper i, nav a.button-collapse, nav a.button-collapse i {
 }
 
 /* Allow the use of default <li> */
-.default-li ul, ol {
+.default-li ul {
     display: block;
     list-style: disc outside none;
     margin: 1em 0;
@@ -569,6 +569,9 @@ nav, nav .nav-wrapper i, nav a.button-collapse, nav a.button-collapse i {
 }
 .default-li ol {
     list-style-type: decimal;
+    display: block;
+    margin: 1em 0;
+    padding: 0 0 0 40px;
 }
 .default-li li {
     display: list-item;

--- a/src/themes/material/assets/material.js
+++ b/src/themes/material/assets/material.js
@@ -22,3 +22,17 @@ $( document ).ready(function(){
     figure_downloads();
     table_downloads();
 })
+
+var $root = $('html, body');
+
+$('a[href^="#"]').click(function() {
+    var href = $.attr(this, 'href');
+
+    $root.animate({
+        scrollTop: $(href).offset().top
+    }, 500, function () {
+        window.location.hash = href;
+    });
+
+    return false;
+});

--- a/src/transform/xsl/default.xsl
+++ b/src/transform/xsl/default.xsl
@@ -439,7 +439,9 @@
         <xsl:variable name="fn-number">
             <xsl:number level="any" count="fn[not(ancestor::front)]" from="article | sub-article | response"/>
         </xsl:variable>
-        <xsl:apply-templates/> [<span class="footnotemarker" id="fn{$fn-number}"></span><span class="footnotemarker" id="n{$fn-number}"><a href="#nm{$fn-number}"><sup>^</sup></a></span>]
+        <span class="footnotemarker" id="fn{$fn-number}"></span>
+        <xsl:apply-templates/>
+        [<span class="footnotemarker" id="n{$fn-number}"><a href="#nm{$fn-number}"><sup>^</sup></a></span>]
     </xsl:template>
 
     <xsl:template match="author-notes/fn[@fn-type='con']/p">


### PR DESCRIPTION
Closes #2399 
Bonus:
 - Smooth scrolling on relative urls for material
 - Fix article `<ol>` tags rendering as `<li>`