### PR TITLE
#2620 added a --force_update flag to load_default_settings

### DIFF
--- a/src/utils/management/commands/load_default_settings.py
+++ b/src/utils/management/commands/load_default_settings.py
@@ -10,7 +10,17 @@ class Command(BaseCommand):
     help = ("Loads the default values for Janeway settings. "
         "If ran multiple times, it will only load missing entries")
 
+    def add_arguments(self, parser):
+        parser.add_argument('--force_update',
+                            action='store_true',
+                            dest='force_update',
+                            default=False,
+                            help='Resets all of the default settings from the value in JSON.')
+
     def handle(self, *args, **options):
 
         translation.activate('en')
-        install.update_settings(management_command=True)
+        install.update_settings(
+            management_command=True,
+            overwrite_with_defaults=options.get('force_update', False),
+        )


### PR DESCRIPTION
- Can be used thus: `python3 src/manage.py load_default_settings --force_update`
- Closes #2620 