### PR TITLE
Bugfixes for popular and featured homepage elements

### DIFF
--- a/src/themes/OLH/templates/journal/homepage_elements/featured.html
+++ b/src/themes/OLH/templates/journal/homepage_elements/featured.html
@@ -12,18 +12,20 @@
                     <a href="{% if fa.article.is_remote %}{{ fa.article.remote_url }}{% else %}{{ fa.article.url }}{% endif %}"
                        class="box-link"></a>
 
-                    {% if fa.article.large_image_file %}
-                        <img src="{% url 'article_file_download' 'id' fa.article.id fa.article.large_image_file.id %}"
-                             alt="{{ article.title|striptags }}" class="feature-article-image">
-                    {% elif fa.article.issue.large_image %}
-                        <img src="{{ fa.article.issue.large_image.url }}"
-                             alt="{{ article.title|striptags }}" class="feature-article-image">
-                    {% elif fa.article.journal.default_large_image %}
-                        <img src="{{ fa.article.journal.default_large_image.url }}"
-                             alt="{{ article.title|striptags }}" class="feature-article-image">
-                    {% else  %}
-                        <img src="{% static 'common/img/sample/article-small.jpg' %}"
-                             alt="{{ article.title|striptags }}" class="feature-article-image">
+                    {% if not journal.disable_article_images %}
+                        {% if fa.article.large_image_file %}
+                            <img src="{% url 'article_file_download' 'id' fa.article.id fa.article.large_image_file.id %}"
+                                 alt="{{ article.title|striptags }}" class="feature-article-image">
+                        {% elif fa.article.issue.large_image %}
+                            <img src="{{ fa.article.issue.large_image.url }}"
+                                 alt="{{ article.title|striptags }}" class="feature-article-image">
+                        {% elif fa.article.journal.default_large_image %}
+                            <img src="{{ fa.article.journal.default_large_image.url }}"
+                                 alt="{{ article.title|striptags }}" class="feature-article-image">
+                        {% else  %}
+                            <img src="{% static 'common/img/sample/article-small.jpg' %}"
+                                 alt="{{ article.title|striptags }}" class="feature-article-image">
+                        {% endif %}
                     {% endif %}
 
                     <div class="content">

--- a/src/themes/OLH/templates/journal/homepage_elements/featured.html
+++ b/src/themes/OLH/templates/journal/homepage_elements/featured.html
@@ -15,6 +15,9 @@
                     {% if fa.article.large_image_file %}
                         <img src="{% url 'article_file_download' 'id' fa.article.id fa.article.large_image_file.id %}"
                              alt="{{ article.title|striptags }}" class="feature-article-image">
+                    {% elif fa.article.issue.large_image %}
+                        <img src="{{ fa.article.issue.large_image.url }}"
+                             alt="{{ article.title|striptags }}" class="feature-article-image">
                     {% elif fa.article.journal.default_large_image %}
                         <img src="{{ fa.article.journal.default_large_image.url }}"
                              alt="{{ article.title|striptags }}" class="feature-article-image">

--- a/src/themes/OLH/templates/journal/homepage_elements/popular.html
+++ b/src/themes/OLH/templates/journal/homepage_elements/popular.html
@@ -15,6 +15,9 @@
                     {% if article.large_image_file %}
                         <img src="{% url 'article_file_download' 'id' article.id article.large_image_file.id %}"
                              alt="{{ article.title|striptags }}" class="feature-article-image">
+                    {% elif article.issue.large_image %}
+                        <img src="{{ article.issue.large_image.url }}"
+                             alt="{{ article.title|striptags }}" class="feature-article-image">
                     {% elif article.journal.default_large_image %}
                         <img src="{{ article.journal.default_large_image.url }}"
                              alt="{{ article.title|striptags }}" class="feature-article-image">

--- a/src/themes/OLH/templates/journal/homepage_elements/popular.html
+++ b/src/themes/OLH/templates/journal/homepage_elements/popular.html
@@ -12,18 +12,20 @@
                     <a href="{% if article.is_remote %}{{ article.remote_url }}{% else %}{{ article.url }}{% endif %}"
                        class="box-link"></a>
 
