### PR TITLE
Add Undo Article Rejection button on archive page

### DIFF
--- a/docs/source/published/articles.rst
+++ b/docs/source/published/articles.rst
@@ -20,6 +20,7 @@ From this page you can:
 - Manage identifiers
 - Manage galley files
 - Manage which issues an article appears in
+- If an article is rejected, unreject the article
 
 Metadata
 --------
@@ -87,3 +88,9 @@ You can see the issues that an article is part of at the bottom of the Article A
 
     Archive issue block
 
+
+Actions
+-------
+You can unreject a previously rejected article using this button. You will have the opportunity to write an email to the author before the change takes effect.
+
+If the article was previously assigned to an editor, the article will move to the Review stage. Otherwise, it will move to the Unassigned stage.

--- a/src/events/logic.py
+++ b/src/events/logic.py
@@ -58,6 +58,10 @@ class Events:
     ON_ARTICLE_DECLINED = 'on_article_declined'
 
     # kwargs: article, request, user_message_content, decision, skip (boolean)
+    # raised when an editor undeclines an article
+    ON_ARTICLE_UNDECLINED = 'on_article_undeclined'
+
+    # kwargs: article, request, user_message_content, decision, skip (boolean)
     # raised when an editor accepts or accepts an article
     ON_ARTICLE_ACCEPTED = 'on_article_accepted'
 

--- a/src/events/registration.py
+++ b/src/events/registration.py
@@ -34,6 +34,8 @@ event_logic.Events.register_for_event(event_logic.Events.ON_REVIEW_COMPLETE,
                                       transactional_emails.send_review_complete_acknowledgements)
 event_logic.Events.register_for_event(event_logic.Events.ON_ARTICLE_DECLINED,
                                       transactional_emails.send_article_decision)
