### PR TITLE
Tweak the display of the preprint_doi field in repository author_article template

### DIFF
--- a/src/templates/admin/repository/author_article.html
+++ b/src/templates/admin/repository/author_article.html
@@ -47,7 +47,7 @@
                             <th>Published DOI</th>
                         </tr>
                         <tr>
-                            <td colspan="2">{% if preprint.preprint_doi %}<a target="_blank" href="{{ preprint.preprint_doi }}">{{ preprint.preprint_doi }}{% else %}pending{% endif %}</a></td>
+                            <td>{% if preprint.preprint_doi %}<a target="_blank" href="{{ preprint.preprint_doi }}">{{ preprint.preprint_doi }}{% else %}pending{% endif %}</a></td>
                             <td>{% if preprint.doi %}<a target="_blank" href="{{ preprint.doi }}">{{ preprint.doi }}{% else %}No Published DOI{% endif %}</a></td>
                         </tr>
                         <tr>


### PR DESCRIPTION
* the table rows in the author_article template only have two columns, use those, don't try to span them