### PR TITLE
db backend names typos

### DIFF
--- a/src/core/example_settings.py
+++ b/src/core/example_settings.py
@@ -31,8 +31,8 @@ DATABASES = {
     'default': {
         #Example ENGINEs:
         #   sqlite:     'django.db.backends.sqlite
-        #   mysql:      'django.db.backends.sqlite
-        #   postgres:   'django.db.backends.postgres
+        #   mysql:      'django.db.backends.mysql
+        #   postgres:   'django.db.backends.postgresql
         'ENGINE': 'django.db.backends.mysql',
         'NAME': '',
         'USER': '',
@@ -42,4 +42,3 @@ DATABASES = {
         'OPTIONS': {'init_command': 'SET default_storage_engine=INNODB'},
     }
 }
-


### PR DESCRIPTION
In the comments, the backend name for postgres was missing the "ql" at
the end, and the one for mysql was pointing to sqlite.