### PR TITLE
Added new settings to disable article thumbnails and article large image independantly 

### DIFF
--- a/src/core/forms.py
+++ b/src/core/forms.py
@@ -359,7 +359,6 @@ class JournalArticleForm(forms.ModelForm):
         fields = (
             'view_pdf_button',
             'disable_metrics_display',
-            'disable_article_images',
         )
 
 

--- a/src/core/logic.py
+++ b/src/core/logic.py
@@ -431,6 +431,8 @@ def get_settings_to_edit(display_group, journal):
     elif display_group == 'article':
         article_settings = [
             'suppress_how_to_cite',
+            'disable_article_thumbnails',
+            'disable_article_large_image',
             'display_guest_editors',
             'suppress_citations_metric',
             'display_altmetric_badge',

--- a/src/journal/migrations/0015_auto_20181108_1220.py
+++ b/src/journal/migrations/0015_auto_20181108_1220.py
@@ -19,7 +19,7 @@ class Migration(migrations.Migration):
             name='disable_article_images',
             field=models.BooleanField(
                 default=False,
-                help_text='When checked, articles will not have header imagesor thumbnail images. Does not affect figures andtables within an article.',
+                help_text='This field has been deprecated in v1.4.3',
             ),
         ),
         migrations.AlterField(

--- a/src/journal/migrations/0053_display_article_images_settings.py
+++ b/src/journal/migrations/0053_display_article_images_settings.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.core.management import call_command
+from django.db import migrations, models
+
+
+def update_setting_values(apps, schema_editor):
+    Journal = apps.get_model("journal", "Journal")
+    Setting = apps.get_model("core", "Setting")
+    SettingGroup = apps.get_model("core", "SettingGroup")
+    SettingValue = apps.get_model("core", "SettingValue")
+    setting_group, _ = SettingGroup.objects.get_or_create(
+        name="article")
+    call_command('load_default_settings')
+    thumb_setting = Setting.objects.get_or_create(name="disable_article_thumbnails")
+    large_image_setting= Setting.objects.get(name="disable_article_large_image")
+    for journal in Journal.objects.filter(disable_article_images=True):
+        SettingValue.objects.get_or_create(
+            setting=thumb_setting,
+            value_en="on",
+            journal=journal,
+        )
+        SettingValue.objects.get_or_create(
+            setting=large_image_setting,
+            value_en="on",
+            journal=journal,
+        )
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('journal', '0052_issue_display_title'),
+    ]
+
+    operations = [
+        migrations.RunPython(update_setting_values, reverse_code=migrations.RunPython.noop),
+    ]

--- a/src/journal/models.py
+++ b/src/journal/models.py
@@ -139,9 +139,7 @@ class Journal(AbstractSiteModel):
     disable_metrics_display = models.BooleanField(default=False)
     disable_article_images = models.BooleanField(
         default=False,
-        help_text=ugettext('When checked, articles will not have header images'
-                           'or thumbnail images. Does not affect figures and'
-                           'tables within an article.'),
+        help_text=ugettext('This field has been deprecated in v1.4.3'),
     )
     enable_correspondence_authors = models.BooleanField(default=True)
     disable_html_downloads = models.BooleanField(default=False)

--- a/src/templates/admin/elements/forms/group_article.html
+++ b/src/templates/admin/elements/forms/group_article.html
@@ -3,7 +3,8 @@
 </div>
 <div class="content">
     <p>{% trans 'A set of controls for how things display on the article page' %}.</p>
-    {% include "admin/elements/forms/field.html" with field=attr_form.disable_article_images %}
+    {% include "admin/elements/forms/field.html" with field=edit_form.disable_article_thumbnails %}
+    {% include "admin/elements/forms/field.html" with field=edit_form.disable_article_large_image %}
     {% include "admin/elements/forms/field.html" with field=edit_form.display_guest_editors %}
     {% include "admin/elements/forms/field.html" with field=edit_form.suppress_how_to_cite %}
     {% include "admin/elements/forms/field.html" with field=attr_form.view_pdf_button %}

--- a/src/themes/OLH/templates/elements/journal/box_article.html
+++ b/src/themes/OLH/templates/elements/journal/box_article.html
@@ -5,7 +5,7 @@
     <a href="{% if article.is_remote %}{{ article.remote_url }}{% else %}{{ article.local_url }}{% endif %}"
        class="box-link"></a>
        <div class="clearfix">
-        {% if not journal.disable_article_images %}
+        {% if not journal_settings.article.disable_article_thumbnails %}
          <div class="large-2 columns show-for-large">
             {% if article.thumbnail_image_file %}
             <img src="{% url 'article_file_download' 'id' article.id article.thumbnail_image_file.id %}"
@@ -17,7 +17,7 @@
                  class="article-thumbnail"> {% endif %}
         </div>
         {% endif %}
-    <div class="{% if not journal.disable_article_images %}large-10{% endif %} columns end">
+    <div class="{% if not journal_settings.article.disable_article_thumbnails %}large-10{% endif %} columns end">
             <h2>{{ article.title|safe }}{% if article.is_remote %}&nbsp;<i class="fa fa-external-link small-icon-text"></i>{% endif %}</h2>
            {% include "elements/journal/authors_block.html" %}
             <p><span class="date"><i

