### PR TITLE
Fixes a bug with page ranges that caused articles not to appear in lists

### DIFF
--- a/docs/source/manager/articlesissues/index.rst
+++ b/docs/source/manager/articlesissues/index.rst
@@ -15,6 +15,9 @@ The Article Display Settings page has settings for controlling the way articles 
 - Disable Metrics Display
 - Suppress Citation Metrics
 
+How To Cite is an auto-generated citation based on a custom OLH citation style.  Note that a previous version of the citation included "p" before page ranges. To get this back, enter a custom value in Page Numbers in the Edit Metadata pane for each article.
+
+You can suppress How To Cite for all articles with Suppress How To Cite. You can also override it for individual articles by entering a custom citation in the Edit Metadata pane for each article.
 
 Article Images Manager
 ----------------------

--- a/src/submission/models.py
+++ b/src/submission/models.py
@@ -772,9 +772,12 @@ class Article(AbstractLastModifiedModel):
     def page_range(self):
         if self.page_numbers:
             return self.page_numbers
-        if self.first_page and self.last_page:
+        elif self.first_page and self.last_page:
             return "{}–{}".format(self.first_page, self.last_page)
-        return self.first_page
+        elif self.first_page:
+            return "{}".format(self.first_page)
+        else:
+            return ""
 
     @property
     def metrics(self):

--- a/src/submission/models.py
+++ b/src/submission/models.py
@@ -751,7 +751,7 @@ class Article(AbstractLastModifiedModel):
         doi_str = ""
         pages_str = ""
         if self.page_range:
-            pages_str = " p.{0}.".format(self.page_range)
+            pages_str = " {0}.".format(self.page_range)
         doi = self.get_doi()
         if doi:
             doi_str = ('doi: <a href="https://doi.org/{0}">'

--- a/src/submission/tests.py
+++ b/src/submission/tests.py
@@ -113,33 +113,6 @@ class SubmissionTests(TestCase):
         self.assertEqual(galley.file_content().strip(), expected)
 
     def test_article_how_to_cite(self):
-        issue = journal_models.Issue.objects.create(journal=self.journal_one)
-        journal_models.Issue
-        article = models.Article.objects.create(
-            journal = self.journal_one,
-            title="Test article: a test article",
-            primary_issue=issue,
-            date_published=dateparser.parse("2020-01-01"),
-            page_numbers = "2-4"
-        )
-        author = models.FrozenAuthor.objects.create(
-            article=article,
-            first_name="Mauro",
-            middle_name="Middle",
-            last_name="Sanchez",
-        )
-        id_logic.generate_crossref_doi_with_pattern(article)
-
-        expected = """
-        <p>
-         Sanchez, M. M.,
-        (2020) “Test article: a test article”,
-        <i>Janeway JS</i> 1(1), p.2-4.
-        doi: <a href="https://doi.org/{0}">https://doi.org/{0}</a></p>
-        """.format(article.get_doi())
-        self.assertHTMLEqual(expected, article.how_to_cite)
-
-    def test_article_how_to_cite(self):
         issue = journal_models.Issue.objects.create(
                 journal=self.journal_one,
                 issue="0",
@@ -164,7 +137,7 @@ class SubmissionTests(TestCase):
         <p>
          Sanchez, M. M.,
         (2020) “Test article: a test article”,
-        <i>Janeway JS</i> 1, p.2-4.
+        <i>Janeway JS</i> 1, 2-4.
         doi: <a href="https://doi.org/{0}">https://doi.org/{0}</a></p>
         """.format(article.get_doi())
         self.assertHTMLEqual(expected, article.how_to_cite)

--- a/src/submission/tests.py
+++ b/src/submission/tests.py
@@ -570,6 +570,34 @@ class SubmissionTests(TestCase):
             '0000-0003-2126-266X',
         )
 
+    def test_page_range_first_last(self):
+        article = models.Article.objects.create(
+            journal=self.journal_one,
+            title='Test article: A test of page ranges',
+            first_page=3,
+            last_page=5,
+        )
+        self.assertEqual(article.page_range, '3–5')
+
+    def test_page_range_first_only(self):
+        article = models.Article.objects.create(
+            journal=self.journal_one,
+            title='Test article: A test of page ranges',
+            first_page=3,
+        )
+        self.assertEqual(article.page_range, '3')
+
+    def test_page_range_custom(self):
+        article = models.Article.objects.create(
+            journal=self.journal_one,
+            title='Test article: A test of page ranges',
+            first_page=3,
+            last_page=5,
+            page_numbers='custom'
+        )
+        self.assertEqual(article.page_range, 'custom')
+
+
 class ArticleSearchTests(TransactionTestCase):
     roles_path = os.path.join(
         settings.BASE_DIR,


### PR DESCRIPTION
Fixes #3130.

When the First Page field is populated but no other page number field, the number will now properly display in the Issue table of contents.