### PR TITLE
Add DOI and Preprint DOI to Author_Article template

### DIFF
--- a/src/templates/admin/repository/author_article.html
+++ b/src/templates/admin/repository/author_article.html
@@ -43,6 +43,14 @@
                             <td colspan="2"><small>{{ preprint.abstract }}</small></td>
                         </tr>
                         <tr>
+                            <th colspan="2">Preprint DOI</th>
+                            <th>Published DOI</th>
+                        </tr>
+                        <tr>
+                            <td colspan="2">{% if preprint.preprint_doi %}<a target="_blank" href="{{ preprint.preprint_doi }}">{{ preprint.preprint_doi }}{% else %}pending{% endif %}</a></td>
+                            <td>{% if preprint.doi %}<a target="_blank" href="{{ preprint.doi }}">{{ preprint.doi }}{% else %}No Published DOI{% endif %}</a></td>
+                        </tr>
+                        <tr>
                             <th colspan="2">
                                 Subjects
                             </th>


### PR DESCRIPTION
The Author_article template currently does not mention DOIs at all, #2188 implies that it should. This commit ports the new logic from the author.html template to author_article.html.