### PR TITLE
OLH: Changes citation picker to a dropdown on mobile

### DIFF
--- a/src/themes/OLH/templates/journal/article.html
+++ b/src/themes/OLH/templates/journal/article.html
@@ -118,7 +118,7 @@
                         </div>
                         <div class="large-6 columns">
                             <ul class="menu vertical medium-horizontal align-right"
-                                data-responsive-menu="drilldown medium-dropdown">
+                                data-responsive-menu="dropdown">
                                 {% hook 'article_buttons' %}
                                 <li><a href="{{ article.local_url }}print/"><i class="fa fa-print">&nbsp;</i></a></li>
                                 <li><a href="javascript:resizeText(-1)">A-</a></li>
@@ -127,7 +127,7 @@
                                 <li><a href="#" id="dyslexia-mode">{% trans "Dyslexia" %}</a></li>
                                 <li>
                                     <a><i class="fa fa-comments"></i></a>
-                                    <ul class="menu">
+                                    <ul class="menu vertical">
                                         <li><a data-open="HarvardModal">{% trans "View" %} Harvard Citation Style</a></li>
                                         <li><a data-open="VancouverModal">{% trans "View" %} Vancouver Citation Style</a></li>
                                         <li><a data-open="APAModal">{% trans "View" %} APA Citation Style</a></li>


### PR DESCRIPTION
The drilldown menu for citations on small screens didn't work properly, because there isn't enough space to render all the submenu options.

I've changed it to a regular dropdown menu instead, as with the medium/large screens.