-                    {% if article.large_image_file %}
-                        <img src="{% url 'article_file_download' 'id' article.id article.large_image_file.id %}"
-                             alt="{{ article.title|striptags }}" class="feature-article-image">
-                    {% elif article.issue.large_image %}
-                        <img src="{{ article.issue.large_image.url }}"
-                             alt="{{ article.title|striptags }}" class="feature-article-image">
-                    {% elif article.journal.default_large_image %}
-                        <img src="{{ article.journal.default_large_image.url }}"
-                             alt="{{ article.title|striptags }}" class="feature-article-image">
-                    {% else  %}
-                        <img src="{% static 'common/img/sample/article-small.jpg' %}"
-                             alt="{{ article.title|striptags }}" class="feature-article-image">
+                    {% if not journal.disable_article_images %}
+                        {% if article.large_image_file %}
+                            <img src="{% url 'article_file_download' 'id' article.id article.large_image_file.id %}"
+                                 alt="{{ article.title|striptags }}" class="feature-article-image">
+                        {% elif article.issue.large_image %}
+                            <img src="{{ article.issue.large_image.url }}"
+                                 alt="{{ article.title|striptags }}" class="feature-article-image">
+                        {% elif article.journal.default_large_image %}
+                            <img src="{{ article.journal.default_large_image.url }}"
+                                 alt="{{ article.title|striptags }}" class="feature-article-image">
+                        {% else  %}
+                            <img src="{% static 'common/img/sample/article-small.jpg' %}"
+                                 alt="{{ article.title|striptags }}" class="feature-article-image">
+                        {% endif %}
                     {% endif %}
 
                     <div class="content">

--- a/src/themes/clean/templates/journal/homepage_elements/featured.html
+++ b/src/themes/clean/templates/journal/homepage_elements/featured.html
@@ -8,8 +8,12 @@
     {% for fa in featured_articles %}
         <div class="col-md-4 row-eq-height">
             <div class="card">
-              {% if fa.article.large_image_file %}
+                {% if fa.article.large_image_file %}
                     <img src="{% url 'article_file_download' 'id' fa.article.id fa.article.large_image_file.id %}"
+                         alt="{{ article.title|striptags }}"
+                         class="card-img-top">
+                {% elif fa.article.issue.large_image %}
+                    <img src="{{ fa.article.issue.large_image.url }}"
                          alt="{{ article.title|striptags }}"
                          class="card-img-top">
                 {% elif fa.article.journal.default_large_image %}

--- a/src/themes/clean/templates/journal/homepage_elements/featured.html
+++ b/src/themes/clean/templates/journal/homepage_elements/featured.html
@@ -8,22 +8,24 @@
     {% for fa in featured_articles %}
         <div class="col-md-4 row-eq-height">
             <div class="card">
-                {% if fa.article.large_image_file %}
-                    <img src="{% url 'article_file_download' 'id' fa.article.id fa.article.large_image_file.id %}"
-                         alt="{{ article.title|striptags }}"
-                         class="card-img-top">
-                {% elif fa.article.issue.large_image %}
-                    <img src="{{ fa.article.issue.large_image.url }}"
-                         alt="{{ article.title|striptags }}"
-                         class="card-img-top">
-                {% elif fa.article.journal.default_large_image %}
-                    <img src="{{ fa.article.journal.default_large_image.url }}"
-                         alt="{{ article.title|striptags }}"
-                         class="card-img-top">
-                {% else %}
-                    <img src="{% static 'common/img/sample/article-small.jpg' %}"
-                         alt="{{ article.title|striptags }}"
-                         class="card-img-top">
+                {% if not journal.disable_article_images %}
+                    {% if fa.article.large_image_file %}
+                        <img src="{% url 'article_file_download' 'id' fa.article.id fa.article.large_image_file.id %}"
+                             alt="{{ article.title|striptags }}"
+                             class="card-img-top">
+                    {% elif fa.article.issue.large_image %}
+                        <img src="{{ fa.article.issue.large_image.url }}"
+                             alt="{{ article.title|striptags }}"
+                             class="card-img-top">
+                    {% elif fa.article.journal.default_large_image %}
+                        <img src="{{ fa.article.journal.default_large_image.url }}"
+                             alt="{{ article.title|striptags }}"
+                             class="card-img-top">
+                    {% else %}
+                        <img src="{% static 'common/img/sample/article-small.jpg' %}"
+                             alt="{{ article.title|striptags }}"
+                             class="card-img-top">
+                    {% endif %}
                 {% endif %}
               <div class="card-body">
                 <p class="card-text">{{ fa.article.author_list }}</p>

