### PR TITLE
Drop Assign with Defaults button

### DIFF
--- a/src/review/views.py
+++ b/src/review/views.py
@@ -1037,33 +1037,7 @@ def add_review_assignment(request, article_id):
 
     if request.POST:
 
-        if 'quick_assign' in request.POST:
-            logic.quick_assign(request, article)
-            return redirect(reverse('review_in_review', kwargs={'article_id': article_id}))
-        elif 'add_and_assign' in request.POST:
-            # first check whether the user exists
-            new_reviewer_form = core_forms.QuickUserForm(request.POST)
-
-            try:
-                user = core_models.Account.objects.get(email=new_reviewer_form.data['email'])
-                user.add_account_role('reviewer', request.journal)
-            except core_models.Account.DoesNotExist:
-                user = None
-
-            if user:
-                logic.quick_assign(request, article, reviewer_user=user)
-                return redirect(reverse('review_in_review', kwargs={'article_id': article_id}))
-
-            valid = new_reviewer_form.is_valid()
-
-            if valid:
-                acc = logic.handle_reviewer_form(request, new_reviewer_form)
-                logic.quick_assign(request, article, reviewer_user=acc)
-                return redirect(reverse('review_in_review', kwargs={'article_id': article_id}))
-            else:
-                modal = 'reviewer'
-
-        elif 'assign' in request.POST:
+        if 'assign' in request.POST:
             # first check whether the user exists
             new_reviewer_form = core_forms.QuickUserForm(request.POST)
 

--- a/src/templates/admin/review/add_review_assignment.html
+++ b/src/templates/admin/review/add_review_assignment.html
@@ -26,7 +26,7 @@
 
                     <p>
                         {% blocktrans %}
-                        You can select a reviewer using the radio buttons in the first column and complete the section under "Set Options" or if you want to send a review request using defaults select "Assign with Defaults". <strong>Warning: use of "Instant Assign with Defaults"</strong> you will not have the change to edit the outgoing email message.
+                        You can select a reviewer using the radio buttons in the first column and complete the section under "Set Options".
                         If you cannot find the reviewer you want in this list you can use "Enroll Existing User" to search the database and give users the Reviewer role, or "Add New Reviewer" to create a new account for a reviewer (this process is silent, they will not receive an account creation email).
                         {% endblocktrans %}
                     </p>
@@ -40,7 +40,6 @@
                             <th width="30%">Interests</th>
                             <th>Average Score</th>
                             <th>Last Review Completed</th>
-                            <th width="15%">Quick Assign</th>
                         </tr>
                         </thead>
 
@@ -55,7 +54,6 @@
                                     {% if not forloop.last %}, {% endif %}{% endfor %}</td>
                                 <td>{{ reviewer.rating_average|default_if_none:"" }}</td>
                                 <td>{{ reviewer.reviewer.all.0.date_complete }}</td>
-                                <td><button type="submit" name="quick_assign" value="{{ reviewer.id }}" class="small success button">Instant Assign with Defaults</button></td>
                             </tr>
                         {% endfor %}
                         {% for reviewer in reviewers %}
@@ -68,7 +66,6 @@
                                 <td>{% for interest in reviewer.interest.all %}{{ interest.name }}{% if not forloop.last %}, {% endif %}{% endfor %}</td>
                                 <td>{{ reviewer.rating_average|default_if_none:"" }}</td>
                                 <td>{{ reviewer.reviewer.all.0.date_complete }}</td>
-                                <td><button type="submit" name="quick_assign" value="{{ reviewer.id }}" class="small success button">Instant Assign with Defaults</button></td>
                             </tr>
                             {% endif %}
                         {% empty %}
@@ -122,7 +119,6 @@
                         {% csrf_token %}
                         {{ new_reviewer_form|foundation }}
                         <button type="submit" class="button success" name="assign" id="assign">Add Reviewer</button>
-                        <button type="submit" class="button success" name="add_and_assign" id="assign">Add Reviewer and Assign with Defaults</button>
                     </form>
                 </div>
             </div>


### PR DESCRIPTION
Removes the Assign with Defaults button as Editors seem unable to resist clicking it without checking what it does in the documentation.