--- a/src/themes/OLH/templates/journal/article.html
+++ b/src/themes/OLH/templates/journal/article.html
@@ -15,7 +15,7 @@
 {% block body %}
 
     <article>
-    {% if not journal.disable_article_images %}
+    {% if not journal_settings.article.disable_article_large_image %}
         <section class="no-padding meta show-for-small-only">
             <div class="row">
                 <div class="large-8 columns">
@@ -145,7 +145,7 @@
                 <div class="large-8 columns border-right">
                     <div class="row">
                         <div id="article" class="large-10 columns">
-                {% if journal.disable_article_images %}
+                {% if journal_settings.article.disable_article_large_image %}
                     <small>{{ article.section.name }}</small>
                     <h1>{{ article.title|safe }}</h1>
                     <div class="section show-for-small-only">
@@ -289,7 +289,7 @@
                           data-anchor="content" data-sticky-on="large">
 
                             {% include "common/elements/altmetric_badges.html" with article=article class='section' %}
-                            {% if journal.disable_article_images %}
+                            {% if journal_settings.article.disable_article_large_image %}
                                 <div class="section">
                                     <h4>{% trans "Authors" %}</h4>
                                     <ul>

--- a/src/themes/OLH/templates/journal/homepage_elements/featured.html
+++ b/src/themes/OLH/templates/journal/homepage_elements/featured.html
@@ -12,7 +12,7 @@
                     <a href="{% if fa.article.is_remote %}{{ fa.article.remote_url }}{% else %}{{ fa.article.url }}{% endif %}"
                        class="box-link"></a>
 
-                    {% if not journal.disable_article_images %}
+                    {% if not journal_settings.article.disable_article_large_image %}
                         {% if fa.article.large_image_file %}
                             <img src="{% url 'article_file_download' 'id' fa.article.id fa.article.large_image_file.id %}"
                                  alt="{{ article.title|striptags }}" class="feature-article-image">

--- a/src/themes/OLH/templates/journal/homepage_elements/popular.html
+++ b/src/themes/OLH/templates/journal/homepage_elements/popular.html
@@ -12,7 +12,7 @@
                     <a href="{% if article.is_remote %}{{ article.remote_url }}{% else %}{{ article.url }}{% endif %}"
                        class="box-link"></a>
 
-                    {% if not journal.disable_article_images %}
+                    {% if not journal_settings.article.disable_article_large_image %}
                         {% if article.large_image_file %}
                             <img src="{% url 'article_file_download' 'id' article.id article.large_image_file.id %}"
                                  alt="{{ article.title|striptags }}" class="feature-article-image">

--- a/src/themes/clean/templates/elements/article_listing.html
+++ b/src/themes/clean/templates/elements/article_listing.html
@@ -4,7 +4,7 @@
 <div class="card">
     <div class="card-block">
         <div class="row">
-            {% if not journal.disable_article_images %}
+            {% if not journal_settings.article.disable_article_thumbnails %}
                 <div class="col-md-2">
                     {% if article.thumbnail_image_file %}
                         <img src="{% url 'article_file_download' 'id' article.id article.thumbnail_image_file.id %}"

--- a/src/themes/clean/templates/journal/article.html
+++ b/src/themes/clean/templates/journal/article.html
@@ -13,7 +13,7 @@
 {% block body %}
 
     <div class="row">
-    {% if not journal.disable_article_images %}
+    {% if not journal_settings.article.disable_article_large_image %}
         <div class="col-md-12">
             <div class="card">
                     <img class="card-img img-fluid article-img"
@@ -69,7 +69,7 @@
 
         <div class="col-md-7">
             <div id="article">
-                {% if journal.disable_article_images %}
+                {% if journal_settings.article.disable_article_large_image %}
                     <small>{{ article.section.name }}</small>
                     <h3>{{ article.title|safe }}</h3>
                 {% endif %}
@@ -126,7 +126,7 @@
         <div class="col-md-4 offset-md-1 left-bar">
             <div class="article-menu">
                 {% include "common/elements/altmetric_badges.html" with article=article %}
-                {% if journal.disable_article_images %}
+                {% if journal_settings.article.disable_article_large_image %}
                     <h2>{% trans "Authors" %}</h2>
                     <ul>
                     {% for author in article.frozen_authors.all %}

--- a/src/themes/clean/templates/journal/homepage_elements/featured.html
+++ b/src/themes/clean/templates/journal/homepage_elements/featured.html
@@ -8,7 +8,7 @@
     {% for fa in featured_articles %}
         <div class="col-md-4 row-eq-height">
             <div class="card">
-                {% if not journal.disable_article_images %}
+                {% if not journal_settings.article.disable_article_large_image %}
                     {% if fa.article.large_image_file %}
                         <img src="{% url 'article_file_download' 'id' fa.article.id fa.article.large_image_file.id %}"
                              alt="{{ article.title|striptags }}"

