### PR TITLE
Password length not showing in pwd reset form

### DIFF
--- a/src/themes/material/templates/core/accounts/reset_password.html
+++ b/src/themes/material/templates/core/accounts/reset_password.html
@@ -16,7 +16,7 @@
                                 <span class="card-title">{% trans "Enter your new password twice to complete the reset process" %}:</span>
                                 <p>{% trans "Password Rules" %}:</p>
                                 <ul class="no-top-margin">
-                                    <li>- {% blocktrans %}Your password should be {{ request.press.password_length }} characters long.{% endblocktrans %}</li>
+                                    <li>- {% blocktrans with password_length=request.press.password_length %}Your password should be {{ password_length }} characters long.{% endblocktrans %}</li>
                                     {% if request.press.password_upper %}<li>- {% blocktrans %}Your password should contain at least one upper case letter."{% endblocktrans %} %}</li>{% endif %}
                                     {% if request.press.password_number %}<li>- {% blocktrans %}Your password should contain at least one number." %}{% endblocktrans %}</li>{% endif %}
                                 </ul>


### PR DESCRIPTION
I think it's because we are accessing an object attribute from the `blocktrans` [block](https://docs.djangoproject.com/en/1.11/topics/i18n/translation/#blocktrans-template-tag).

It probably happens in many other forms also.

For completeness, django 4.1 uses the tag [`blocktranslate`](https://docs.djangoproject.com/en/4.1/topics/i18n/translation/#blocktranslate-template-tag) (instead of `blocktrans`).