### PR TITLE
Allow plugins page to render even when plugins fail to load

### DIFF
--- a/src/core/include_urls.py
+++ b/src/core/include_urls.py
@@ -215,21 +215,31 @@ urlpatterns = [
 
 # Journal homepage block loading
 
-blocks = plugin_loader.load(os.path.join('core', 'homepage_elements'), prefix='core.homepage_elements',
-                            permissive=True)
+blocks = plugin_loader.load(
+    os.path.join('core', 'homepage_elements'),
+    prefix='core.homepage_elements',
+    permissive=True,
+)
 
 if blocks:
     for block in blocks:
         try:
             urlpatterns += [
-                url(r'^homepage/elements/{0}/'.format(block.name),
-                    include('core.homepage_elements.{0}.urls'.format(block.name))),
+                url(
+                    r'^homepage/elements/{0}/'.format(block.name),
+                    include(
+                        'core.homepage_elements.{0}.urls'.format(block.name))
+                ),
             ]
             logger.debug("Loaded URLs for %s", block.name)
-        except ImportError as e:
-            logger.debug(
-                "Homepage Element %s has no urls.py module", block.name
+        except ImportError as error:
+            logger.warning(
+                "Failed to import urls for homepage element %s: %s",
+                block.name, error,
             )
+        except Exception as error:
+            logger.error("Error loading homepage element %s", block.name)
+            logger.exception(error)
 
 # Plugin Loading
 # TODO: plugin_loader should handle the logic below
@@ -239,11 +249,19 @@ if plugins:
     for plugin in plugins:
         try:
             urlpatterns += [
-                url(r'^plugins/{0}/'.format(plugin.best_name(slug=True)), include('plugins.{0}.urls'.format(plugin.name))),
+                url(
+                    r'^plugins/{0}/'.format(plugin.best_name(slug=True)),
+                    include('plugins.{0}.urls'.format(plugin.name))
+                ),
             ]
             logger.debug("Loaded URLs for %s", plugin.name)
-        except ImportError as e:
-            logger.debug("Plugin %s has no urls.py module", plugin.name)
+        except ImportError as error:
+            logger.warning(
+                "Failed to import urls for plugin %s: %s", plugin.name, error,
+            )
+        except Exception as error:
+            logger.error("Error loading plugin %s", block.name)
+            logger.exception(error)
 
 # load the notification plugins
 if len(settings.NOTIFY_FUNCS) == 0:

--- a/src/templates/admin/core/manager/plugins.html
+++ b/src/templates/admin/core/manager/plugins.html
@@ -29,6 +29,16 @@
                             {% endif %}
                         {% endfor %}
                     </div>
+                    {% if failed_to_load %}
+                    <div class="bs-callout bs-callout-danger">
+                        <p>Some installed plugins failed to load:</p>
+                        <ul>
+                        {% for failed in failed_to_load %}
+                          <li>{{ failed.name }}</li>
+                        {% endfor %}
+                        </ul>
+                    </div>
+                    {% endif %}
                 </div>
 
             </div>


### PR DESCRIPTION
An error is displayed listing all plugins that are installed on the database but have failed to load.
Additionally, during startup, all kinds of load errors are now handled and logged properly