### PR TITLE
Prevent empty keywords from being saved when using KeywordModelForm

### DIFF
--- a/src/utils/forms.py
+++ b/src/utils/forms.py
@@ -54,9 +54,10 @@ class KeywordModelForm(ModelForm):
         instance = super().save(commit=commit, *args, **kwargs)
         instance.keywords.clear()
         posted_keywords = self.cleaned_data.get(
-            'keywords', '').split(',')
+            'keywords', '')
         if posted_keywords:
-            for i, keyword in enumerate(posted_keywords):
+            keyword_list = posted_keywords.split(",")
+            for i, keyword in enumerate(keyword_list):
                 obj, _ = submission_models.Keyword.objects.get_or_create(
                     word=keyword)
                 instance.keywords.add(obj)

--- a/src/utils/forms.py
+++ b/src/utils/forms.py
@@ -51,10 +51,12 @@ class KeywordModelForm(ModelForm):
             field.initial = ",".join(current_keywords)
 
     def save(self, commit=True, *args, **kwargs):
+        posted_keywords = self.cleaned_data.get( 'keywords', '')
+        self.data["keywords"] = self.cleaned_data["keywords"] = ""
+
         instance = super().save(commit=commit, *args, **kwargs)
         instance.keywords.clear()
-        posted_keywords = self.cleaned_data.get(
-            'keywords', '')
+
         if posted_keywords:
             keyword_list = posted_keywords.split(",")
             for i, keyword in enumerate(keyword_list):
@@ -63,6 +65,7 @@ class KeywordModelForm(ModelForm):
                 instance.keywords.add(obj)
         if commit:
             instance.save()
+        self.data["keywords"] = self.cleaned_data["keywords"] = posted_keywords
         return instance
 
 

--- a/src/utils/tests.py
+++ b/src/utils/tests.py
@@ -158,13 +158,14 @@ class TestForms(TestCase):
             class Meta:
                 update_xsl_files()
                 model = journal_models.Journal
-                fields = ('keywords', )
+                fields = ("keywords",)
                 exclude = tuple()
         expected = "Expected Keyword"
         data = {
-            "keywords": "Keyword, another one, and another one, %s" % expected
+            "keywords": "Keyword, another one, and another one,%s" % expected
         }
         form = KeywordTestForm(data, instance=self.journal)
+        form.is_valid()
         journal = form.save()
         self.assertTrue(journal.keywords.filter(word=expected).exists())
 
@@ -180,6 +181,7 @@ class TestForms(TestCase):
 
         data = {"keywords": ""}
         form = KeywordTestForm(data, instance=self.journal)
+        form.is_valid()
         journal = form.save()
         self.assertFalse(journal.keywords.exists())
 

--- a/src/utils/tests.py
+++ b/src/utils/tests.py
@@ -9,7 +9,7 @@ from django.core import mail
 from django.contrib.contenttypes.models import ContentType
 
 from utils import merge_settings, transactional_emails
-from utils.forms import FakeModelForm
+from utils.forms import FakeModelForm, KeywordModelForm
 from utils.testing import helpers
 from journal import models as journal_models
 from review import models as review_models
@@ -132,11 +132,18 @@ class TestMergeSettings(TestCase):
 
 class TestForms(TestCase):
 
+    @classmethod
+    def setUpTestData(cls):
+        helpers.create_press()
+        helpers.create_journals()
+
+        update_xsl_files()
+        cls.journal = journal_models.Journal.objects.get(code="TST", domain="testserver")
+
     def test_fake_model_form(self):
 
         class FakeTestForm(FakeModelForm):
             class Meta:
-                update_xsl_files()
                 model = journal_models.Journal
                 exclude = tuple()
 
@@ -144,4 +151,35 @@ class TestForms(TestCase):
 
         with self.assertRaises(NotImplementedError):
             form.save()
+
+    def test_keyword_form_empty_string(self):
+
+        class KeywordTestForm(KeywordModelForm):
+            class Meta:
+                update_xsl_files()
+                model = journal_models.Journal
+                fields = ('keywords', )
+                exclude = tuple()
+        expected = "Expected Keyword"
+        data = {
+            "keywords": "Keyword, another one, and another one, %s" % expected
+        }
+        form = KeywordTestForm(data, instance=self.journal)
+        journal = form.save()
+        self.assertTrue(journal.keywords.filter(word=expected).exists())
+
+
+    def test_keyword_form_empty_string(self):
+
+        class KeywordTestForm(KeywordModelForm):
+            class Meta:
+                update_xsl_files()
+                model = journal_models.Journal
+                fields = ('keywords', )
+                exclude = tuple()
+
+        data = {"keywords": ""}
+        form = KeywordTestForm(data, instance=self.journal)
+        journal = form.save()
+        self.assertFalse(journal.keywords.exists())
 

--- a/src/utils/tests.py
+++ b/src/utils/tests.py
@@ -152,7 +152,7 @@ class TestForms(TestCase):
         with self.assertRaises(NotImplementedError):
             form.save()
 
-    def test_keyword_form_empty_string(self):
+    def test_keyword_form(self):
 
         class KeywordTestForm(KeywordModelForm):
             class Meta:


### PR DESCRIPTION
closes #2701 