### PR TITLE
#2972 move password rules markup from register to reset_password templates

### DIFF
--- a/src/themes/OLH/templates/core/accounts/reset_password.html
+++ b/src/themes/OLH/templates/core/accounts/reset_password.html
@@ -24,10 +24,15 @@
                 <div class="callout">
                     <div class="row column log-in-form">
                         <h5>{% trans "Enter your new password twice to complete the reset process" %}:</h5>
-                        <p>{% blocktrans %}Your password should be at minimum 12 characters long. It does not need to
-                            contain specific
-                            characters but you should make it as long as possible. For more information read our
-                            <a href="#" data-open="password-modal">password guide</a>{% endblocktrans %}.</p>
+                        <p>Password Rules:</p>
+                    <ul class="no-top-margin">
+                        <li>- {% trans "Your password should be" %} {{ request.press.password_length }} {% trans "characters long" %}.</li>
+                        {% if request.press.password_upper %}<li>- {% trans "Your password should contain at least one upper case letter." %}</li>{% endif %}
+                        {% if request.press.password_number %}<li>- {% trans "Your password should contain at least one number." %}</li>{% endif %}
+                    </ul>
+                    <p>{% blocktrans %}For more information read our
+                        <a href="#passwordmodal" class="modal-trigger">password guide</a>
+                        .{% endblocktrans %}</p>
                         {{ form|foundation }}
                         <p>
                             <button type="submit" class="button expanded">{% trans "Reset Password" %}</button>

--- a/src/themes/clean/templates/core/accounts/reset_password.html
+++ b/src/themes/clean/templates/core/accounts/reset_password.html
@@ -14,11 +14,15 @@
                             {% csrf_token %}
                             <div class="form-group">
                                 <h5>{% trans "Enter your new password twice to complete the reset process" %}:</h5>
-                                <p>{% blocktrans %}Your password should be at minimum 12 characters long. It does not
-                                    need to contain specific
-                                    characters but you should make it as long as possible. For more information read our
-                                    <a href="#" data-toggle="modal" data-target="#passwordmodal">password
-                                        guide</a>.{% endblocktrans %}</p>
+                                <p>Password Rules:</p>
+                                <ul class="no-top-margin">
+                                    <li>- {% trans "Your password should be" %} {{ request.press.password_length }} {% trans "characters long" %}.</li>
+                                    {% if request.press.password_upper %}<li>- {% trans "Your password should contain at least one upper case letter." %}</li>{% endif %}
+                                    {% if request.press.password_number %}<li>- {% trans "Your password should contain at least one number." %}</li>{% endif %}
+                                </ul>
+                                <p>{% blocktrans %}For more information read our
+                                    <a href="#passwordmodal" class="modal-trigger">password guide</a>
+                                    .{% endblocktrans %}</p>
                                 {% bootstrap_form form %}
                                 <br/>
                                 <button type="submit"

--- a/src/themes/material/templates/core/accounts/reset_password.html
+++ b/src/themes/material/templates/core/accounts/reset_password.html
@@ -14,10 +14,15 @@
                             {% csrf_token %}
                             <div class="form-group">
                                 <span class="card-title">{% trans "Enter your new password twice to complete the reset process" %}:</span>
-                                <p>{% blocktrans %}Your password should be at minimum 12 characters long. It does not
-                                    need to contain specific
-                                    characters but you should make it as long as possible. For more information read our{% endblocktrans %}
-                                    <a href="#passwordmodal" class="modal-trigger">{% trans "password guide" %}</a>.</p>
+                                <p>Password Rules:</p>
+                                <ul class="no-top-margin">
+                                    <li>- {% trans "Your password should be" %} {{ request.press.password_length }} {% trans "characters long" %}.</li>
+                                    {% if request.press.password_upper %}<li>- {% trans "Your password should contain at least one upper case letter." %}</li>{% endif %}
+                                    {% if request.press.password_number %}<li>- {% trans "Your password should contain at least one number." %}</li>{% endif %}
+                                </ul>
+                                <p>{% blocktrans %}For more information read our
+                                    <a href="#passwordmodal" class="modal-trigger">password guide</a>
+                                    .{% endblocktrans %}</p>
                                 {% materialize_form form=form %}
                                 <br/>
                                 <button type="submit"


### PR DESCRIPTION
Fixes: #2972 by copying password rules from the registration page to the reset password page