### PR TITLE
Author address won't be shared as reply-to on submission acknowledgements

### DIFF
--- a/src/utils/notify_helpers.py
+++ b/src/utils/notify_helpers.py
@@ -16,14 +16,18 @@ def send_slack(request, slack_message, slack_channels):
     notify.notification(**notify_contents)
 
 
-def send_email_with_body_from_setting_template(request, template, subject, to, context, log_dict=None):
+def send_email_with_body_from_setting_template(
+        request, template, subject, to, context, log_dict=None,
+        custom_reply_to=None,
+    ):
     notify_contents = {
         'subject': subject,
         'to': to,
         'html': render_template.get_message_content(request, context, template),
         'action': ['email'],
         'request': request,
-        'log_dict': log_dict
+        'log_dict': log_dict,
+        'custom_reply_to': custom_reply_to,
     }
     notify.notification(**notify_contents)
 

--- a/src/utils/notify_plugins/notify_email.py
+++ b/src/utils/notify_plugins/notify_email.py
@@ -92,6 +92,7 @@ def notify_hook(**kwargs):
     attachment = kwargs.pop('attachment', None)
     request = kwargs.pop('request', None)
     task = kwargs.pop('task', None)
+    custom_reply_to = kwargs.pop('custom_reply_to')
 
     if request and request.journal:
         subject_setting = setting_handler.get_email_subject_setting('email_subject', subject, request.journal)
@@ -99,10 +100,17 @@ def notify_hook(**kwargs):
 
     # call the method
     if not task:
-        response = send_email(subject, to, html, request.journal, request, bcc, cc, attachment)
+        response = send_email(
+            subject, to, html, request.journal,
+            request, bcc, cc, attachment,
+            replyto=custom_reply_to,
+        )
     else:
-        response = send_email(task.email_subject, task.email_to, task.email_html, task.email_journal, request,
-                              task.email_bcc, task.email_cc)
+        response = send_email(
+            task.email_subject, task.email_to, task.email_html,
+            task.email_journal, request,task.email_bcc, task.email_cc,
+            replyto=custom_reply_to,
+        )
 
     log_dict = kwargs.get('log_dict', None)
 

--- a/src/utils/transactional_emails.py
+++ b/src/utils/transactional_emails.py
@@ -3,6 +3,7 @@ __author__ = "Martin Paul Eve & Andy Byers"
 __license__ = "AGPL v3"
 __maintainer__ = "Birkbeck Centre for Technology and Publishing"
 
+from django.conf import settings
 from django.urls import reverse
 from django.utils.translation import ugettext_lazy as _
 
@@ -382,7 +383,7 @@ def send_submission_acknowledgement(**kwargs):
         log_dict=log_dict,
     )
 
-    # send to all authors
+    # send to all editors
     editors_to_email = setting_handler.get_setting(
         'general', 'editors_for_notification', request.journal).processed_value
 
@@ -409,6 +410,7 @@ def send_submission_acknowledgement(**kwargs):
         editor_emails,
         context,
         log_dict=log_dict,
+        custom_reply_to=f"noreply{settings.DUMMY_EMAIL_DOMAIN}"
     )
 
 


### PR DESCRIPTION
There have been reports of editors accidentally including authors onto communications amongst editors, as a result of editors replying to the submission acknowledgement email which comes from a Janeway configured email address but has the author as the Reply-To header.

By removing the header, editors can still reply (Other editors are cc'ed in) and discuss amongst themselves without accidentally including the author