### PR TITLE
Makes profile image responsive on material

### DIFF
--- a/src/themes/material/templates/core/accounts/public_profile.html
+++ b/src/themes/material/templates/core/accounts/public_profile.html
@@ -8,7 +8,7 @@
 	<section id="content">
 		<div class="row">
             <div class="col m3">
-                <img class="thumbnail editorial-image" src="{% if user.profile_image %}{{ user.profile_image.url }}{% else %}{% static "common/img/icons/users.png" %}{% endif %}" alt="Profile photo.">
+                <img class="responsive-img thumbnail editorial-image" src="{% if user.profile_image %}{{ user.profile_image.url }}{% else %}{% static "common/img/icons/users.png" %}{% endif %}" alt="Profile photo of {{ user.full_name }}">
                 <h3>{{ user.full_name }}</h3>
                 <p><strong>{% trans "Roles" %}: </strong><br>{% for role in roles %}{{ role.role.name }}{% if not forloop.last %}, {% endif %}{% endfor %}</p>
                 <p><strong>{% trans "Affiliation" %}: </strong><br>{{ user.affiliation }}</p>


### PR DESCRIPTION
Without this, the profile images can overflow beyond their column, sometimes spanning across the entire profile page