### PR TITLE
Allow search results to be orderered by relevance (Postgresql)

### DIFF
--- a/src/core/model_utils.py
+++ b/src/core/model_utils.py
@@ -473,17 +473,15 @@ class SearchLookup(PGSearchLookup):
        params = lhs_params + rhs_params
        return 'MATCH (%s) AGAINST (%s IN BOOLEAN MODE)' % (lhs, rhs), params
 
-    def as_others(self, compiler, connection):
-       lhs, lhs_params = self.process_lhs(compiler, connection)
-       rhs, rhs_params = self.process_rhs(compiler, connection)
-       params = lhs_params + rhs_params
-       return 'MATCH (%s) AGAINST (%s IN BOOLEAN MODE)' % (lhs, rhs), params
+    def as_postgresql(self, compiler, connection):
+        return super().as_sql(compiler, connection)
+
 
     def as_sql(self, compiler, connection):
-        if connection.vendor != 'postgresql':
-            return self.as_others(self, compiler, connection)
-        else:
-            return super().as_sql(compiler, connection)
+        lhs, lhs_params = self.process_lhs(compiler, connection)
+        rhs, rhs_params = self.process_rhs(compiler, connection)
+        params = lhs_params + rhs_params
+        return 'MATCH (%s) AGAINST (%s IN BOOLEAN MODE)' % (lhs, rhs), params
 
     def process_lhs(self, compiler, connection):
         if connection.vendor != 'postgresql':
@@ -506,11 +504,11 @@ class BaseSearchManagerMixin(Manager):
 
     def search(self, search_term, search_filters, sort=None, site=None):
         if connection.vendor == "postgresql":
-            return self.postgres_search(search_term, search_filters, site)
+            return self.postgres_search(search_term, search_filters, sort, site)
         elif connection.vendor == "mysql":
-            return self.mysql_search(search_term, search_filters, site)
+            return self.mysql_search(search_term, search_filters, sort, site)
         else:
-            return self._search(search_term, search_filters, site)
+            return self._search(search_term, search_filters, sort, site)
 
     def _search(self, search_term, search_filters, sort=None, site=None):
         """ This is a copy of search from journal.views.old_search with filters

--- a/src/submission/models.py
+++ b/src/submission/models.py
@@ -10,7 +10,8 @@ import os
 from dateutil import parser as dateparser
 
 from django.urls import reverse
-from django.db import models
+from django.db import connection, models
+from django.db.models.query import RawQuerySet
 from django.conf import settings
 from django.contrib.postgres.search import SearchQuery, SearchRank, SearchVector
 from django.utils import timezone
@@ -380,10 +381,12 @@ class ArticleSearchManager(BaseSearchManagerMixin):
 
     def search(self, *args, **kwargs):
         queryset = super().search(*args, **kwargs)
-        return queryset.filter(
-            date_published__lte=timezone.now(),
-            stage=STAGE_PUBLISHED,
-        )
+        if not isinstance(queryset, RawQuerySet):
+            queryset = queryset.filter(
+                date_published__lte=timezone.now(),
+                stage=STAGE_PUBLISHED,
+            )
+        return queryset
 
     def mysql_search(self, search_term, search_filters, sort=None, site=None):
         queryset = self.get_queryset().none()
@@ -420,6 +423,10 @@ class ArticleSearchManager(BaseSearchManagerMixin):
         queryset = self.get_queryset()
         if not search_term or not any(search_filters.values()):
             return queryset.none()
+        queryset = queryset.filter(
+            date_published__lte=timezone.now(),
+            stage=STAGE_PUBLISHED,
+        )
         if site:
             queryset = queryset.filter(journal=site)
         lookups, annotations = self.build_postgres_lookups(
@@ -429,11 +436,27 @@ class ArticleSearchManager(BaseSearchManagerMixin):
         if lookups:
             queryset = queryset.filter(**lookups)
 
+
         if not sort or sort not in self.SORT_KEYS:
             sort = "-relevance"
 
         # Postgresql requires adding the DISTINCT ON column to ORDER BY
-        return queryset.distinct("id").order_by( "id", sort)
+        queryset = queryset.order_by("id").distinct("id")
+
+        # Now we can order the result set based by another column
+        if "relevance" in sort:
+            # We can't use the ORM because it is not possible to select
+            # a column from a subquery filter
+            inner_sql = self.stringify_queryset(queryset)
+            return Article.objects.raw(
+                f"SELECT * from ({inner_sql}) AS search "
+                "ORDER BY relevance DESC"
+            )
+        else:
+            return self.get_queryset().filter(
+                id__in=queryset
+            ).order_by(sort)
+
 
     def build_postgres_lookups(self, search_term, search_filters):
         """ Build the necessary lookup expressions based on the provided filters
