### PR TITLE
Add pagination for Django REST Framework to Janeway global settings

### DIFF
--- a/src/core/janeway_global_settings.py
+++ b/src/core/janeway_global_settings.py
@@ -571,3 +571,9 @@ CORE_THEMES = [
     'clean',
 ]
 INSTALLATION_BASE_THEME = 'OLH'
+
+# Use pagination for all of our APIs based on Django REST Framework
+REST_FRAMEWORK = {
+    'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.LimitOffsetPagination',
+    'PAGE_SIZE': 100
+}


### PR DESCRIPTION
Add pagination for Django REST Framewark, so that all API endpoints paginate their results.