### PR TITLE
3015 editors can now send author copyedit review notifications if they are initially skipped. Editors can also delete uncomplete author reviews with an optioinal email notification.

### DIFF
--- a/src/copyediting/logic.py
+++ b/src/copyediting/logic.py
@@ -21,11 +21,16 @@ def get_copyeditors(article):
     :param article: a Article object
     :return: a queryset of AccountRole objects
     """
-    copyeditor_assignments = models.CopyeditAssignment.objects.filter(article=article)
-    copyeditors = [assignment.copyeditor.pk for assignment in copyeditor_assignments]
-
-    return core_models.AccountRole.objects.filter(role__slug='copyeditor',
-                                                  journal=article.journal).exclude(user__pk__in=copyeditors)
+    copyeditor_assignments = models.CopyeditAssignment.objects.filter(
+        article=article,
+        copyedit_accepted__isnull=True,
+    ).values('copyeditor__id')
+    return core_models.AccountRole.objects.filter(
+        role__slug='copyeditor',
+        journal=article.journal
+    ).exclude(
+        user__pk__in=copyeditor_assignments,
+    )
 
 
 def get_user_from_post(request):

--- a/src/copyediting/logic.py
+++ b/src/copyediting/logic.py
@@ -138,15 +138,19 @@ def request_author_review(request, article, copyedit, author_review):
     :return:
     """
     user_message_content = request.POST.get('content_email')
-
+    skip = True if 'skip' in request.POST else False
     kwargs = {
         'copyedit_assignment': copyedit,
         'article': article,
         'author_review': author_review,
         'user_message_content': user_message_content,
         'request': request,
-        'skip': True if 'skip' in request.POST else False,
+        'skip': skip,
     }
+
+    if not skip:
+        author_review.notified = True
+        author_review.save()
 
     event_logic.Events.raise_event(
         event_logic.Events.ON_COPYEDIT_AUTHOR_REVIEW, **kwargs)

--- a/src/copyediting/models.py
+++ b/src/copyediting/models.py
@@ -48,6 +48,9 @@ class CopyeditAssignment(models.Model):
 
     copyedit_acknowledged = models.BooleanField(default=False)
 
+    class Meta:
+        ordering = ('assigned',)
+
     def __str__(self):
         return "Assignment of {0} to {1}".format(self.copyeditor.full_name(), self.article.title)
 

--- a/src/copyediting/urls.py
+++ b/src/copyediting/urls.py
@@ -24,6 +24,8 @@ urlpatterns = [
         name='editor_review'),
     url(r'^article/(?P<article_id>\d+)/assignment/(?P<copyedit_id>\d+)/author_review/(?P<author_review_id>\d+)/$', views.request_author_copyedit,
         name='request_author_copyedit'),
