### PR TITLE
Fix an issue where table footnotes would lead article footnotes to no longer link correctly

### DIFF
--- a/src/transform/xsl/default.xsl
+++ b/src/transform/xsl/default.xsl
@@ -431,7 +431,7 @@
 
     <xsl:template match="fn-group/fn">
         <xsl:variable name="fn-number">
-            <xsl:number level="any" count="fn[not(ancestor::front)]" from="article | sub-article | response"/>
+            <xsl:number level="any" count="fn[not(ancestor::front| ancestor::table-wrap-foot)]" from="article | sub-article | response"/>
         </xsl:variable>
         <li id="fn{$fn-number}">
             <span id="n{$fn-number}"></span>


### PR DESCRIPTION
This was fixed in #2681 but accidentally lost in f0ff0bf7ca39fdf49f7483df9ef06ba76f599f7d