### PR TITLE
Add empty template block to accomodate extra fields from third parties.

### DIFF
--- a/src/core/janeway_global_settings.py
+++ b/src/core/janeway_global_settings.py
@@ -155,9 +155,9 @@ TEMPLATES = [
                 'django.template.context_processors.i18n'
             ],
             'loaders': [
+                'django.template.loaders.app_directories.Loader',
                 'utils.template_override_middleware.Loader',
                 'django.template.loaders.filesystem.Loader',
-                'django.template.loaders.app_directories.Loader',
             ],
             'builtins': [
                 'core.templatetags.fqdn',

--- a/src/themes/OLH/templates/elements/accounts/user_form.html
+++ b/src/themes/OLH/templates/elements/accounts/user_form.html
@@ -34,6 +34,7 @@
         {{ form.preferred_timezone|foundation }}
     </div>
 </div>
+{% block extra_corefields %}{% endblock %}
 <hr />
 <h5>{% trans 'Social Media and Accounts' %}</h5>
 <div class="row">

--- a/src/themes/clean/templates/elements/accounts/user_form.html
+++ b/src/themes/clean/templates/elements/accounts/user_form.html
@@ -31,6 +31,7 @@
         {% bootstrap_field form.preferred_timezone %}
     </div>
 </div>
+{% block extra_corefields %}{% endblock %}
 <hr />
 <h5>{% trans 'Social Media and Accounts' %}</h5>
 <div class="row">

--- a/src/themes/material/templates/elements/accounts/user_form.html
+++ b/src/themes/material/templates/elements/accounts/user_form.html
@@ -32,6 +32,7 @@
         {% bootstrap_field form.preferred_timezone %}
     </div>
 </div>
+{% block extra_corefields %}{% endblock %}
 <hr />
 <h5>{% trans "Social Media and Accounts" %}</h5>
 <div class="row">


### PR DESCRIPTION
This is just a proof of concept with documentation purposes.
Please feel free to just close the PR.

The extra block in the themes template and the re-ordering of the templates loaders enable third party apps and plugins to add extra code (e.g. extra fields) in the profile form.

The app/plugin should define a template named `[myapp]/templates/elements/accounts/user_form.html` with something like the following:
```html
{% extends "elements/accounts/user_form.html" %}
{% load bootstrap4 %}
{% block extra_corefields %}
Included from wjs/jcom_profile/templates/elements/accounts/user_form.html
<div class="row">
    <div class="col m3">
        {% bootstrap_field form.profession %}
    </div>
</div>
{% endblock %}
```

The important parts are
* `{% extends "elements/accounts/user_form.html" %}` that will look for the currently configured template (in django's standard way)
* `{% block extra_corefields %}...{% endblock %}` that will add the `...` code

![Screenshot_2022-06-08_15-28-02](https://user-images.githubusercontent.com/11026476/172631594-e3df9e60-3fc4-41d5-95ab-9a85541eb0eb.png)



## Bug

This solution does not distinguish between themes. I.e., the added code is the same for each theme. \
In the example above, the html used gives good results only with the theme "clean" (not with "OLH") because of the tags and css classes used.

