### PR TITLE
Add new hooks "extra_corefields" in all themes.

### DIFF
--- a/src/themes/OLH/templates/elements/accounts/user_form.html
+++ b/src/themes/OLH/templates/elements/accounts/user_form.html
@@ -1,6 +1,7 @@
 {% load foundation %}
 {% load static %}
 {% load i18n %}
+{% load hooks %}
 
 <h5>{% trans 'Core Data' %}</h5>
 <div class="row">
@@ -34,6 +35,7 @@
         {{ form.preferred_timezone|foundation }}
     </div>
 </div>
+{% hook 'extra_corefields' %}
 <hr />
 <h5>{% trans 'Social Media and Accounts' %}</h5>
 <div class="row">

--- a/src/themes/clean/templates/elements/accounts/user_form.html
+++ b/src/themes/clean/templates/elements/accounts/user_form.html
@@ -1,6 +1,7 @@
 {% load foundation %}
 {% load bootstrap4 %}
 {% load static %}
+{% load hooks %}
 
 <h5>{% trans 'Core Data' %}</h5>
 <div class="row">
@@ -31,6 +32,7 @@
         {% bootstrap_field form.preferred_timezone %}
     </div>
 </div>
+{% hook 'extra_corefields' %}
 <hr />
 <h5>{% trans 'Social Media and Accounts' %}</h5>
 <div class="row">

--- a/src/themes/material/templates/elements/accounts/user_form.html
+++ b/src/themes/material/templates/elements/accounts/user_form.html
@@ -2,6 +2,7 @@
 {% load bootstrap4 %}
 {% load static %}
 {% load i18n %}
+{% load hooks %}
 
 <h5>{% trans "Core Data" %}</h5>
 <div class="row">
@@ -32,6 +33,7 @@
         {% bootstrap_field form.preferred_timezone %}
     </div>
 </div>
+{% hook 'extra_corefields' %}
 <hr />
 <h5>{% trans "Social Media and Accounts" %}</h5>
 <div class="row">


### PR DESCRIPTION
So that plugins and apps can customize the user profile form.

The extra code will appear in the "Core data" section of the user profile form.\
Example with hook function defined [here](https://github.com/gamboz/wjs-profile-project/blob/61ce9752d7450a73fac9b59384d6d0eb1670c4dc/wjs/jcom_profile/hooks.py)

<img src="https://user-images.githubusercontent.com/11026476/174796837-d59065f5-c8dc-4931-81b4-f0b04e07ee70.png" alt="example" width="400"/>
