### PR TITLE
Fix logic on issue assignment during prepublication checklist

### DIFF
--- a/src/journal/logic.py
+++ b/src/journal/logic.py
@@ -200,6 +200,9 @@ def handle_assign_issue(request, article, issues):
         if issue_to_assign in issues:
             issue_to_assign.articles.add(article)
             issue_to_assign.save()
+            if not article.primary_issue:
+                article.primary_issue = issue_to_assign
+                article.save()
             messages.add_message(request, messages.SUCCESS, 'Article assigned to issue.')
         else:
 
@@ -215,6 +218,12 @@ def handle_unassign_issue(request, article, issues):
         if issue_to_unassign in issues:
             issue_to_unassign.articles.remove(article)
             issue_to_unassign.save()
+            if issue_to_unassign == article.primary_issue:
+                if article.issues_list().exists():
+                    article.primary_issue = article.issues_list().first()
+                else:
+                    article.primary_issue = None
+                article.save()
             messages.add_message(request, messages.SUCCESS, 'Article unassigned from Issue.')
         else:
 

--- a/src/journal/logic.py
+++ b/src/journal/logic.py
@@ -200,9 +200,6 @@ def handle_assign_issue(request, article, issues):
         if issue_to_assign in issues:
             issue_to_assign.articles.add(article)
             issue_to_assign.save()
-            if not article.primary_issue:
-                article.primary_issue = issue_to_assign
-                article.save()
             messages.add_message(request, messages.SUCCESS, 'Article assigned to issue.')
         else:
 
@@ -218,12 +215,6 @@ def handle_unassign_issue(request, article, issues):
         if issue_to_unassign in issues:
             issue_to_unassign.articles.remove(article)
             issue_to_unassign.save()
-            if issue_to_unassign == article.primary_issue:
-                if article.issues_list().exists():
-                    article.primary_issue = article.issues_list().first()
-                else:
-                    article.primary_issue = None
-                article.save()
             messages.add_message(request, messages.SUCCESS, 'Article unassigned from Issue.')
         else:
 

--- a/src/journal/models.py
+++ b/src/journal/models.py
@@ -1114,6 +1114,13 @@ def issue_articles_change(sender, **kwargs):
                 except ArticleOrdering.DoesNotExist:
                     pass
 
+                if issue == article.primary_issue:
+                    if article.issues_list().exists():
+                        article.primary_issue = article.issues_list().first()
+                    else:
+                        article.primary_issue = None
+                    article.save()
+
             elif action == 'post_add':
                 ArticleOrdering.objects.get_or_create(
                     issue=issue,
@@ -1122,5 +1129,8 @@ def issue_articles_change(sender, **kwargs):
                     order=issue.next_order(),
                 )
 
+                if not article.primary_issue:
+                    article.primary_issue = issue
+                    article.save()
 
 m2m_changed.connect(issue_articles_change, sender=Issue.articles.through)

--- a/src/templates/admin/elements/publish/issues.html
+++ b/src/templates/admin/elements/publish/issues.html
@@ -22,22 +22,23 @@
                 <h6>Issues</h6>
                 <table class="scroll">
                     <tr>
-                        <th>Title</th>
-                        <th>Volume</th>
-                        <th>Number</th>
+                        <th>Display Title</th>
                         <th>Date</th>
+                        <th>Primary</th>
                         <th></th>
                     </tr>
                 {% for issue in issues %}
                     <tr{% if issue.pk == article.projected_issue.pk %} style="background-color: darkseagreen;"{% endif %}>
-                        <td>{{ issue.issue_title }}</td>
-                        <td>{{ issue.volume }}</td>
-                        <td>{{ issue.issue }}</td>
+                        <td>{{ issue.display_title }}</td>
                         <td>{{ issue.date|date:"Y-m-d" }}</td>
+                        <td>
+                            {% if article.primary_issue == issue %}
+                                <i class="fa fa-check-circle-o" style="color: green;"></i> Primary
+                            {% endif %}
                         <td>
                             {% if issue in article.issues_list %}
                             <button name="unassign_issue" value="{{ issue.pk }}", type="submit" class="tiny alert button">
-                                <i class="fa fa-plus">&nbsp;</i>Unassign
+                                <i class="fa fa-minus">&nbsp;</i>Unassign
                             </button>
                             {% else %}
                             <button name="assign_issue" value="{{ issue.pk }}", type="submit" class="tiny success button">

--- a/src/themes/OLH/templates/elements/journal/article_issue_list.html
+++ b/src/themes/OLH/templates/elements/journal/article_issue_list.html
@@ -6,7 +6,9 @@
 <ul>
     {% if article.primary_issue %}
         <li>
-            <a href="{% url 'journal_issue' article.primary_issue.pk %}">{{ article.primary_issue.display_title }}</a>
+            <a href="{% url 'journal_issue' article.primary_issue.pk %}">
+                {% if article.issues_list.count > 1 %}{% trans 'Primary: ' %}{% endif %}{{ article.primary_issue.display_title }}
+            </a>
             {% if journal_settings.article.display_guest_editors %}
             <br />
             {% include "common/elements/guest_editors.html" with issue=article.primary_issue small="small" %}

--- a/src/themes/clean/templates/elements/journal/article_issue_list.html
+++ b/src/themes/clean/templates/elements/journal/article_issue_list.html
@@ -1,10 +1,13 @@
+
 {% with issue_length=article.issues_list|length %}
     <h4>{% if issue_length > 1 %}Issues{% else %}Issue{% endif %}</h4>
 {% endwith %}
 <ul>
     {% if article.primary_issue %}
         <li>
-            <a href="{% url 'journal_issue' article.primary_issue.pk %}">{{ article.primary_issue.display_title }}</a>
+            <a href="{% url 'journal_issue' article.primary_issue.pk %}">
+                {% if article.issues_list.count > 1 %}{% trans 'Primary: ' %}{% endif %}{{ article.primary_issue.display_title }}
+            </a>
             {% if journal_settings.article.display_guest_editors %}
                 <br/>
                 {% include "common/elements/guest_editors.html" with issue=article.primary_issue small="small" %}


### PR DESCRIPTION
In addition to the logic changes specified in the bug description, I've made the primary issue visible on the modal:

![Peek 2022-07-26 16-33](https://user-images.githubusercontent.com/47217308/181054508-b73c091b-1467-4620-9467-9215955b2332.gif)

I've also added "Primary" before the primary issue in the OLH and material theme sidebars for consistency, since we prepend the name of the issue type (e.g. "Collection" or "Issue") for subsequent issues in the issue list).