### PR TITLE
Fix: render orcid when article images are disabled

### DIFF
--- a/src/themes/OLH/templates/journal/article.html
+++ b/src/themes/OLH/templates/journal/article.html
@@ -27,7 +27,7 @@
                         {% for author in article.frozen_authors.all %}
                         {{ author.full_name }}
                             {% if author.orcid %}<a href="https://orcid.org/{{ author.orcid }}" class=""><img src="https://orcid.org/sites/default/files/images/orcid_16x16.png" alt="orcid logo"></a>{% endif %}
-                            {% if author.institution %} ({{ author.institution }}){% endif %}
+                            {% if author.institution and author.institution != " " %} ({{ author.institution }}){% endif %}
                         {% if author.is_correspondence_author %}<a itemprop="email" href="mailto:{{ author.email }}" class="fa fa-envelope email-link"></a>{% endif %}
                         {% if not forloop.last %}, {% endif %}
                         {% endfor %}
@@ -65,7 +65,7 @@
                                             {% if author.orcid %}<a href="https://orcid.org/{{ author.orcid }}" class="">
                                                 <img src="https://orcid.org/sites/default/files/images/orcid_16x16.png" alt="orcid logo">
                                             </a>{% endif %}
-                                            {% if author.institution %}
+                                            {% if author.institution and author.institution != " " %}
                                             <span itemprop="worksFor" itemscope
                                                   itemtype="http://schema.org/CollegeOrUniversity"><span
                                                     itemprop="name">({{ author.institution }})</span></span>{% endif %}

--- a/src/themes/OLH/templates/journal/article.html
+++ b/src/themes/OLH/templates/journal/article.html
@@ -247,7 +247,15 @@
                                     <h4>{% trans "Authors" %}</h4>
                                     <ul>
                                         {% for author in article.frozen_authors.all %}
-                                            <li>{{ author.full_name }} ({{ author.affiliation }})</li>
+                                            <li>
+                                                {{ author.full_name }}
+                                                {% if author.orcid %}
+                                                <a href="https://orcid.org/{{ author.orcid }}" class="">
+                                                    <img src="https://orcid.org/sites/default/files/images/orcid_16x16.png" alt="orcid logo">
+                                                </a>
+                                                {% endif %}
+                                                {% if author.institution and author.institution != " " %}({{ author.affiliation }}) {% endif %}
+                                            </li>
                                         {% endfor %}
                                     </ul>
                                 </div>

--- a/src/themes/clean/templates/journal/article.html
+++ b/src/themes/clean/templates/journal/article.html
@@ -47,7 +47,7 @@
                                     {% if author.orcid %}<a href="https://orcid.org/{{ author.orcid }}">
                                         <span style="background: url(https://orcid.org/sites/default/files/images/orcid_16x16.png) no-repeat;" class="orcid-img"></span>
                                     </a>{% endif %}
-                                    {% if author.institution %}
+                                    {% if author.institution and author.institution != " " %}
                                         <span itemprop="worksFor" itemscope
                                               itemtype="http://schema.org/CollegeOrUniversity"><span
                                                 itemprop="name">({{ author.institution }})</span></span>{% endif %}
@@ -116,6 +116,11 @@
                             {% if author.orcid %}<a href="https://orcid.org/{{ author.orcid }}" class="">
                                 <img src="https://orcid.org/sites/default/files/images/orcid_16x16.png" alt="orcid logo">
                             </a>{% endif %}
+                            {% if author.institution and author.institution != " " %}
+                                <span itemprop="worksFor" itemscope
+                                        itemtype="http://schema.org/CollegeOrUniversity"><span
+                                        itemprop="name">({{ author.institution }})</span></span>
+                            {% endif %}
                         </li>
                     {% endfor %}
                      </ul>

--- a/src/themes/material/templates/journal/article.html
+++ b/src/themes/material/templates/journal/article.html
@@ -222,7 +222,7 @@
                             {{ author.full_name }}
                             {% if author.orcid %}<a href="https://orcid.org/{{ author.orcid }}"
                                 class=""><img src="https://orcid.org/sites/default/files/images/orcid_16x16.png" alt="orcid logo"></a>{% endif %}
-                            {% if author.institution %}
+                            {% if author.institution  and author.institution != " " %}
                                 <span itemprop="worksFor" itemscope itemtype="http://schema.org/CollegeOrUniversity">
                                     <span itemprop="name">({{ author.institution }})
                             {% endif %}


### PR DESCRIPTION
Also, avoid rendering isntitution when its value is `" "`