### PR TITLE
#2904 fixes an issue that caused modified dates for File objects not to show up

### DIFF
--- a/src/core/models.py
+++ b/src/core/models.py
@@ -10,6 +10,7 @@ import json
 from datetime import timedelta
 import pytz
 from hijack.signals import hijack_started, hijack_ended
+import warnings
 
 from bs4 import BeautifulSoup
 from django.conf import settings
@@ -918,6 +919,11 @@ class File(AbstractLastModifiedModel):
             indexed = True
 
         return indexed
+
+    @property
+    def date_modified(self):
+        warnings.warn("'date_modified' is deprecated and will be removed, use last_modified instead.")
+        return self.last_modified
 
 
     def __str__(self):

--- a/src/templates/admin/journal/document_management.html
+++ b/src/templates/admin/journal/document_management.html
@@ -42,7 +42,7 @@
                         <td>{{ file.pk }}</td>
                         <td class="wrap-long-text">{% if not file.label %}No Label{% endif %}{{ file.label }}</td>
                         <td>{{ file.date_uploaded|date:"Y-m-d G:i" }}</td>
-                        <td>{{ file.date_modified|date:"Y-m-d G:i" }}</td>
+                        <td>{{ file.last_modified|date:"Y-m-d G:i" }}</td>
                         <td class="wrap-long-text">{{ file }}</td>
                         <td>{% if can_view_file_flag %}
                             <a href="{% url 'article_file_download' 'id' article.pk file.pk %}"><i

--- a/src/templates/admin/production/assign_typesetter.html
+++ b/src/templates/admin/production/assign_typesetter.html
@@ -93,7 +93,7 @@
                             <td>{{ file.label }}</td>
                             <td>{{ file.original_filename }}</td>
                             <td>Manuscript</td>
-                            <td>{{ file.date_modified|date:"Y-m-d G:i" }}</td>
+                            <td>{{ file.last_modified|date:"Y-m-d G:i" }}</td>
                             <td><a href="{% url 'editor_file_download' article.pk file.pk %}"><i class="fa fa-download">&nbsp;</i></a></td>
                         </tr>
                     {% endfor %}
@@ -104,7 +104,7 @@
                             <td>{{ file.label }}</td>
                             <td>{{ file.original_filename }}</td>
                             <td>Data/Figure</td>
-                            <td>{{ file.date_modified|date:"Y-m-d G:i" }}</td>
+                            <td>{{ file.last_modified|date:"Y-m-d G:i" }}</td>
                             <td><a href="{% url 'editor_file_download' article.pk file.pk %}"><i class="fa fa-download">&nbsp;</i></a></td>
                         </tr>
                     {% endfor %}
@@ -115,7 +115,7 @@
                             <td>{{ file.label }}</td>
                             <td>{{ file.original_filename }}</td>
                             <td>Copyedit</td>
-                            <td>{{ file.date_modified|date:"Y-m-d G:i" }}</td>
+                            <td>{{ file.last_modified|date:"Y-m-d G:i" }}</td>
                             <td><a href="{% url 'editor_file_download' article.pk file.pk %}"><i class="fa fa-download">&nbsp;</i></a></td>
                         </tr>
                     {% endfor %}

--- a/src/templates/admin/production/assigned_article.html
+++ b/src/templates/admin/production/assigned_article.html
@@ -140,7 +140,7 @@
                             <td>{{ file.label }}</td>
                             <td>{{ file.original_filename|truncatechars:40 }}</td>
                             <td>Manuscript</td>
-                            <td>{{ file.date_modified|date:"Y-m-d G:i" }}</td>
+                            <td>{{ file.last_modified|date:"Y-m-d G:i" }}</td>
                             <td>{% if can_view_file_flag %}
                                 <a href="{% url 'article_file_download' 'id' article.pk file.pk %}"><i
                                         class="fa fa-download">&nbsp;</i></a>{% endif %}
@@ -158,7 +158,7 @@
                             <td>{{ file.label }}</td>
                             <td>{{ file.original_filename|truncatechars:40 }}</td>
                             <td>Data/Figure</td>
-                            <td>{{ file.date_modified|date:"Y-m-d G:i" }}</td>
+                            <td>{{ file.last_modified|date:"Y-m-d G:i" }}</td>
                             <td>{% if can_view_file_flag %}
                                 <a href="{% url 'article_file_download' 'id' article.pk file.pk %}"><i
                                         class="fa fa-download">&nbsp;</i></a>{% endif %}
@@ -176,7 +176,7 @@
                             <td>{{ file.label }}</td>
                             <td>{{ file.original_filename|truncatechars:40 }}</td>
                             <td>Copyedit</td>
-                            <td>{{ file.date_modified|date:"Y-m-d G:i" }}</td>
+                            <td>{{ file.last_modified|date:"Y-m-d G:i" }}</td>
                             <td>{% if can_view_file_flag %}
                                 <a href="{% url 'article_file_download' 'id' article.pk file.pk %}"><i
                                         class="fa fa-download">&nbsp;</i></a>{% endif %}