+    url(r'^article/(?P<article_id>\d+)/assignment/(?P<copyedit_id>\d+)/author_review/(?P<author_review_id>\d+)/delete/$', views.delete_author_review,
+        name='delete_author_review'),
 
     # Author URLs
     url(r'^author/article/(?P<article_id>\d+)/assignment/(?P<author_review_id>\d+)/$', views.author_copyedit,

--- a/src/copyediting/views.py
+++ b/src/copyediting/views.py
@@ -10,7 +10,6 @@ from django.db.models import Q
 from django.http import Http404
 from django.shortcuts import render, get_object_or_404, redirect
 from django.utils import timezone
-from django.views.decorators.http import require_POST
 
 from copyediting import models, logic, forms
 from core import models as core_models, files

--- a/src/copyediting/views.py
+++ b/src/copyediting/views.py
@@ -10,6 +10,7 @@ from django.db.models import Q
 from django.http import Http404
 from django.shortcuts import render, get_object_or_404, redirect
 from django.utils import timezone
+from django.views.decorators.http import require_POST
 
 from copyediting import models, logic, forms
 from core import models as core_models, files
@@ -466,7 +467,6 @@ def editor_review(request, article_id, copyedit_id):
             author_review = models.AuthorReview.objects.create(
                 author=article.correspondence_author,
                 assignment=copyedit,
-                notified=True
             )
             return redirect(
                 reverse(
@@ -572,6 +572,71 @@ def request_author_copyedit(request, article_id, copyedit_id,
     }
 
     return render(request, template, context)
+
+
+@editor_user_required
+def delete_author_review(request, article_id, copyedit_id, author_review_id):
+    author_review = get_object_or_404(
+        models.AuthorReview,
+        pk=author_review_id,
+        assignment__article__journal=request.journal,
+    )
+    email_template = logic.get_copyedit_message(
+        request,
+        article=author_review.assignment.article,
+        copyedit=author_review.assignment,
+        template='author_copyedit_deleted',
+        author_review=author_review,
+    )
+    email_subject = request.journal.get_setting(
+        'email_subject',
+        'subject_author_copyedit_deleted',
+    )
+
+    if request.POST:
+        event_kwargs = {
+            'user_message_content': request.POST.get('user_message_content'),
+            'subject': email_subject,
+            'author_review': author_review,
+            'request': request,
+            'skip': True if 'skip' in request.POST else False
+        }
+        event_logic.Events.raise_event(
+            event_logic.Events.ON_COPYEDIT_AUTHOR_REVIEW_DELETED,
+            **event_kwargs,
+        )
+        messages.add_message(
+            request,
+            messages.SUCCESS,
+            'Author review for {} has been deleted.'.format(
+                author_review.assignment.article.title,
+            )
+        )
+        author_review.delete()
+
+        return redirect(
+            reverse(
+                'editor_review',
+                kwargs={
+                    'article_id': article_id,
+                    'copyedit_id': copyedit_id,
+                }
+            )
+        )
+
+    template = 'admin/copyediting/delete_author_review.html'
+    context = {
+        'author_review': author_review,
+        'article': author_review.assignment.article,
+        'copyedit': author_review.assignment,
+        'email_template': email_template,
+        'email_subject': email_subject,
+    }
+    return render(
+        request,
+        template,
+        context,
+    )
 
 
 @article_author_required

--- a/src/events/logic.py
+++ b/src/events/logic.py
@@ -108,6 +108,10 @@ class Events:
     # raised when an author completes their copyedit review
     ON_COPYEDIT_AUTHOR_REVIEW_COMPLETE = 'on_copyedit_author_review_complete'
 
+    # kwargs author_review, request
+    # raised when an author review is deleted
+    ON_COPYEDIT_AUTHOR_REVIEW_DELETED = 'on_copyedit_author_review_delete'
+
     # kwargs: article, copyeditor assignment, request, skip (boolean)
     # raised when a copyedit assignment is acknowledged
     ON_COPYEDIT_ACKNOWLEDGE = 'on_copyedit_acknowledge'

--- a/src/events/registration.py
+++ b/src/events/registration.py
@@ -64,6 +64,8 @@ event_logic.Events.register_for_event(event_logic.Events.ON_COPYEDIT_AUTHOR_REVI
                                       transactional_emails.send_copyedit_author_review)
 event_logic.Events.register_for_event(event_logic.Events.ON_COPYEDIT_AUTHOR_REVIEW_COMPLETE,
                                       transactional_emails.send_author_copyedit_complete)
+event_logic.Events.register_for_event(event_logic.Events.ON_COPYEDIT_AUTHOR_REVIEW_DELETED,
+                                      transactional_emails.send_author_copyedit_deleted)
 event_logic.Events.register_for_event(event_logic.Events.ON_COPYEDIT_ASSIGNMENT_COMPLETE,
                                       transactional_emails.send_copyedit_complete)
 event_logic.Events.register_for_event(event_logic.Events.ON_COPYEDIT_REOPEN,

--- a/src/templates/admin/copyediting/add_copyeditor_assignment.html
+++ b/src/templates/admin/copyediting/add_copyeditor_assignment.html
@@ -21,6 +21,7 @@
                 <a href="#" data-open="enrol" class="button">Enrol Users</a>
             </div>
             <div class="content">
+                <p>Select a copyeditor from the list of users below. <strong>Note: </strong> if a copyeditor already has an active copyediting task for this article they will not appear in the list, you should first close that task if you wish to assign them again.</p>
                 {% include "elements/forms/errors.html" with form=form %}
                 <table class="scroll small" id="copyeditor">
                     <thead>

--- a/src/templates/admin/copyediting/article_copyediting.html
+++ b/src/templates/admin/copyediting/article_copyediting.html
@@ -92,19 +92,26 @@
                                         <th>Notified</th>
                                         <th>Decision</th>
                                         <th>Decision Date</th>
+                                        <th></th>
                                     </tr>
                                     {% for review in assignment.author_reviews %}
                                         <tr>
                                         <td>{{ review.assigned|date:"Y-m-d" }}</td>
                                         <td>
                                             <i class="fa {% if review.notified %}fa-check-circle-o{% else %}fa-times-circle-o{% endif %}"></i>
+                                            {% if not review.notified %}<a href="{% url 'request_author_copyedit' article.pk assignment.pk review.pk %}"> <i class="fa fa-send-o"> </i> Send Notification</a>{% endif %}
                                         </td>
                                         <td>{% if review.decision %} {{ review.get_decision_display }} {% else %}
                                             Awaiting
                                             response{% endif %}</td>
-                                        <td>{% if review.date_decided %} {{ review.date_decided|date:"Y-m-d" }}
-                                    {% else %}--
-                                    {% endif %}
+                                        <td>{% if review.date_decided %} {{ review.date_decided|date:"Y-m-d" }}{% else %}--{% endif %}
+                                        <td>
+                                            {% if review.decision %}
+                                                 <a href="{% url 'editor_review' article.id assignment.id %}" class="button">Review</a>
+                                            {% else %}
+                                                <a href="{% url 'delete_author_review' article.id assignment.id review.pk %}" class="alert button delete">Delete Author Review</a>
+                                            {% endif %}
+                                        </td>
                                     {% endfor %}
                                 </table>
                             </div>

--- a/src/templates/admin/copyediting/delete_author_review.html
+++ b/src/templates/admin/copyediting/delete_author_review.html
@@ -1,0 +1,52 @@
+{% extends "admin/core/base.html" %}
+{% load static from staticfiles %}
+
+{% block title %}Delete Author Copyedit Request{% endblock %}
+{% block title-section %}
+    Delete Author Copyedit Request #{{ author_review.id }}
+{% endblock %}
+{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.title }}{% endblock %}
+
+{% block breadcrumbs %}
+    {{ block.super }}
+    {% include "elements/breadcrumbs/copyediting_base.html" %}
+    <li><a href="{% url 'editor_review' article.pk copyedit.pk %}">Review Copyediting</a></li>
+{% endblock breadcrumbs %}
+
+{% block body %}
+
+    <div class="box">
+        <div class="title-area">
+            <h2>Delete Author Copyedit Request</h2>
+        </div>
+        <div class="content">
+            <p>To delete this Author Copyedit Request, review the message below and, if needed, add a reason for the deletion. You can skip sending the email, this is particularly useful if you have not yet notified the author of the review request.</p>
+            <div class="card">
+                <form method="POST" enctype="multipart/form-data">
+                    {% csrf_token %}
+                    <div class="card-divider">
+                        <h4>To {{ copyedit.article.correspondence_author.full_name }}</h4>
+                        <h5>From {{ request.user.full_name }}</h5>
+                    </div>
+                    <div class="card-section">
+                         <p>Subject: <strong>{{ email_subject }}</strong></p>
+                        <textarea rows="10" name="user_message_content">{{ email_template|linebreaksbr }}</textarea>
+                        <label for="attachment"><p>Attachment (You can select multiple files): </p></label>
+                        <input type="file" name="attachment" multiple>
+                    </div>
+                    <div class="card-divider">
+                        <div class="button-group">
+                            <button type="submit" class="button success" name="send"><i class="fa fa-envelope-o">&nbsp;</i>Send</button>
+                            <button type="submit" class="button warning" name="skip"><i class="fa fa-step-forward">&nbsp;</i>Skip</button>
+                        </div>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+
+{% endblock %}
+
+{% block js %}
+	{% include "elements/jqte.html" %}
+{% endblock js %}

--- a/src/templates/admin/copyediting/editor_review.html
+++ b/src/templates/admin/copyediting/editor_review.html
@@ -81,6 +81,7 @@
                                 <th>Notified</th>
                                 <th>Decision</th>
                                 <th>Decision Date</th>
+                                <th></th>
                                 {% if request.user.is_admin %}<th></th>{% endif %}
                             </tr>
 
@@ -88,11 +89,19 @@
                                 <td>{{ review.assigned|date:"Y-m-d" }}</td>
                                 <td>
                                     <i class="fa {% if review.notified %}fa-check-circle-o{% else %}fa-times-circle-o{% endif %}"></i>
+                                            {% if not review.notified %}<a href="{% url 'request_author_copyedit' article.pk copyedit.pk review.pk %}"> <i class="fa fa-send-o"> </i> Send Notification</a>{% endif %}
                                 </td>
                                 <td>{% if review.decision %} {{ review.get_decision_display }} {% else %}Awaiting
                                     response{% endif %}</td>
                                 <td>{% if review.date_decided %} {{ review.date_decided|date:"Y-m-d" }} {% else %}
                                     --{% endif %}</td>
+                                <td>
+                                    {% if review.decision %}
+                                        <small>Cannot delete a completed author review.</small>
+                                    {% else %}
+                                        <a href="{% url 'delete_author_review' article.id copyedit.id review.pk %}" class="small alert button delete">Delete Author Review</a>
+                                    {% endif %}
+                                </td>
                                 {% if request.user.is_admin %}<td><a class="" target="_blank" href="{% url 'admin:copyediting_authorreview_change' review.pk %}"><span class="fa fa-cogs">&nbsp;</span>Edit in Admin</a></td>{% endif %}
                             </tr>
                         </table>

--- a/src/utils/install/journal_defaults.json
+++ b/src/utils/install/journal_defaults.json
@@ -774,9 +774,6 @@
             "name": "copyeditor_notify_author",
             "pretty_name": "Copyedit Notify Author",
             "type": "rich-text"
-        },
-        "value": {
-            "default": "Dear {{ assignment.article.correspondence_author.full_name }},<br/><br/>The copyeditor has completed their task, you can review the copyedits: {{ author_copyedit_url }} <br/><br/>Regards, <br/>{{ request.user.signature|safe }}"
         }
     },
     {
@@ -3462,6 +3459,36 @@
         },
         "value": {
             "default": "25"
+        }
+    },
+    {
+        "group": {
+            "name": "email"
+        },
+        "setting": {
+            "description": "Email sent to an author when an editor deletes their copyedit review task.",
+            "is_translatable": false,
+            "name": "author_copyedit_deleted",
+            "pretty_name": "Author Copyedit Deleted",
+            "type": "rich-text"
+        },
+        "value": {
+            "default": "<p>Dear {{ author_review.assignment.article.correspondence_author.full_name }},</p><p>The copyediting review request for \"{{ author_review.assignment.article.title|safe }}\" that we sent you has been deleted.</p><p>Regards,</p>{{ request.user.signature|safe }}"
+        }
+    },
+    {
+        "group": {
+            "name": "email_subject"
+        },
+        "setting": {
+            "description": "Subjedt for Author Copyedit Deleted email.",
+            "is_translatable": false,
+            "name": "subject_author_copyedit_deleted",
+            "pretty_name": "Author Copyedit Deleted Subject",
+            "type": "text"
+        },
+        "value": {
+            "default": "Copyedit Review Request Deleted"
         }
     }
 