+event_logic.Events.register_for_event(event_logic.Events.ON_ARTICLE_UNDECLINED,
+                                      transactional_emails.send_article_decision)
 event_logic.Events.register_for_event(event_logic.Events.ON_ARTICLE_ACCEPTED,
                                       transactional_emails.send_article_decision)
 event_logic.Events.register_for_event(event_logic.Events.ON_DRAFT_DECISION,

--- a/src/journal/views.py
+++ b/src/journal/views.py
@@ -35,7 +35,7 @@ from identifiers import models as id_models
 from journal import logic, models, issue_forms, forms, decorators
 from journal.logic import get_galley_content
 from metrics.logic import store_article_access
-from review import forms as review_forms
+from review import forms as review_forms, models as review_models
 from security.decorators import article_stage_accepted_or_later_required, \
     article_stage_accepted_or_later_or_staff_required, article_exists, file_user_required, has_request, has_journal, \
     file_history_user_required, file_edit_user_required, production_user_or_editor_required, \
@@ -1706,6 +1706,9 @@ def manage_archive_article(request, article_id):
         note_form = submission_forms.PublisherNoteForm(instance=publisher_note)
         note_forms.append(note_form)
 
+    assigned_editors = [assignment.editor for assignment in
+                       review_models.EditorAssignment.objects.filter(article=article)]
+
     template = 'journal/manage/archive_article.html'
     context = {
         'article': article,
@@ -1714,6 +1717,7 @@ def manage_archive_article(request, article_id):
         'newnote_form': newnote_form,
         'note_forms': note_forms,
         'galley_form': galley_form,
+        'assigned_editors': assigned_editors,
     }
 
     return render(request, template, context)

--- a/src/journal/views.py
+++ b/src/journal/views.py
@@ -1706,8 +1706,11 @@ def manage_archive_article(request, article_id):
         note_form = submission_forms.PublisherNoteForm(instance=publisher_note)
         note_forms.append(note_form)
 
-    assigned_editors = [assignment.editor for assignment in
-                       review_models.EditorAssignment.objects.filter(article=article)]
+    assigned_editors = [
+        assignment.editor for assignment in review_models.EditorAssignment.objects.filter(
+            article=article
+        )
+    ]
 
     template = 'journal/manage/archive_article.html'
     context = {

--- a/src/review/urls.py
+++ b/src/review/urls.py
@@ -32,8 +32,7 @@ urlpatterns = [
         name='review_assignment_notification'),
     url(r'^unassigned/article/(?P<article_id>\d+)/move/review/$', views.move_to_review, name='review_move_to_review'),
     url(r'^article/(?P<article_id>\d+)/crosscheck/$', views.view_ithenticate_report, name='review_crosscheck'),
-
-    url(r'^article/(?P<article_id>\d+)/move/(?P<decision>accept|decline)/$', views.review_decision,
+    url(r'^article/(?P<article_id>\d+)/move/(?P<decision>accept|decline|undecline)/$', views.review_decision,
         name='review_decision'),
     url(r'^article/(?P<article_id>\d+)/summary/$', views.unassigned_article, name='review_summary'),
     url(r'^article/(?P<article_id>\d+)/$', views.in_review, name='review_in_review'),

--- a/src/review/views.py
+++ b/src/review/views.py
@@ -1438,10 +1438,9 @@ def review_decision(request, article_id, decision):
     )
     email_content = logic.get_decision_content(request, article, decision, author_review_url)
 
-    if article.date_accepted or article.date_declined:
-        if decision != 'undecline':
-            messages.add_message(request, messages.WARNING, _('This article has already been accepted or declined.'))
-            return redirect(reverse('review_in_review', kwargs={'article_id': article.pk}))
+    if (article.date_accepted or article.date_declined) and decision != 'undecline':
+        messages.add_message(request, messages.WARNING, _('This article has already been accepted or declined.'))
+        return redirect(reverse('review_in_review', kwargs={'article_id': article.pk}))
 
     if request.POST:
         email_content = request.POST.get('decision_rationale')

--- a/src/submission/models.py
+++ b/src/submission/models.py
@@ -1318,6 +1318,17 @@ class Article(AbstractLastModifiedModel):
         self.stage = STAGE_REJECTED
         self.save()
 
+    def undo_review_decision(self):
+        self.date_accepted = None
+        self.date_declined = None
+
+        if review_models.EditorAssignment.objects.filter(article=self):
+            self.stage = STAGE_ASSIGNED
+        else:
+            self.stage = STAGE_UNASSIGNED
+
+        self.save()
+
     def accept_preprint(self, date, time):
         self.date_accepted = timezone.now()
         self.date_declined = None

--- a/src/templates/admin/journal/manage/archive_article.html
+++ b/src/templates/admin/journal/manage/archive_article.html
@@ -5,6 +5,7 @@
 {% load foundation %}
 {% load hooks %}
 {% load bool_fa %}
+{% load i18n %}
 
 {% block title %}Article Archive {{ article.pk }}{% endblock title %}
 {% block title-section %}{% if article.stage == 'Rejected' %}Rejected Article {% else %}Article Archive{% endif %} {{ article.pk }}{% endblock %}
@@ -20,9 +21,11 @@
         <div class="box">
             <div class="title-area">
                 <h2>Metadata</h2>
-                <a class="button" href="{% url 'core_article_image_edit' article.pk %}">Edit Article Images</a>
-                <a class="button" href="{% url 'publish_article' article.pk %}">Edit Publication Info</a>
-                {% if article.is_remote %}<a class="button" href="{{ article.remote_url }}">Remote Article View <i class="fa fa-external-link"></i></a>{% endif %}
+                <a class="button" href="{% url 'core_article_image_edit' article.pk %}">{% trans 'Edit Article Images' %}</a>
+                {% if not article.stage == 'Rejected' %}
+                    <a class="button" href="{% url 'publish_article' article.pk %}">{% trans 'Edit Publication Info' %}</a>
+                {% endif %}
+                {% if article.is_remote %}<a class="button" href="{{ article.remote_url }}">{% trans 'Remote Article View' %}<i class="fa fa-external-link"></i></a>{% endif %}
                 {% hook 'request_edit' %}
             </div>
             <div class="content">
@@ -164,6 +167,26 @@
             </div>
         </div>
     </div>
+    {% if article.stage == 'Rejected' %}
+    <div class="large-12 columns">
+        <div class="box">
+            <div class="title-area">
+                <h2>Actions</h2>
+            </div>
+            <div class="button-group">
+                <a href="{% url 'review_decision' article.id 'undecline' %}" class="button success">
+                    <i class="fa fa-undo action-icon">&nbsp;</i> {% trans 'Undo Article Rejection' %}
+                </a>
+            </div>
+            {% if assigned_editors %}
+                {% trans 'Review' as stage %}
+            {% else %}
+                {% trans 'Unassigned' as stage %}
+            {% endif %}
+            <p>{% blocktrans %}You will have the opportunity to send an email to the author, and then the article will move back to the {{ stage }} stage.{% endblocktrans %}</p>
+        </div>
+    </div>
+    {% endif %}
 {% endblock body %}
 
 {% block js %}

--- a/src/utils/install/journal_defaults.json
+++ b/src/utils/install/journal_defaults.json
@@ -379,6 +379,21 @@
             "name": "email"
         },
         "setting": {
+            "description": "Email sent to authors when a decision to decline an article is reversed.",
+            "is_translatable": true,
+            "name": "review_decision_undecline",
+            "pretty_name": "Undo Article Rejection",
+            "type": "rich-text"
+        },
+        "value": {
+            "default": "<p>Dear {{ article.correspondence_author.full_name }},<br><br>We wish to inform you that the earlier decision to decline \"{{ article.title }}\" in {{ article.journal.name }} has been reversed. The article is now being reconsidered.<br><br>Regards,</p><p>{{ request.user.signature|safe }}</p>"
+        }
+    },
+    {
+        "group": {
+            "name": "email"
+        },
+        "setting": {
             "description": "Email sent to editors when they are unassigned from an article",
             "is_translatable": true,
             "name": "unassign_editor",
@@ -2454,6 +2469,21 @@
             "is_translatable": true,
             "description": "Subject for Email sent to authors when an article is declined.",
             "name": "subject_review_decision_decline"
+        },
+        "group": {
+            "name": "email_subject"
+        }
+    },
+    {
+        "value": {
+            "default": "Article Reconsidered"
+        },
+        "setting": {
+            "type": "text",
+            "pretty_name": "Undo Article Rejection Subject",
+            "is_translatable": true,
+            "description": "Subject for email sent to authors when a decision to reject an article is reversed.",
+            "name": "subject_review_decision_undecline"
         },
         "group": {
             "name": "email_subject"


### PR DESCRIPTION
The button appears at the bottom of the Article Archive page.

Fixes #2859.

![Screenshot from 2022-07-05 11-19-24](https://user-images.githubusercontent.com/47217308/178027427-962eedf4-9804-404c-b971-28bb7ecaf343.png)

Editors can draft an email to the author, much like they can when accepting or declining an article.

![Screenshot from 2022-07-08 16-54-42](https://user-images.githubusercontent.com/47217308/178027723-b58bf9ce-e886-4526-8add-811ee2494235.png)