### PR TITLE
Git-ignore emacs' backup files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,3 +132,6 @@ src/themes/superhero
 local.env
 .lando.local.yml
 dockerfiles/lando_local.env
+
+# Emacs backup files
+*~


### PR DESCRIPTION
By default, the emacs editor leaves copies of modified files that end with "~". These can safely be ignored by git.