### PR TITLE
Improved performance of repository manager page

### DIFF
--- a/src/repository/logic.py
+++ b/src/repository/logic.py
@@ -7,7 +7,14 @@ from django.utils import timezone
 from django.shortcuts import get_object_or_404, redirect
 from django.urls import reverse
 from django.contrib import messages
-from django.db.models import Q
+from django.db.models import (
+    CharField,
+    Q,
+    OuterRef,
+    Subquery,
+    Value,
+)
+from django.db.models.functions import Concat
 from django.forms import formset_factory
 
 from production.logic import save_galley
@@ -356,12 +363,20 @@ def get_unpublished_preprints(request, user_subject_pks):
 
 
 def get_published_preprints(request, user_subject_pks):
+    author_name_subq = models.PreprintAuthor.objects.filter(
+        preprint=OuterRef('pk')
+    ).annotate(
+        full_name=Concat(
+            "account__first_name", Value(" "), "account__last_name",
+            output_field=CharField(),
+        )
+    ).values('full_name')
     published_preprints = models.Preprint.objects.filter(
         date_published__isnull=False,
         date_submitted__isnull=False,
         repository=request.repository,
-    ).prefetch_related(
-        'preprintauthor_set'
+    ).annotate(
+        author_full_name=Subquery(author_name_subq[:1])
     )
 
     if request.user.is_staff or request.user.is_repository_manager(request.repository):

--- a/src/templates/admin/repository/manager.html
+++ b/src/templates/admin/repository/manager.html
@@ -32,7 +32,7 @@
                                 <td>
                                     <a href="{% url 'repository_manager_article' preprint.pk %}">{{ preprint.title|safe }}</a>
                                 </td>
-                                <td>{{ preprint.preprintauthor_set.first.full_name }}</td>
+                                <td>{{ preprint.author_full_name }}</td>
                                 <td>{{ preprint.date_submitted }}</td>
                             </tr>
                         {% endfor %}
@@ -109,7 +109,7 @@
                                 <td>
                                     <a href="{% url 'repository_manager_article' preprint.pk %}">{{ preprint.title|safe }}</a>
                                 </td>
-                                <td>{{ preprint.preprintauthor_set.first.full_name }}</td>
+                                <td>{{ preprint.author_full_name }}</td>
                                 <td>{{ preprint.date_published }}</td>
                             </tr>
                         {% endfor %}


### PR DESCRIPTION
closes #3309 

pre-calculates the author name for each preprint at the database, avoiding potentially thousands of roundtrip requests to the database to fetch the related author data