### PR TITLE
check is_published for View Article moderator page (preprint-merge)

### DIFF
--- a/src/templates/admin/repository/article.html
+++ b/src/templates/admin/repository/article.html
@@ -19,7 +19,9 @@
         <div class="box">
             <div class="title-area">
                 <h2>Metadata</h2>
-                <a class="button" href="{{ preprint.url }}">View Live Article</a>
+                {% if preprint.is_published %}
+                  <a class="button" href="{{ preprint.url }}">View Live Article</a>
+                {% endif %}
             </div>
             <div class="content">
                 <table class="scroll small">


### PR DESCRIPTION
11:47 AM alainna ah, I've found an unexpected issue with the "View live article" link on the dashboards - link will display even if the preprint hasn't yet been published, but only on the moderator's side.