### PR TITLE
Handle error when nose is not present

### DIFF
--- a/src/core/templatetags/debug_tools.py
+++ b/src/core/templatetags/debug_tools.py
@@ -19,7 +19,7 @@ class TraceNode(template.Node):
         try:
             from nose import tools
             tools.set_trace()         # Debugger will stop here
-        except ImportError:
+        except (ModuleNotFoundError, ImportError):
             import pdb
             pdb.set_trace()           # Debugger will stop here
         return ''


### PR DESCRIPTION
`ModuleNotFoundError` is the correct exception raised in this scenario