### PR TITLE
#2435 rebalanced headers.

### DIFF
--- a/src/static/OLH/css/app.css
+++ b/src/static/OLH/css/app.css
@@ -5280,8 +5280,7 @@ button.list-group-item-danger.active:focus {
   text-decoration-thickness: 3px; }
 
 .pad-left-15 {
-  padding-left: 15px;
-}
+  padding-left: 15px; }
 
 .language-menu {
   padding-left: 15px; }

--- a/src/themes/clean/templates/cms/page.html
+++ b/src/themes/clean/templates/cms/page.html
@@ -9,6 +9,7 @@
     <section id="content">
         <div class="row">
             <div class="col-md-12">
+                <h1>{{ page.display_name }}</h1>
                 <hr/>
                 {{ page.content|safe }}
             </div>

--- a/src/themes/material/assets/mat.css
+++ b/src/themes/material/assets/mat.css
@@ -583,7 +583,7 @@ nav, nav .nav-wrapper i, nav a.button-collapse, nav a.button-collapse i {
 }
 
 .default-li ul > li {
-    list-style-type: disc;
+    list-style-type: revert;
 }
 
 .language-select {

--- a/src/themes/material/assets/mat.css
+++ b/src/themes/material/assets/mat.css
@@ -564,13 +564,11 @@ nav, nav .nav-wrapper i, nav a.button-collapse, nav a.button-collapse i {
 .default-li ul {
     display: block;
     list-style: disc outside none;
-    margin: 1em 0;
     padding: 0 0 0 40px;
 }
 .default-li ol {
     list-style-type: decimal;
     display: block;
-    margin: 1em 0;
     padding: 0 0 0 40px;
 }
 .default-li li {

--- a/src/themes/material/assets/mat.css
+++ b/src/themes/material/assets/mat.css
@@ -584,6 +584,10 @@ nav, nav .nav-wrapper i, nav a.button-collapse, nav a.button-collapse i {
     list-style-type: lower-latin;
 }
 
+.default-li ul > li {
+    list-style-type: disc;
+}
+
 .language-select {
     color: #616161;
 }

--- a/src/themes/material/assets/mat.css
+++ b/src/themes/material/assets/mat.css
@@ -363,7 +363,7 @@ a:hover .article-title {
 }
 
 h1 {
-    font-size: 2.8rem;
+    font-size: 2.5rem;
     font-weight: 300;
     margin: 1.68rem 0 1.68rem 0;
 }
@@ -374,11 +374,11 @@ h2 {
 }
 
 h3 {
-    font-size: 1.6rem;
+    font-size: 2.0rem;
 }
 
 h4 {
-    font-size: 1.6rem;
+    font-size: 1.8rem;
     font-weight: 300;
 }
 

--- a/src/themes/material/templates/cms/page.html
+++ b/src/themes/material/templates/cms/page.html
@@ -10,7 +10,7 @@
 		<div class="col s12">
             <div class="card">
                 <div class="card-content">
-                  <span class="card-title">{{ page.display_name }}</span>
+                  <h1 class="no-bottom-margin">{{ page.display_name }}</h1>
                   <div class="divider spacer"></div>
                     <div id="cms" class="default-li">{{ page.content|safe }}</<div>
                 </div>


### PR DESCRIPTION
Closes #2435 

Updated material to use a H1 for its cms/page.html. Tweaked some CSS to make the balance better. Screenshots of an example page for each theme below.

![image](https://user-images.githubusercontent.com/8321378/133584152-ac73e360-4716-4f5b-aecd-738e0ec871dc.png)
![image](https://user-images.githubusercontent.com/8321378/133584187-dba812e1-b977-432d-9204-8159b44f3f3b.png)
![image](https://user-images.githubusercontent.com/8321378/133584202-9cbda2f8-fa1f-4b56-8d0a-4ab5a8403ad5.png)