@@ -218,7 +218,7 @@
                             <td>{{ galley.label }}</td>
                             <td>{{ galley.file.original_filename|truncatechars:40 }}</td>
                             <td>{{ galley.public|bool_fa }}</td>
-                            <td>{{ galley.file.date_modified|date:"Y-m-d G:i" }}</td>
+                            <td>{{ galley.file.last_modified|date:"Y-m-d G:i" }}</td>
                             <td><a href="{% url 'pm_edit_galley' article.pk galley.pk %}" class="fa fa-edit"></a></td>
                             <td>{% if can_view_file_flag %}
                                 <a href="{% url 'article_file_download' 'id' article.pk galley.file.pk %}"><i
@@ -303,7 +303,7 @@
                             <td>{{ galley.pk }}</td>
                             <td>{{ galley.label }}</td>
                             <td>{{ galley.file.original_filename|truncatechars:40 }}</td>
-                            <td>{{ galley.file.date_modified|date:"Y-m-d G:i" }}</td>
+                            <td>{{ galley.file.last_modified|date:"Y-m-d G:i" }}</td>
                             <td>{% if can_view_file_flag %}
                                 <a href="{% url 'article_file_download' 'id' article.pk galley.file.pk %}"><i
                                         class="fa fa-download">&nbsp;</i></a>{% endif %}
@@ -360,7 +360,7 @@
                             <td>{{ file.pk }}</td>
                             <td>{{ file.original_filename|truncatechars:40 }}</td>
                             <td>Source File</td>
-                            <td>{{ file.date_modified|date:"Y-m-d G:i" }}</td>
+                            <td>{{ file.last_modified|date:"Y-m-d G:i" }}</td>
                             <td>{% if can_view_file_flag %}
                                 <a href="{% url 'article_file_download' 'id' article.pk file.pk %}"><i
                                         class="fa fa-download">&nbsp;</i></a>{% endif %}

--- a/src/templates/admin/production/edit_galley.html
+++ b/src/templates/admin/production/edit_galley.html
@@ -43,7 +43,7 @@
                     <td>{{ galley.label }}</td>
                     <td>{{ galley.file.original_filename|truncatechars:40 }}</td>
                     <td>Galley</td>
-                    <td>{{ galley.file.date_modified|date:"Y-m-d G:i" }}</td>
+                    <td>{{ galley.file.last_modified|date:"Y-m-d G:i" }}</td>
                     <td>{% if can_view_file_flag %}
                         <a href="{% url 'article_file_download' 'id' article.pk galley.file.pk %}"><i
                                 class="fa fa-download">&nbsp;</i></a>{% endif %}
@@ -140,7 +140,7 @@
                         <td>{{ image.label }}</td>
                         <td>{{ image.original_filename }}</td>
                         <td>Galley Images</td>
-                        <td>{{ image.date_modified|date:"Y-m-d G:i" }}</td>
+                        <td>{{ image.last_modified|date:"Y-m-d G:i" }}</td>
                         <td>{% if can_view_file_flag %}
                             <a href="{% url 'article_file_download' 'id' article.pk image.pk %}"><i
                                     class="fa fa-download">&nbsp;</i></a>{% endif %}

--- a/src/templates/admin/production/edit_typesetter_assignment.html
+++ b/src/templates/admin/production/edit_typesetter_assignment.html
@@ -49,7 +49,7 @@
                                     <td>{{ file.label }}</td>
                                     <td>{{ file.original_filename }}</td>
                                     <td>Manuscript</td>
-                                    <td>{{ file.date_modified|date:"Y-m-d G:i" }}</td>
+                                    <td>{{ file.last_modified|date:"Y-m-d G:i" }}</td>
                                     <td>
                                         <a href="{% url 'editor_file_download' article.pk file.pk %}"><i
                                                 class="fa fa-download">&nbsp;</i></a>
@@ -65,7 +65,7 @@
                                     <td>{{ file.label }}</td>
                                     <td>{{ file.original_filename }}</td>
                                     <td>Data/Figure</td>
-                                    <td>{{ file.date_modified|date:"Y-m-d G:i" }}</td>
+                                    <td>{{ file.last_modified|date:"Y-m-d G:i" }}</td>
                                     <td>
                                         <a href="{% url 'editor_file_download' article.pk file.pk %}"><i
                                                 class="fa fa-download">&nbsp;</i></a>
@@ -81,7 +81,7 @@
                                     <td>{{ file.label }}</td>
                                     <td>{{ file.original_filename }}</td>
                                     <td>Copyedit</td>
-                                    <td>{{ file.date_modified|date:"Y-m-d G:i" }}</td>
+                                    <td>{{ file.last_modified|date:"Y-m-d G:i" }}</td>
                                     <td>
                                         <a href="{% url 'editor_file_download' article.pk file.pk %}"><i
                                                 class="fa fa-download">&nbsp;</i></a>

