### PR TITLE
wrong indentation and typo

### DIFF
--- a/src/utils/management/commands/install_janeway.py
+++ b/src/utils/management/commands/install_janeway.py
@@ -82,7 +82,7 @@ class Command(BaseCommand):
                 journal.code = "journal"
             else:
                 journal.code = input('Journal #1 code: ')
-                    journal.domain = input('Journal #1 domain: (Optional)')
+                journal.domain = input('Journal #1 domain (Optional): ')
             journal.save()
             print("Installing issue types fixtures... ", end="")
             update_issue_types(journal, management_command=False)
@@ -151,4 +151,3 @@ JANEWAY_ASCII = """
 ===   =    =====   ,   ==   ====   ===   ============   ====        ====  ===       ====   ============       =====     =====    ====         ===     ===
 =================  ,   ==   ==== =====     ========    ====          ==== ===         ==   ============        ===       ===    ====          ====    ===
 """
-


### PR DESCRIPTION
During install, I had `make install` failing on `janeway-web` with an error such as:
```python
...
  File "/vol/janeway/src/utils/management/commands/install_janeway.py", line 85
    journal.domain = input('Journal #1 domain: (Optional)')
    ^
IndentationError: unexpected indent
```
