### PR TITLE
Enable preprint moderators to un-reject preprint

### DIFF
--- a/src/templates/admin/repository/article.html
+++ b/src/templates/admin/repository/article.html
@@ -151,7 +151,7 @@
                                 </button>
                             </li>
                         {% endif %}
-                        {% if request.user.is_staff and preprint.date_declined and not preprint.date_published %}
+                        {% if preprint.date_declined and not preprint.date_published %}
                             <li>
                                 <button name="reset" class="control-button"><i class="fa fa-recycle">&nbsp;</i>Un-reject
                                     this {{ request.repository.object_name }}


### PR DESCRIPTION
Does this work to enable both moderators and super users/staff to un-reject preprints? Only preprint moderators should be able to access this page, no? 

https://github.com/BirkbeckCTP/janeway/issues/2539