--- a/src/utils/install/journal_defaults.json
+++ b/src/utils/install/journal_defaults.json
@@ -774,6 +774,9 @@
             "name": "copyeditor_notify_author",
             "pretty_name": "Copyedit Notify Author",
             "type": "rich-text"
+        },
+        "value": {
+            "default": "Dear {{ assignment.article.correspondence_author.full_name }},<br/><br/>The copyeditor has completed their task, you can review the copyedits: {{ author_copyedit_url }} <br/><br/>Regards, <br/>{{ request.user.signature|safe }}"
         }
     },
     {
@@ -3481,7 +3484,7 @@
             "name": "email_subject"
         },
         "setting": {
-            "description": "Subjedt for Author Copyedit Deleted email.",
+            "description": "Subject for Author Copyedit Deleted email.",
             "is_translatable": false,
             "name": "subject_author_copyedit_deleted",
             "pretty_name": "Author Copyedit Deleted Subject",

--- a/src/utils/transactional_emails.py
+++ b/src/utils/transactional_emails.py
@@ -680,6 +680,44 @@ def send_copyedit_complete(**kwargs):
     notify_helpers.send_slack(request, description, ['slack_editors'])
 
 
+def send_author_copyedit_deleted(**kwargs):
+    request = kwargs.get('request')
+    author_review = kwargs.get('author_review')
+    subject = kwargs.get('subject')
+    user_message_content = kwargs.get('user_message_content')
+    skip = kwargs.get('skip', False)
+
+    description = '{0} has deleted a copyedit review for {1} from {2}'.format(
+        request.user.full_name(),
+        author_review.assignment.article.title,
+        author_review.assignment.article.correspondence_author.full_name(),
+    )
+    log_dict = {
+        'level': 'Info',
+        'action_text': description,
+        'types': 'Author Copyedit Review Deleted',
+        'target': author_review.assignment.article,
+    }
+
+    if not skip:
+        notify_helpers.send_email_with_body_from_user(
+            request,
+            subject,
+            author_review.assignment.article.correspondence_author.email,
+            user_message_content,
+            log_dict=log_dict,
+        )
+    else:
+        util_models.LogEntry.add_entry(
+            'Author Copyedit Review Deleted',
+            description,
+            'Info',
+            request.user,
+            request,
+            author_review.assignment.article,
+        )
+
+
 def send_copyedit_ack(**kwargs):
     request = kwargs['request']
     copyedit_assignment = kwargs['copyedit_assignment']


### PR DESCRIPTION
Closes #3015 