### PR TITLE
Add swagger and redoc docs to api

### DIFF
--- a/src/api/urls.py
+++ b/src/api/urls.py
@@ -1,6 +1,7 @@
 from django.conf.urls import url, include
 
 from rest_framework import routers
+from rest_framework.schemas import get_schema_view
 
 from api import views
 from api.oai import views as oai_views
@@ -21,4 +22,7 @@ urlpatterns = [
     url(r'^oai/$', oai_views.oai_view_factory, name='OAI_list_records'),
     url(r'^kbart/$', views.kbart, name='kbart'),
     url(r'^kbart/csv$', views.kbart_csv, name='kbart'),
+    url(r'^schema/$', get_schema_view(title="Janeway API", description="API for Janeway", version="1.0.0"), name='openapi-schema'),
+    url(r'^swagger_ui/$', views.swagger_ui, name='swagger_ui'),
+    url(r'^redoc/$', views.redoc, name='redoc'),
 ]

--- a/src/api/urls.py
+++ b/src/api/urls.py
@@ -22,7 +22,7 @@ urlpatterns = [
     url(r'^oai/$', oai_views.oai_view_factory, name='OAI_list_records'),
     url(r'^kbart/$', views.kbart, name='kbart'),
     url(r'^kbart/csv$', views.kbart_csv, name='kbart'),
-    url(r'^schema/$', get_schema_view(title="Janeway API", description="API for Janeway", version="1.0.0"), name='openapi-schema'),
+    url(r'^schema/$', get_schema_view(title="Janeway API", description="API for Janeway", version="0.0.1"), name='openapi-schema'),
     url(r'^swagger_ui/$', views.swagger_ui, name='swagger_ui'),
     url(r'^redoc/$', views.redoc, name='redoc'),
 ]

--- a/src/api/views.py
+++ b/src/api/views.py
@@ -17,7 +17,6 @@ from api import serializers, permissions as api_permissions
 from core import models as core_models
 from submission import models as submission_models
 from journal import models as journal_models
-from repository import models as repository_models
 
 
 @api_view(['GET'])
@@ -140,18 +139,6 @@ class ArticleViewSet(viewsets.ModelViewSet):
                                                                 date_published__lte=timezone.now())
 
         return queryset
-
-
-class PreprintViewSet(viewsets.ModelViewSet):
-    """
-    API Endpoint for preprints.
-    """
-    serializer_class = serializers.PreprintSerializer
-
-    def get_queryset(self):
-        return repository_models.Preprint.objects.filter(repository=self.request.repository,
-                                                         date_published__lte=timezone.now(),
-                                                         stage=repository_models.STAGE_PREPRINT_PUBLISHED)
 
 
 def oai(request):

--- a/src/api/views.py
+++ b/src/api/views.py
@@ -17,6 +17,7 @@ from api import serializers, permissions as api_permissions
 from core import models as core_models
 from submission import models as submission_models
 from journal import models as journal_models
+from repository import models as repository_models
 
 
 @api_view(['GET'])
@@ -139,6 +140,18 @@ class ArticleViewSet(viewsets.ModelViewSet):
                                                                 date_published__lte=timezone.now())
 
         return queryset
+
+
+class PreprintViewSet(viewsets.ModelViewSet):
+    """
+    API Endpoint for preprints.
+    """
+    serializer_class = serializers.PreprintSerializer
+
+    def get_queryset(self):
+        return repository_models.Preprint.objects.filter(repository=self.request.repository,
+                                                         date_published__lte=timezone.now(),
+                                                         stage=repository_models.STAGE_PREPRINT_PUBLISHED)
 
 
 def oai(request):
@@ -309,3 +322,21 @@ def kbart(request, tsv=True):
         writer.writerow(journal_line)
 
     return response
+
+def swagger_ui(request):
+    
+    template = 'apis/swagger_ui.html'
+    context = {
+        'schema_url':'openapi-schema'
+    }
+
+    return render(request, template, context)
+
+def redoc(request):
+    
+    template = 'apis/redoc.html'
+    context = {
+        'schema_url':'openapi-schema'
+    }
+
+    return render(request, template, context)

--- a/src/templates/common/apis/redoc.html
+++ b/src/templates/common/apis/redoc.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>ReDoc</title>
+    <!-- needed for adaptive design -->
+    <meta charset="utf-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link href="https://fonts.googleapis.com/css?family=Montserrat:300,400,700|Roboto:300,400,700" rel="stylesheet">
+    <!-- ReDoc doesn't change outer page styles -->
+    <style>
+      body {
+        margin: 0;
+        padding: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <redoc spec-url='{% url schema_url %}'></redoc>
+    <script src="https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"> </script>
+  </body>
+</html>

--- a/src/templates/common/apis/swagger_ui.html
+++ b/src/templates/common/apis/swagger_ui.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Swagger</title>
+    <meta charset="utf-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="stylesheet" type="text/css" href="//unpkg.com/swagger-ui-dist@3/swagger-ui.css" />
+  </head>
+  <body>
+    <div id="swagger-ui"></div>
+    <script src="//unpkg.com/swagger-ui-dist@3/swagger-ui-bundle.js"></script>
+    <script>
+    const ui = SwaggerUIBundle({
+        url: "{% url schema_url %}",
+        dom_id: '#swagger-ui',
+        presets: [
+          SwaggerUIBundle.presets.apis,
+          SwaggerUIBundle.SwaggerUIStandalonePreset
+        ],
+        layout: "BaseLayout",
+        requestInterceptor: (request) => {
+          request.headers['X-CSRFToken'] = "{{ csrf_token }}"
+          return request;
+        }
+      })
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
These dynamically-generated API docs are helpful when working with building out the API. The spec version has been set to 0.0.1 to make clear this is a draft API.