### PR TITLE
Document and test reply-to setting

### DIFF
--- a/docs/source/manager/journal/index.rst
+++ b/docs/source/manager/journal/index.rst
@@ -13,6 +13,7 @@ The general journal settings page is home to various configuration settings for 
 
 - Journal information (title, ISSN, description, keywords, design theme)
 - Publisher information (name, website, contact)
+- Email settings for system-generated emails
 - Remote website settings
 - Language settings
 - Integration with Slack or Discord

--- a/src/core/logic.py
+++ b/src/core/logic.py
@@ -411,6 +411,7 @@ def get_settings_to_edit(display_group, journal):
             'use_ga_four', 'display_login_page_notice', 'login_page_notice', 
             'display_register_page_notice', 'register_page_notice',
             'support_email', 'support_contact_message_for_staff',
+            'replyto_address',
         ]
 
         settings = process_setting_list(journal_settings, 'general', journal)

--- a/src/templates/admin/elements/forms/group_journal.html
+++ b/src/templates/admin/elements/forms/group_journal.html
@@ -28,6 +28,7 @@
     <p>{% trans 'You can set the from address your journal will use to send emails and the base signature that will be included.' %}</p>
     {% include "admin/elements/forms/field.html" with field=edit_form.from_address %}
     {% include "admin/elements/forms/field.html" with field=edit_form.auto_signature %}
+    {% include "admin/elements/forms/field.html" with field=edit_form.replyto_address%}
 </div>
 
 <div class="title-area">

--- a/src/utils/install/journal_defaults.json
+++ b/src/utils/install/journal_defaults.json
@@ -154,7 +154,7 @@
             "name": "general"
         },
         "setting": {
-            "description": "Addres set as the 'Reply-to' for system emails.",
+            "description": "Address set as the 'Reply-to' for system emails.",
             "is_translatable": false,
             "name": "replyto_address",
             "pretty_name": "Reply-To Address",

--- a/src/utils/tests.py
+++ b/src/utils/tests.py
@@ -9,16 +9,18 @@ from django.test import TestCase, override_settings
 from django.utils import timezone
 from django.core import mail
 from django.contrib.contenttypes.models import ContentType
+import mock
 
 from utils import merge_settings, transactional_emails, models, oidc
 from utils.forms import FakeModelForm, KeywordModelForm
 from utils.logic import generate_sitemap
 from utils.testing import helpers
+from utils.notify_plugins import notify_email
 from journal import models as journal_models
 from review import models as review_models
 from submission import models as submission_models
 from utils.install import update_xsl_files
-from core import models as core_models
+from core import models as core_models, include_urls
 
 
 class UtilsTests(TestCase):
@@ -316,6 +318,36 @@ class TestModels(TestCase):
         log_entries = models.LogEntry.objects.filter(types='Submission')
         articles = [entry.target for entry in log_entries]
         self.assertEqual(self.ten_articles, articles)
+
+
+class NotifyEmail(TestCase):
+
+    @classmethod
+    def setUpTestData(cls):
+        helpers.create_press()
+        cls.journal_one, cls.journal_two = helpers.create_journals()
+        cls.request = mock.Mock()
+        cls.request.site_type.name = 'Mock request site type name'
+        cls.request.FILES = None
+
+    def test_send_email_reply_to(self):
+        args = [
+            'subject',
+            'to@example.com',
+            'html_body',
+            self.journal_one,
+            self.request,
+        ]
+
+        kwargs = {
+            'bcc': 'bcc@example.com',
+            'cc': 'cc@example.com',
+            'replyto': 'replyto@example.com',
+        }
+
+        with mock.patch('utils.notify_plugins.notify_email.EmailMultiAlternatives') as msg:
+            notify_email.send_email(*args, **kwargs)
+            self.assertIn(kwargs['replyto'], msg.call_args.kwargs['reply_to'])
 
 
 class TestOIDC(TestCase):


### PR DESCRIPTION
Closes #2667.

We actually already have a setting for reply-to email addresses, it just wasn't very visible. The changes in this branch add it to the general journal settings page and mention it in the documentation, as well as testing existing functionality.