### PR TITLE
#2986 when editing an articles metadata the additional field options will now be also editable.

### DIFF
--- a/src/submission/views.py
+++ b/src/submission/views.py
@@ -583,6 +583,7 @@ def edit_metadata(request, article_id):
     """
     with translation.override(request.override_language):
         article = get_object_or_404(models.Article, pk=article_id)
+        additional_fields = models.Field.objects.filter(journal=request.journal)
         submission_summary = setting_handler.get_setting(
             'general',
             'submission_summary',
@@ -590,6 +591,7 @@ def edit_metadata(request, article_id):
         ).processed_value
         info_form = forms.ArticleInfo(
             instance=article,
+            additional_fields=additional_fields,
             submission_summary=submission_summary,
             pop_disabled_fields=False,
         )
@@ -691,6 +693,7 @@ def edit_metadata(request, article_id):
         'author_form': author_form,
         'modal': modal,
         'frozen_author': frozen_author,
+        'additional_fields': additional_fields,
         'return': return_param
     }
 

--- a/src/templates/admin/elements/submission/additional_fields.html
+++ b/src/templates/admin/elements/submission/additional_fields.html
@@ -1,0 +1,12 @@
+{% load field foundation %}
+{% if additional_fields %}
+    <div class="title-area spacer-top-20">
+        <h2>{% trans 'Additional Fields' %}</h2>
+    </div>
+    {% for additional_field in additional_fields %}
+        {% get_form_field form additional_field.name as field %}
+        <div class="{{ field.field.widget.attrs.div_class }} columns">
+            {{ field|foundation }}
+        </div>
+    {% endfor %}
+{% endif %}

--- a/src/templates/admin/submission/edit/metadata.html
+++ b/src/templates/admin/submission/edit/metadata.html
@@ -94,13 +94,16 @@
                     <div class="large-10 columns">
                         {{ info_form.custom_how_to_cite|foundation }}
                     </div>
-                    <div class="row expanded">
-                        <div class="large-12 columns">
-                            <label for="id_keywords">Keywords</label>
-                            <input type="text" id="id_keywords" name="keywords" value="
+                    <div class="large-12 columns">
+                        <div class="row expanded">
+                            <div class="large-12 columns">
+                                <label for="id_keywords">Keywords</label>
+                                <input type="text" id="id_keywords" name="keywords" value="
 
-                                    {% if info_form.cleaned_data.keywords %}{{ info_form.cleaned_data.keywords }}{% else %}{% for keyword in article.keywords.all %}{{ keyword.word }}{% if not forloop.last %},{% endif %}{% endfor %}{% endif %}"/>
-                            <p>Hit Enter to add a new keyword.</p>
+
+                                        {% if info_form.cleaned_data.keywords %}{{ info_form.cleaned_data.keywords }}{% else %}{% for keyword in article.keywords.all %}{{ keyword.word }}{% if not forloop.last %},{% endif %}{% endfor %}{% endif %}"/>
+                                <p>Hit Enter to add a new keyword.</p>
+                            </div>
                         </div>
                     </div>
 

--- a/src/templates/admin/submission/edit/metadata.html
+++ b/src/templates/admin/submission/edit/metadata.html
@@ -94,13 +94,17 @@
                     <div class="large-10 columns">
                         {{ info_form.custom_how_to_cite|foundation }}
                     </div>
-                    <div class="large-12 columns">
-                        <label for="id_keywords">Keywords</label>
-                        <input type="text" id="id_keywords" name="keywords" value="
-                                {% if form.cleaned_data.keywords %}{{ form.cleaned_data.keywords }}{% else %}{% for keyword in article.keywords.all %}{{ keyword.word }}{% if not forloop.last %},{% endif %}{% endfor %}{% endif %}"/>
-                        <p>Hit Enter to add a new keyword.</p>
+                    <div class="row expanded">
+                        <div class="large-12 columns">
+                            <label for="id_keywords">Keywords</label>
+                            <input type="text" id="id_keywords" name="keywords" value="
 
+                                    {% if info_form.cleaned_data.keywords %}{{ info_form.cleaned_data.keywords }}{% else %}{% for keyword in article.keywords.all %}{{ keyword.word }}{% if not forloop.last %},{% endif %}{% endfor %}{% endif %}"/>
+                            <p>Hit Enter to add a new keyword.</p>
+                        </div>
                     </div>
+
+                    {% include "admin/elements/submission/additional_fields.html" with form=info_form additional_fields=additional_fields %}
 
                     <div class="large-12 columns">
                         <button type="submit" name="metadata" class="small success button">Update Metadata</button>

--- a/src/templates/admin/submission/submit_info.html
+++ b/src/templates/admin/submission/submit_info.html
@@ -2,7 +2,6 @@
 {% load static from staticfiles %}
 {% load foundation %}
 {% load i18n %}
-{% load field %}
 
 {% block title-section %}{% trans "Article Info" %}{% endblock %}
 {% block css %}
@@ -77,18 +76,7 @@
                     <div class="clearfix"></div>
 
 
-
-                    {% if additional_fields %}
-                        <div class="title-area spacer-top-20">
-                            <h2>{% trans 'Additional Fields' %}</h2>
-                        </div>
-                        {% for additional_field in additional_fields %}
-                            {% get_form_field form additional_field.name as field %}
-                            <div class="{{ field.field.widget.attrs.div_class }} columns">
-                                {{ field|foundation }}
-                            </div>
-                        {% endfor %}
-                    {% endif %}
+                    {% include "admin/elements/submission/additional_fields.html" with form=form additional_fields=additional_fields %}
 
                     <div class="large-12 columns">
                         <button class="success button pull-right" type="submit" name="start_submission"><i


### PR DESCRIPTION
Closes #2986

An example: 
![Screenshot 2022-07-12 at 13 20 43](https://user-images.githubusercontent.com/8321378/178488257-e32a0404-d759-41b1-82ff-989f5ebdbcae.png)
 