### PR TITLE
#3284 Clarify template text for peer review status during review

### DIFF
--- a/src/templates/admin/elements/metadata.html
+++ b/src/templates/admin/elements/metadata.html
@@ -88,7 +88,13 @@
     </tr>
     <tr>
         <td colspan="4">
-            {% if article.peer_reviewed %}This article has been marked as having been reviewed in the metadata{% else %}This article has not been marked as having been reviewed. If this article has completed reviews above this may be incorrect.{% endif %}
+            {% if article.peer_reviewed %}
+                This article has been marked as peer reviewed.
+            {% elif not article.is_accepted and article.completed_reviews_with_decision %}
+                If this article is accepted, it will be marked as peer reviewed.
+            {% else %}
+                This article has not been marked as peer reviewed.
+            {% endif %}
         </td>
     </tr>
     <tr>


### PR DESCRIPTION
When an article has had several reviews completed, but it is not yet accepted or declined, this new text will more clearly explain the status to authors.