--- a/src/themes/clean/templates/journal/homepage_elements/popular.html
+++ b/src/themes/clean/templates/journal/homepage_elements/popular.html
@@ -12,7 +12,7 @@
     {% for article in popular_articles %}
         <div class="col-md-4 row-eq-height">
             <div class="card">
-                {% if not journal.disable_article_images %}
+                {% if not journal_settings.article.disable_article_large_image %}
                     {% if article.large_image_file %}
                         <img src="{% url 'article_file_download' 'id' article.id article.large_image_file.id %}"
                              alt="{{ article.title|striptags }}"

--- a/src/themes/material/templates/elements/article_listing.html
+++ b/src/themes/material/templates/elements/article_listing.html
@@ -4,7 +4,7 @@
 
 <div class="card-panel">
     <div class="row">
-	{% if not journal.disable_article_images %}
+	{% if not journal_settings.article.disable_article_thumbnails %}
         <div class="col m2 hide-on-small-and-down">
             {% if article.thumbnail_image_file %}
                 <img src="{% url 'article_file_download' 'id' article.id article.thumbnail_image_file.id %}"
@@ -17,7 +17,7 @@
             {% endif %}
         </div>
 	{% endif %}
-	<div class="col m{% if not journal.disable_article_images %}10{% else %}12{% endif %} s12">
+	<div class="col m{% if not journal_settings.article.disable_article_thumbnails %}10{% else %}12{% endif %} s12">
             <a href="{% if article.is_remote %}{{ article.remote_url }}{% else %}{{ article.local_url }}{% endif %}">
                 <h5 class="article-title">{{ article.title|safe }}</h5>
             </a>

--- a/src/themes/material/templates/journal/article.html
+++ b/src/themes/material/templates/journal/article.html
@@ -17,7 +17,7 @@
     <div class="row">
         <div class="col m12">
             <div class="card">
-            {% if not journal.disable_article_images %}
+            {% if not journal_settings.article.disable_article_large_image %}
                 <div class="card-image article-card waves-effect waves-block waves-light">
                         <img class="orbit-image"
                             {% if article.large_image_file.id %}
@@ -61,7 +61,7 @@
         <div id="article" class="col m8 s12">
             <div class="card">
                 <div class="card-content">
-                    {% if journal.disable_article_images %}
+                    {% if journal_settings.article.disable_article_large_image %}
                         <span class="card-title">
                                 <small class="article_section">{{ article.section.name }}</small>
                                 <h1>{{ article.title|safe }}</h1>

--- a/src/themes/material/templates/journal/homepage_elements/featured.html
+++ b/src/themes/material/templates/journal/homepage_elements/featured.html
@@ -7,9 +7,9 @@
     </div>
     {% for fa in featured_articles %}
         <div class="col m4">
-            <div {% if journal.disable_article_images %}class="card"{% else %}class="card feature-article-card"{% endif %}>
+            <div {% if journal_settings.article.disable_article_large_image %}class="card"{% else %}class="card feature-article-card"{% endif %}>
                 <div class="card-content">
-                    {% if not journal.disable_article_images %}
+                    {% if not journal_settings.article.disable_article_large_image %}
                         {% if fa.article.large_image_file %}
                             <img src="{% url 'article_file_download' 'id' fa.article.id fa.article.large_image_file.id %}"
                                  alt="{{ article.title|striptags }}"

--- a/src/themes/material/templates/journal/homepage_elements/popular.html
+++ b/src/themes/material/templates/journal/homepage_elements/popular.html
@@ -7,9 +7,9 @@
     </div>
     {% for article in popular_articles %}
         <div class="col m4">
-            <div {% if journal.disable_article_images %}class="card"{% else %}class="card feature-article-card"{% endif %}>
+            <div {% if journal_settings.article.disable_article_large_image %}class="card"{% else %}class="card feature-article-card"{% endif %}>
                 <div class="card-content">
-                    {% if not journal.disable_article_images %}
+                    {% if not journal_settings.article.disable_article_large_image %}
                         {% if article.large_image_file %}
                             <img src="{% url 'article_file_download' 'id' article.id article.large_image_file.id %}"
                                  alt="{{ article.title|striptags }}"

--- a/src/utils/install/journal_defaults.json
+++ b/src/utils/install/journal_defaults.json
@@ -1231,6 +1231,36 @@
     },
     {
         "group": {
+            "name": "article"
+        },
+        "setting": {
+            "description": "If checked, the article large image will not be displayed on the article page",
+            "is_translatable": false,
+            "name": "disable_article_large_image",
+            "pretty_name": "Disable article large image",
+            "type": "boolean"
+        },
+        "value": {
+            "default": ""
+        }
+    },
+    {
+        "group": {
+            "name": "article"
+        },
+        "setting": {
+            "description": "If checked, no article thumbnails will be rendered on public article lists",
+            "is_translatable": false,
+            "name": "disable_article_thumbnails",
+            "pretty_name": "Disable article thumbnails",
+            "type": "boolean"
+        },
+        "value": {
+            "default": ""
+        }
+    },
+    {
+        "group": {
             "name": "styling"
         },
         "setting": {


### PR DESCRIPTION
A migration will toggle both settings on for installations that had toggled the `disable_article_images` boolean on the journal