--- a/src/templates/admin/production/typeset_task.html
+++ b/src/templates/admin/production/typeset_task.html
@@ -76,7 +76,7 @@
                         <td>{{ galley.label }}</td>
                         <td>{{ galley.file.original_filename|truncatechars:40 }}</td>
                         <td>Galley</td>
-                        <td>{{ galley.file.date_modified|date:"Y-m-d G:i" }}</td>
+                        <td>{{ galley.file.last_modified|date:"Y-m-d G:i" }}</td>
                         <td><a href="{% url 'edit_galley' typeset_task.pk galley.pk %}" class="fa fa-edit"></a></td>
                         <td>{% if can_view_file_flag %}
                             <a href="{% url 'article_file_download' 'id' article.pk galley.file.pk %}"><i
@@ -161,7 +161,7 @@
                     <tr>
                         <td>{{ file.original_filename|truncatechars:40 }}</td>
                         <td>Source File</td>
-                        <td>{{ file.date_modified|date:"Y-m-d G:i" }}</td>
+                        <td>{{ file.last_modified|date:"Y-m-d G:i" }}</td>
                         <td>{% if can_view_file_flag %}
                             <a href="{% url 'article_file_download' 'id' article.pk file.pk %}"><i
                                     class="fa fa-download">&nbsp;</i></a>{% endif %}

--- a/src/templates/admin/proofing/proofing_article.html
+++ b/src/templates/admin/proofing/proofing_article.html
@@ -186,7 +186,7 @@
                             <td>{{ galley.label }}</td>
                             <td>{{ galley.file.original_filename|truncatechars:40 }}</td>
                             <td>Galley</td>
-                            <td>{{ galley.file.date_modified|date:"Y-m-d G:i" }}</td>
+                            <td>{{ galley.file.last_modified|date:"Y-m-d G:i" }}</td>
                             <td><a href="{% url 'pm_edit_galley' article.pk galley.pk %}" class="fa fa-edit"></a></td>
                             <td>{% if can_view_file_flag %}
                                 <a href="{% url 'article_file_download' 'id' article.pk galley.file.pk %}"><i

--- a/src/templates/admin/proofing/request_typesetting_changes.html
+++ b/src/templates/admin/proofing/request_typesetting_changes.html
@@ -68,7 +68,7 @@
                             <td><input type="checkbox" name="galleys_for_proofing" value="{{ galley.id }}"
                                        {% if galley in galleys %}checked="checked"{% endif %}></td>
                             <td>{{ galley.label }}</td>
-                            <td>{{ file.date_modified|date:"Y-m-d G:i" }}</td>
+                            <td>{{ file.last_modified|date:"Y-m-d G:i" }}</td>
                             <td>{{ galley.file.original_filename|truncatechars:40 }}</td>
                             <td>Galley {% if galley in proofing_task.galleys_for_proofing.all %}(Proofed){% else %}(Not Proofed){% endif %}</td>
                             <td>{% if can_view_file_flag %}
@@ -106,7 +106,7 @@
                                        {% if galley in galleys %}checked="checked"{% endif %}></td>
                             <td>{{ file.label }}</td>
                             <td>{{ file.original_filename|truncatechars:40 }}</td>
-                            <td>{{ file.date_modified|date:"Y-m-d G:i" }}</td>
+                            <td>{{ file.last_modified|date:"Y-m-d G:i" }}</td>
                             <td>Proofing</td>
                             <td>{% if can_view_file_flag %}
                                 <a href="{% url 'article_file_download' 'id' article.pk file.pk %}"><i

--- a/src/templates/admin/review/unassigned_article.html
+++ b/src/templates/admin/review/unassigned_article.html
@@ -156,7 +156,7 @@
                                 <td>{{ file.label }}</td>
                                 <td>{{ file.original_filename }}</td>
                                 <td>Manuscript</td>
-                                <td>{{ file.date_modified|date:"Y-m-d G:i" }}</td>
+                                <td>{{ file.last_modified|date:"Y-m-d G:i" }}</td>
                                 <td><a href="{% url 'article_file_download' 'id' article.pk file.pk %}"><i
                                         class="fa fa-download">&nbsp;</i></a></td>
                                 <td>
@@ -185,7 +185,7 @@
                             <td>{{ file.label }}</td>
                             <td>{{ file.original_filename }}</td>
                             <td>Data/Figure</td>
-                            <td>{{ file.date_modified|date:"Y-m-d G:i" }}</td>
+                            <td>{{ file.last_modified|date:"Y-m-d G:i" }}</td>
                             <td><a href="{% url 'article_file_download' 'id' article.pk file.pk %}"><i
                                     class="fa fa-download">&nbsp;</i></a></td>
                             <td>n/a</td>


### PR DESCRIPTION
- Swaps date_modified for last_modified across the core
- Adds a date_modified property for backwads compat
- PR added to Typesetting where this is used extensively: https://github.com/BirkbeckCTP/typesetting/pull/165
- Closes #2904