### PR TITLE
#3109 full text indexing will now work as expected for documents with a <body> tag.

### DIFF
--- a/src/core/files.py
+++ b/src/core/files.py
@@ -929,7 +929,7 @@ def html_to_text(file_path):
         soup = BeautifulSoup(f.read(), "html.parser")
         body = soup.find("body")
         if body:
-            body.text
+            text = body.text
         else:
             text = soup.text
 


### PR DESCRIPTION
Closes #3109 