### PR TITLE
Fixes Keywords not saving due to cleaned data not being mutable

### DIFF
--- a/src/utils/forms.py
+++ b/src/utils/forms.py
@@ -52,7 +52,6 @@ class KeywordModelForm(ModelForm):
 
     def save(self, commit=True, *args, **kwargs):
         posted_keywords = self.cleaned_data.get( 'keywords', '')
-        self.data["keywords"] = self.cleaned_data["keywords"] = ""
 
         instance = super().save(commit=commit, *args, **kwargs)
         instance.keywords.clear()
@@ -65,7 +64,6 @@ class KeywordModelForm(ModelForm):
                 instance.keywords.add(obj)
         if commit:
             instance.save()
-        self.data["keywords"] = self.cleaned_data["keywords"] = posted_keywords
         return instance
 
 

--- a/src/utils/tests.py
+++ b/src/utils/tests.py
@@ -158,14 +158,16 @@ class TestForms(TestCase):
             class Meta:
                 update_xsl_files()
                 model = journal_models.Journal
-                fields = ("keywords",)
+                fields = ("code",)
                 exclude = tuple()
         expected = "Expected Keyword"
         data = {
-            "keywords": "Keyword, another one, and another one,%s" % expected
+            "keywords": "Keyword, another one, and another one,%s" % expected,
+            "code": self.journal.code,
         }
         form = KeywordTestForm(data, instance=self.journal)
-        form.is_valid()
+        valid = form.is_valid()
+
         journal = form.save()
         self.assertTrue(journal.keywords.filter(word=expected).exists())
 


### PR DESCRIPTION
Resolves a bug introduced in 0c38a3fd59725429cba34458636cae87322ea4df due to a pointless overprotective feature