### PR TITLE
OAI resumptionToken now considers querystring params

### DIFF
--- a/src/api/oai/views.py
+++ b/src/api/oai/views.py
@@ -48,6 +48,8 @@ class OAIListRecords(OAIPagedModelView):
         queryset = submission_models.Article.objects.filter(
             date_published__isnull=False,
         )
+        if self.request.journal:
+            queryset = queryset.filter(journal=self.request.journal)
         set_filter = self.request.GET.get('set')
         issue_type_list = [issue_type.code for issue_type in journal_models.IssueType.objects.all()]
 

--- a/src/utils/http/__init__.py
+++ b/src/utils/http/__init__.py
@@ -1,0 +1,16 @@
+from contextlib import ContextDecorator
+
+
+class allow_mutating_GET(ContextDecorator):
+    """CAUTION: Think twice before considering using this"""
+
+    def __init__(self, request):
+        self.request = request
+        self._mutable = self.request.GET._mutable
+
+    def __enter__(self):
+        self.request.GET._mutable = True
+        return self
+
+    def __exit__(self, *exc):
+        self.request.GET._mutable = self._mutable


### PR DESCRIPTION
closes #2768 
Also adds a journal context filter lost with 251e4d1