### PR TITLE
Simplified flow for first-time ORCID login

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -31,6 +31,7 @@ markdown2
 mock
 mozilla-django-oidc==1.2.4
 mysqlclient==1.3.12
+orcid==1.0.3
 pdfkit
 pdfminer
 Pillow>=8.4.0

--- a/src/core/views.py
+++ b/src/core/views.py
@@ -172,9 +172,25 @@ def user_login_orcid(request):
                     return redirect(reverse('website_index'))
 
             except models.Account.DoesNotExist:
-                # Set Token and Redirect
+                # Lookup ORCID email addresses
+                orcid_details = orcid.get_orcid_record_details(orcid_id)
+                for email in orcid_details.get("emails"):
+                    candidates = models.Account.objects.filter(email=email)
+                    if candidates.exists():
+                        # Store ORCID for future authentication requests
+                        candidates.update(orcid=orcid_id)
+                        login(request, candidates.first())
+                        if request.GET.get('next'):
+                            return redirect(request.GET.get('next'))
+                        elif request.journal:
+                            return redirect(reverse('core_dashboard'))
+                        else:
+                            return redirect(reverse('website_index'))
+
+                # Prepare ORCID Token for registration and redirect
                 models.OrcidToken.objects.filter(orcid=orcid_id).delete()
                 new_token = models.OrcidToken.objects.create(orcid=orcid_id)
+
                 return redirect(reverse('core_orcid_registration', kwargs={'token': new_token.token}))
         else:
             messages.add_message(

--- a/src/core/views.py
+++ b/src/core/views.py
@@ -294,12 +294,20 @@ def register(request):
     :param request: HttpRequest object
     :return: HttpResponse object
     """
+    initial = {}
     token, token_obj = request.GET.get('token', None), None
     if token:
         token_obj = get_object_or_404(models.OrcidToken, token=token)
+        if not request.POST:
+            orcid_details = orcid.get_orcid_record_details(token_obj.orcid)
+            initial["first_name"] = orcid_details.get("first_name")
+            initial["last_name"] = orcid_details.get("last_name")
+            if orcid_details.get("emails"):
+                initial["email"] = orcid_details["emails"][0]
 
     form = forms.RegistrationForm(
         journal=request.journal,
+        initial=initial,
     )
 
     if request.POST:

--- a/src/utils/orcid.py
+++ b/src/utils/orcid.py
@@ -13,6 +13,7 @@ from requests.exceptions import HTTPError
 
 from utils import logic
 from utils.logger import get_logger
+from orcid import PublicAPI as OrcidAPI
 
 logger = get_logger(__name__)
 
@@ -60,3 +61,35 @@ def build_redirect_uri(site):
     path = reverse("core_login_orcid")
 
     return request.site_type.site_url(path)
+
+
+def get_orcid_record_details(orcid):
+    details = {}
+    try:
+        logger.info("Retrieving ORCiD profile for %s", orcid)
+        api_client = OrcidAPI(
+            settings.ORCID_CLIENT_ID,
+            settings.ORCID_CLIENT_SECRET,
+        )
+        search_token = api_client.get_search_token_from_orcid()
+        record = api_client.read_record_public(
+            orcid, 'record', search_token,
+        )
+        if record:
+            user_record = record["person"]
+            # Order matters here, we want to get emails first in case anything
+            # goes wrong with person details below
+            details["emails"] = [
+                email["email"]
+                for email in user_record["emails"]["email"]
+            ]
+            details["last_name"] = user_record["name"]["family-name"]["value"]
+            details["first_name"] = user_record["name"]["given-names"]["value"]
+    except HTTPError as e:
+        logger.info("Couldn't retrieve profile with ORCID %s", orcid)
+        logger.info(e)
+    except Exception as e:
+        logger.error("Failed to retrieve user details from ORCID API: %s")
+        logger.exception(e)
+
+    return details


### PR DESCRIPTION
closes #3243 

 - When logging in with ORCiD for the first time, if an account already exists in Janeway it is linked automatically
 - When logging in with ORCiD for the first time, if an account does not exist in Janeway, we pre-fill the form with data from ORCiD API.
 - Users registering using the login with orcid function don't need to activate their account (as long as they use their verified oricd email address)