### PR TITLE
Move call for ON_WORKFLOW_ELEMENT_COMPLETE to follow article.save

### DIFF
--- a/src/submission/views.py
+++ b/src/submission/views.py
@@ -518,6 +518,14 @@ def submit_review(request, article_id):
         article.snapshot_authors(article)
         article.save()
 
+        event_logic.Events.raise_event(
+            event_logic.Events.ON_WORKFLOW_ELEMENT_COMPLETE,
+            **{'handshake_url': 'submit_review',
+               'request': request,
+               'article': article,
+               'switch_stage': False}
+        )
+
         messages.add_message(
             request,
             messages.SUCCESS,
@@ -532,14 +540,6 @@ def submit_review(request, article_id):
             event_logic.Events.ON_ARTICLE_SUBMITTED,
             task_object=article,
             **kwargs
-        )
-
-        event_logic.Events.raise_event(
-            event_logic.Events.ON_WORKFLOW_ELEMENT_COMPLETE,
-            **{'handshake_url': 'submit_review',
-               'request': request,
-               'article': article,
-               'switch_stage': False}
         )
 
         return redirect(reverse('core_dashboard'))


### PR DESCRIPTION
In submit_review, raise the event for ON_WORKFLOW_ELEMENT_COMPLETE to
immediately after the article.save, to avoid a possible race condition
which might cause an article to be in the review queue but without an
entry in the workflowlog.

Fixes #2515