### PR TITLE
Allows Competing Interests to be edited from the Edit Metadata pane

### DIFF
--- a/src/submission/forms.py
+++ b/src/submission/forms.py
@@ -72,7 +72,7 @@ class ArticleInfo(KeywordModelForm, JanewayTranslationModelForm):
                   'language', 'section', 'license', 'primary_issue',
                   'article_number', 'is_remote', 'remote_url', 'peer_reviewed',
                   'first_page', 'last_page', 'page_numbers', 'total_pages',
-                  'custom_how_to_cite',)
+                  'competing_interests', 'custom_how_to_cite',)
         widgets = {
             'title': forms.TextInput(attrs={'placeholder': _('Title')}),
             'subtitle': forms.TextInput(attrs={'placeholder': _('Subtitle')}),

--- a/src/submission/forms.py
+++ b/src/submission/forms.py
@@ -72,7 +72,7 @@ class ArticleInfo(KeywordModelForm, JanewayTranslationModelForm):
                   'language', 'section', 'license', 'primary_issue',
                   'article_number', 'is_remote', 'remote_url', 'peer_reviewed',
                   'first_page', 'last_page', 'page_numbers', 'total_pages',
-                  'competing_interests', 'custom_how_to_cite',)
+                  'custom_how_to_cite',)
         widgets = {
             'title': forms.TextInput(attrs={'placeholder': _('Title')}),
             'subtitle': forms.TextInput(attrs={'placeholder': _('Subtitle')}),

--- a/src/templates/admin/elements/metadata.html
+++ b/src/templates/admin/elements/metadata.html
@@ -79,6 +79,19 @@
                 {% if article.competing_interests %}{{ article.competing_interests }}{% else %}No CI{% endif %}</td>
         </tr>
     {% endif %}
+    <tr>
+        <th colspan="4">Peer Reviewed?</th>
+    </tr>
+    <tr>
+        <td colspan="4">
+            This article has {{ article.completed_reviews_with_decision.count }} completed reviews.
+        </td>
+    </tr>
+    <tr>
+        <td colspan="4">
+            {% if article.peer_reviewed %}This article has been marked as having been reviewed in the metadata{% else %}This article has not been marked as having been reviewed. If this article has completed reviews above this may be incorrect.{% endif %}
+        </td>
+    </tr>
     {% for field_answer in article.fieldanswer_set.all %}
         <tr>
             <th colspan="4">{{ field_answer.field.name }}</th>

--- a/src/templates/admin/elements/metadata.html
+++ b/src/templates/admin/elements/metadata.html
@@ -92,6 +92,18 @@
             {% if article.peer_reviewed %}This article has been marked as having been reviewed in the metadata{% else %}This article has not been marked as having been reviewed. If this article has completed reviews above this may be incorrect.{% endif %}
         </td>
     </tr>
+    <tr>
+        <th>First Page</th>
+        <th>Last Page</th>
+        <th>Page Numbers</th>
+        <th>Total Pages</th>
+    </tr>
+    <tr>
+        <td>{{ article.first_page }}</td>
+        <td>{{ article.last_page }}</td>
+        <td>{{ article.page_numbers }}</td>
+        <td>{{ article.total_pages }}</td>
+    </tr>
     {% for field_answer in article.fieldanswer_set.all %}
         <tr>
             <th colspan="4">{{ field_answer.field.name }}</th>

--- a/src/templates/admin/submission/edit/metadata.html
+++ b/src/templates/admin/submission/edit/metadata.html
@@ -88,8 +88,13 @@
                         <div class="large-3 columns end">
                             {{ info_form.primary_issue|foundation }}
                         </div>
-                     </div>
-                    <div class="large-12 columns">
+                    </div>
+                    {% if journal_settings.general.submission_competing_interests %}
+                        <div class="large-10 columns">
+                            {{ info_form.competing_interests|foundation }}
+                        </div>
+                    {% endif %}
+                    <div class="large-10 columns">
                         {{ info_form.custom_how_to_cite|foundation }}
                     </div>
                     <div class="large-12 columns">

--- a/src/templates/admin/submission/edit/metadata.html
+++ b/src/templates/admin/submission/edit/metadata.html
@@ -88,8 +88,11 @@
                         <div class="large-3 columns end">
                             {{ info_form.primary_issue|foundation }}
                         </div>
-                     </div>
-                    <div class="large-12 columns">
+                    </div>
+                    <div class="large-10 columns end">
+                        {{ info_form.competing_interests|foundation }}
+                    </div>
+                    <div class="large-10 columns">
                         {{ info_form.custom_how_to_cite|foundation }}
                     </div>
                     <div class="large-12 columns">

--- a/src/templates/admin/submission/edit/metadata.html
+++ b/src/templates/admin/submission/edit/metadata.html
@@ -88,11 +88,8 @@
                         <div class="large-3 columns end">
                             {{ info_form.primary_issue|foundation }}
                         </div>
-                    </div>
-                    <div class="large-10 columns end">
-                        {{ info_form.competing_interests|foundation }}
-                    </div>
-                    <div class="large-10 columns">
+                     </div>
+                    <div class="large-12 columns">
                         {{ info_form.custom_how_to_cite|foundation }}
                     </div>
                     <div class="large-12 columns">


### PR DESCRIPTION
Allows Competing Interests to be edited from the Edit Metadata pane. Also tidies up the View Metadata and Edit Metadata pages to correspond to each other more closely with peer review status and page numbers. Fixes #2735.