@@ -483,6 +506,12 @@ class ArticleSearchManager(BaseSearchManagerMixin):
             lookups['frozenauthor__author__orcid'] = search_term
             lookups['frozenauthor__frozen_orcid'] = search_term
         return lookups, annotations
+
+    @staticmethod
+    def stringify_queryset(queryset):
+        sql, params = queryset.query.sql_with_params()
+        with connection.cursor() as cursor:
+            return cursor.mogrify(sql, params).decode()
 
 
 class Article(AbstractLastModifiedModel):

--- a/src/utils/management/commands/generate_search_indexes.py
+++ b/src/utils/management/commands/generate_search_indexes.py
@@ -1,5 +1,5 @@
 from django.db import connection
-from django.db.utils import OperationalError
+from django.db.utils import OperationalError, ProgrammingError
 from django.core.management import call_command
 from django.core.management.base import BaseCommand
 from django.conf import settings
@@ -28,23 +28,49 @@ class Command(BaseCommand):
 
     help = "Generates database indexes for full text search (idempotent)"
 
+    INDEXING_SQL_TEMPLATES = {
+        # We use GIN over GiST indexes as the former are more performant during
+        # Lookups at the expense of lower build/update performance 
+        # https://www.postgresql.org/docs/current/textsearch-indexes.html
+        "postgresql": "CREATE INDEX {idx_name} ON {table} USING gin({col});",
+        "mysql": "CREATE FULLTEXT INDEX {idx_name} on {table}({col});",
+    }
+
     def handle(self, *args, **options):
         if not settings.ENABLE_FULL_TEXT_SEARCH:
             logger.info('Full Text search not enabled')
             return
         cursor = connection.cursor()
-        if connection.vendor == "mysql":
-            for table, col in self.get_charfield_columns():
-                sql = f"CREATE FULLTEXT INDEX {col}_ft_idx on {table}({col})"
+        if connection.vendor in self.INDEXING_SQL_TEMPLATES:
+            if connection.vendor == "postgresql":
+                try:
+                    cursor.execute("CREATE EXTENSION btree_gin;")
+                except ProgrammingError:
+                    pass # Ignore if already exists
+
+            for table, col in self.get_columns_to_index(connection.vendor):
+                idx_name = f"{col}_ft_idx"
+                sql = self.INDEXING_SQL_TEMPLATES[connection.vendor].format(
+                    col=col,
+                    table=table,
+                    idx_name=idx_name
+                )
                 logger.debug("running SQL: %s", sql)
                 try:
                     cursor.execute(sql)
-                except OperationalError as e:
-                        pass # Ignore duplicate indexes
+                except (OperationalError, ProgrammingError) as e:
+                    pass # Ignore if already exists
+        else:
+            logger.warning(
+                "Full-text indexing on %s backend not supported",
+                connection.vendor,
+            )
 
-    def get_charfield_columns(self):
-        for column in FT_SEARCH_COLUMNS:
-            yield column
+    def get_columns_to_index(self, vendor):
+        for table, col in FT_SEARCH_COLUMNS:
+            if table == "core_filetext" and vendor =="postgresql":
+                continue
+            yield table, col
 
         for table, col in FT_SEARCH_TRANSLATABLE_COLUMNS:
             for lang, _ in settings.LANGUAGES:


### PR DESCRIPTION
Due to limitations of the ORM, we have to run raw SQL in order to both run a distinct query on article hits AND be able to sort by relevance