### PR TITLE
3190 Use unofficial Bash strict-mode in .update.sh

### DIFF
--- a/.update.sh
+++ b/.update.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
 # This command will run an update on Janeway.
 

--- a/.update.sh
+++ b/.update.sh
@@ -13,4 +13,4 @@ python3 src/manage.py update_repository_settings
 python3 src/manage.py install_plugins
 python3 src/manage.py update_translation_fields
 echo "REMINDER: don't forget to restart your webserver!"
-
+exit 0

--- a/.update.sh
+++ b/.update.sh
@@ -13,3 +13,4 @@ python3 src/manage.py update_repository_settings
 python3 src/manage.py install_plugins
 python3 src/manage.py update_translation_fields
 echo "REMINDER: don't forget to restart your webserver!"
+


### PR DESCRIPTION
- uses the [unofficial Bash strict-mode](http://redsymbol.net/articles/unofficial-bash-strict-mode/) settings
- underlying errors now cause the .update.sh script to fail
- fixes #3190