--- a/src/themes/clean/templates/journal/homepage_elements/popular.html
+++ b/src/themes/clean/templates/journal/homepage_elements/popular.html
@@ -16,6 +16,10 @@
                     <img src="{% url 'article_file_download' 'id' article.id article.large_image_file.id %}"
                          alt="{{ article.title|striptags }}"
                          class="card-img-top">
+                {% elif article.issue.large_image %}
+                    <img src="{{ article.issue.large_image.url }}"
+                         alt="{{ article.title|striptags }}"
+                         class="card-img-top">
                 {% elif article.journal.default_large_image %}
                     <img src="{{ article.journal.default_large_image.url }}"
                          alt="{{ article.title|striptags }}"

--- a/src/themes/clean/templates/journal/homepage_elements/popular.html
+++ b/src/themes/clean/templates/journal/homepage_elements/popular.html
@@ -12,22 +12,24 @@
     {% for article in popular_articles %}
         <div class="col-md-4 row-eq-height">
             <div class="card">
-                {% if article.large_image_file %}
-                    <img src="{% url 'article_file_download' 'id' article.id article.large_image_file.id %}"
-                         alt="{{ article.title|striptags }}"
-                         class="card-img-top">
-                {% elif article.issue.large_image %}
-                    <img src="{{ article.issue.large_image.url }}"
-                         alt="{{ article.title|striptags }}"
-                         class="card-img-top">
-                {% elif article.journal.default_large_image %}
-                    <img src="{{ article.journal.default_large_image.url }}"
-                         alt="{{ article.title|striptags }}"
-                         class="card-img-top">
-                {% else %}
-                    <img src="{% static 'common/img/sample/article-small.jpg' %}"
-                         alt="{{ article.title|striptags }}"
-                         class="card-img-top">
+                {% if not journal.disable_article_images %}
+                    {% if article.large_image_file %}
+                        <img src="{% url 'article_file_download' 'id' article.id article.large_image_file.id %}"
+                             alt="{{ article.title|striptags }}"
+                             class="card-img-top">
+                    {% elif article.issue.large_image %}
+                        <img src="{{ article.issue.large_image.url }}"
+                             alt="{{ article.title|striptags }}"
+                             class="card-img-top">
+                    {% elif article.journal.default_large_image %}
+                        <img src="{{ article.journal.default_large_image.url }}"
+                             alt="{{ article.title|striptags }}"
+                             class="card-img-top">
+                    {% else %}
+                        <img src="{% static 'common/img/sample/article-small.jpg' %}"
+                             alt="{{ article.title|striptags }}"
+                             class="card-img-top">
+                    {% endif %}
                 {% endif %}
                 <div class="card-body">
                     <p class="card-text">{{ article.author_list }}</p>

--- a/src/themes/material/templates/journal/homepage_elements/featured.html
+++ b/src/themes/material/templates/journal/homepage_elements/featured.html
@@ -13,6 +13,10 @@
                         <img src="{% url 'article_file_download' 'id' fa.article.id fa.article.large_image_file.id %}"
                              alt="{{ article.title|striptags }}"
                              class="feature-article-image">
+                    {% elif fa.article.issue.large_image %}
+                        <img src="{{ fa.article.issue.large_image.url }}"
+                             alt="{{ article.title|striptags }}"
+                             class="feature-article-image">
                     {% elif fa.article.journal.default_large_image %}
                         <img src="{{ fa.article.journal.default_large_image.url }}"
                              alt="{{ article.title|striptags }}"

--- a/src/themes/material/templates/journal/homepage_elements/featured.html
+++ b/src/themes/material/templates/journal/homepage_elements/featured.html
@@ -7,24 +7,26 @@
     </div>
     {% for fa in featured_articles %}
         <div class="col m4">
-            <div class="card feature-article-card">
+            <div {% if journal.disable_article_images %}class="card"{% else %}class="card feature-article-card"{% endif %}>
                 <div class="card-content">
