### PR TITLE
Ignore empty p and br tags from empty summernote fields

### DIFF
--- a/src/core/janeway_global_settings.py
+++ b/src/core/janeway_global_settings.py
@@ -291,6 +291,8 @@ SUMMERNOTE_CONFIG = {
     'attachment_filesize_limit': 2056 * 2056,
 }
 
+SUMMERNOTE_SENTINEL = '<p><br></p>'
+
 # 1.9 appears confused about where null and blank are required for many to
 # many fields, so we're hiding these warning from the console
 SILENCED_SYSTEM_CHECKS = (

--- a/src/core/models.py
+++ b/src/core/models.py
@@ -32,6 +32,7 @@ from copyediting import models as copyediting_models
 from submission import models as submission_models
 from utils.logger import get_logger
 from utils import logic as utils_logic
+from core.janeway_global_settings import SUMMERNOTE_SENTINEL
 
 fs = JanewayFileSystemStorage()
 logger = get_logger(__name__)
@@ -667,6 +668,11 @@ class SettingValue(models.Model):
                 return 0
         elif self.setting.types == 'json' and self.value:
             return json.loads(self.value)
+        elif self.setting.types == 'rich-text' and self.value:
+            if self.value == SUMMERNOTE_SENTINEL:
+                return ''
+            else:
+                return self.value
         else:
             return self.value
 


### PR DESCRIPTION
What do you think of this as a fix for #2713 -- is it the right way to go about it?