### PR TITLE
#2680: XSLT fix fn links colliding with tables

### DIFF
--- a/src/transform/xsl/default.xsl
+++ b/src/transform/xsl/default.xsl
@@ -437,7 +437,7 @@
 
     <xsl:template match="fn-group/fn/p">
         <xsl:variable name="fn-number">
-            <xsl:number level="any" count="fn[not(ancestor::front)]" from="article | sub-article | response"/>
+            <xsl:number level="any" count="fn[not(ancestor::front | ancestor::table-wrap-foot)]" from="article | sub-article | response"/>
         </xsl:variable>
         <span class="footnotemarker" id="fn{$fn-number}"></span>
         <xsl:apply-templates/>


### PR DESCRIPTION
Fixes an issue where the footnote number calculator was considering table footnotes which led the links in the footnotes to not match to be offset by the total number of table footnotes available in the body.

closes #2680 