-                    {% if fa.article.large_image_file %}
-                        <img src="{% url 'article_file_download' 'id' fa.article.id fa.article.large_image_file.id %}"
-                             alt="{{ article.title|striptags }}"
-                             class="feature-article-image">
-                    {% elif fa.article.issue.large_image %}
-                        <img src="{{ fa.article.issue.large_image.url }}"
-                             alt="{{ article.title|striptags }}"
-                             class="feature-article-image">
-                    {% elif fa.article.journal.default_large_image %}
-                        <img src="{{ fa.article.journal.default_large_image.url }}"
-                             alt="{{ article.title|striptags }}"
-                             class="feature-article-image">
-                    {% else %}
-                        <img src="{% static 'common/img/sample/article-small.jpg' %}"
-                             alt="{{ article.title|striptags }}"
-                             class="feature-article-image">
+                    {% if not journal.disable_article_images %}
+                        {% if fa.article.large_image_file %}
+                            <img src="{% url 'article_file_download' 'id' fa.article.id fa.article.large_image_file.id %}"
+                                 alt="{{ article.title|striptags }}"
+                                 class="feature-article-image">
+                        {% elif fa.article.issue.large_image %}
+                            <img src="{{ fa.article.issue.large_image.url }}"
+                                 alt="{{ article.title|striptags }}"
+                                 class="feature-article-image">
+                        {% elif fa.article.journal.default_large_image %}
+                            <img src="{{ fa.article.journal.default_large_image.url }}"
+                                 alt="{{ article.title|striptags }}"
+                                 class="feature-article-image">
+                        {% else %}
+                            <img src="{% static 'common/img/sample/article-small.jpg' %}"
+                                 alt="{{ article.title|striptags }}"
+                                 class="feature-article-image">
+                        {% endif %}
                     {% endif %}
                     <p>
                         <a href="{% if fa.article.is_remote %}{{ fa.article.remote_url }}{% else %}{{ fa.article.url }}{% endif %}">

--- a/src/themes/material/templates/journal/homepage_elements/popular.html
+++ b/src/themes/material/templates/journal/homepage_elements/popular.html
@@ -13,6 +13,10 @@
                         <img src="{% url 'article_file_download' 'id' article.id article.large_image_file.id %}"
                              alt="{{ article.title|striptags }}"
                              class="feature-article-image">
+                    {% elif article.issue.large_image %}
+                        <img src="{{ article.issue.large_image.url }}"
+                             alt="{{ article.title|striptags }}"
+                             class="feature-article-image">
                     {% elif article.journal.default_large_image %}
                         <img src="{{ article.journal.default_large_image.url }}"
                              alt="{{ article.title|striptags }}"

--- a/src/themes/material/templates/journal/homepage_elements/popular.html
+++ b/src/themes/material/templates/journal/homepage_elements/popular.html
@@ -7,24 +7,26 @@
     </div>
     {% for article in popular_articles %}
         <div class="col m4">
-            <div class="card feature-article-card">
+            <div {% if journal.disable_article_images %}class="card"{% else %}class="card feature-article-card"{% endif %}>
                 <div class="card-content">
-                    {% if article.large_image_file %}
-                        <img src="{% url 'article_file_download' 'id' article.id article.large_image_file.id %}"
-                             alt="{{ article.title|striptags }}"
-                             class="feature-article-image">
-                    {% elif article.issue.large_image %}
-                        <img src="{{ article.issue.large_image.url }}"
-                             alt="{{ article.title|striptags }}"
-                             class="feature-article-image">
-                    {% elif article.journal.default_large_image %}
-                        <img src="{{ article.journal.default_large_image.url }}"
-                             alt="{{ article.title|striptags }}"
-                             class="feature-article-image">
-                    {% else %}
-                        <img src="{% static 'common/img/sample/article-small.jpg' %}"
-                             alt="{{ article.title|striptags }}"
-                             class="feature-article-image">
+                    {% if not journal.disable_article_images %}
+                        {% if article.large_image_file %}
+                            <img src="{% url 'article_file_download' 'id' article.id article.large_image_file.id %}"
+                                 alt="{{ article.title|striptags }}"
+                                 class="feature-article-image">
+                        {% elif article.issue.large_image %}
+                            <img src="{{ article.issue.large_image.url }}"
+                                 alt="{{ article.title|striptags }}"
+                                 class="feature-article-image">
+                        {% elif article.journal.default_large_image %}
+                            <img src="{{ article.journal.default_large_image.url }}"
+                                 alt="{{ article.title|striptags }}"
+                                 class="feature-article-image">
+                        {% else %}
+                            <img src="{% static 'common/img/sample/article-small.jpg' %}"
+                                 alt="{{ article.title|striptags }}"
+                                 class="feature-article-image">
+                        {% endif %}
                     {% endif %}
                     <p>
                         <a href="{% if article.is_remote %}{{ article.remote_url }}{% else %}{{ article.url }}{% endif %}">


### PR DESCRIPTION
Closes #2460 and closes #3075:
- Includes large image of issue as fallback on popular and featured homepage elements
- Makes disabling article images work in featured and popular elements