### PR TITLE
Use environment variables for defaults for the install_janeway management command

### DIFF
--- a/src/utils/management/commands/install_janeway.py
+++ b/src/utils/management/commands/install_janeway.py
@@ -42,7 +42,6 @@ class Command(BaseCommand):
         )
         parser.add_argument(
             '--press_name',
-            action='store_true',
             dest='press_name',
             default=os.getenv("JANEWAY_PRESS_NAME", default='Press'),
             help='Specifies the Press Name to use when installing Janeway'
@@ -50,27 +49,23 @@ class Command(BaseCommand):
         parser.add_argument(
             '--press_domain',
             action='store_true',
-            dest='press_domain',
             default=os.getenv("JANEWAY_PRESS_DOMAIN", default='localhost'),
             help='Specifies the Press Domain to use when installing Janeway'
         )
         parser.add_argument(
             '--press_contact',
-            action='store_true',
             dest='press_contact',
             default=os.getenv("JANEWAY_PRESS_CONTACT", default='dev@noemail.com'),
             help='Specifies the Press Contact email address to use when installing Janeway'
         )
         parser.add_argument(
             '--journal_code',
-            action='store_true',
             dest='journal_code',
             default=os.getenv("JANEWAY_JOURNAL_CODE", default='Journal'),
             help='Specifies the Journal Code to use when installing Janeway'
         )
         parser.add_argument(
             '--journal_name',
-            action='store_true',
             dest='journal_name',
             default=os.getenv("JANEWAY_JOURNAL_NAME", default='Test Journal'),
             help='Specifies the Journal Name to use when installing Janeway'

--- a/src/utils/management/commands/install_janeway.py
+++ b/src/utils/management/commands/install_janeway.py
@@ -18,7 +18,6 @@ from utils.install import (
 
 ROLES_RELATIVE_PATH = 'utils/install/roles.json'
 
-
 class Command(BaseCommand):
     """
     Installs a press and oe journal for Janeway.
@@ -32,14 +31,61 @@ class Command(BaseCommand):
             action='store_true',
             dest='dry_run',
             default=False,
-            help='Rolls back the transaction resulting from this command',
+            help='Rolls back the transaction resulting from this command'
         )
         parser.add_argument(
             '--use-defaults',
             action='store_true',
             dest='use_defaults',
             default=False,
-            help='Avoids requesting user input and uses default details',
+            help='Avoids requesting user input and uses default details (defaults can be set with environment variables)'
+        )
+        parser.add_argument(
+            '--press_name',
+            action='store_true',
+            dest='press_name',
+            default=os.getenv("JANEWAY_PRESS_NAME", default='Press'),
+            help='Specifies the Press Name to use when installing Janeway'
+        )
+        parser.add_argument(
+            '--press_domain',
+            action='store_true',
+            dest='press_domain',
+            default=os.getenv("JANEWAY_PRESS_DOMAIN", default='localhost'),
+            help='Specifies the Press Domain to use when installing Janeway'
+        )
+        parser.add_argument(
+            '--press_contact',
+            action='store_true',
+            dest='press_contact',
+            default=os.getenv("JANEWAY_PRESS_CONTACT", default='dev@noemail.com'),
+            help='Specifies the Press Contact email address to use when installing Janeway'
+        )
+        parser.add_argument(
+            '--journal_code',
+            action='store_true',
+            dest='journal_code',
+            default=os.getenv("JANEWAY_JOURNAL_CODE", default='Journal'),
+            help='Specifies the Journal Code to use when installing Janeway'
+        )
+        parser.add_argument(
+            '--journal_name',
+            action='store_true',
+            dest='journal_name',
+            default=os.getenv("JANEWAY_JOURNAL_NAME", default='Test Journal'),
+            help='Specifies the Journal Name to use when installing Janeway'
+        )
+        parser.add_argument(
+            '--journal_domain',
+            dest='journal_domain',
+            default=os.getenv("JANEWAY_JOURNAL_DOMAIN", default=''),
+            help='Specifies the Journal Domain to use when installing Janeway (optional)'
+        )
+        parser.add_argument(
+            '--journal_description',
+            dest='journal_description',
+            default=os.getenv("JANEWAY_JOURNAL_DESCRIPTION", default='Journal #1 description'),
+            help='Specifies the Journal Description to use when installing Janeway'
         )
 
     def handle(self, *args, **options):
@@ -63,9 +109,9 @@ class Command(BaseCommand):
             if not test_one:
                 press = press_models.Press()
                 if use_defaults:
-                    press.name = "press"
-                    press.domain = "localhost"
-                    press.main_contant= "dev@noemail.com"
+                    press.name = options['press_name']
+                    press.domain = options['press_domain']
+                    press.main_contact= options['press_contact']
                 else:
                     press.name = input('Press name: ')
                     press.domain = input('Press domain: ')
@@ -79,7 +125,8 @@ class Command(BaseCommand):
             print("[okay]")
             journal = journal_models.Journal()
             if use_defaults:
-                journal.code = "journal"
+                journal.code = options['journal_code']
+                journal.domain = options['journal_domain']
             else:
                 journal.code = input('Journal #1 code: ')
                 journal.domain = input('Journal #1 domain (Optional): ')
@@ -93,8 +140,8 @@ class Command(BaseCommand):
             call_command('load_default_settings')
             call_command('loaddata', roles_path)
             if use_defaults:
-                journal.name = "Test Journal"
-                journal.description = "Test Journal"
+                journal.name = options['journal_name']
+                journal.description = options['journal_description']
             else:
                 journal.name = input('Journal #1 name: ')
                 journal.description = input('Journal #1 description: ')
@@ -112,9 +159,12 @@ class Command(BaseCommand):
                 call_command('install_cron')
             except FileNotFoundError:
                 self.stderr.write("Error Installing cron")
-            print('Create a super user.')
-            if not use_defaults:
+            if use_defaults:
+                print('Don\'t forget to create a superuser: manage.py createsuperuser')
+            else:
+                print('Create a super user.')
                 call_command('createsuperuser')
+
             print('Open your browser to your new journal domain '
                 '{domain}/install/ to continue this setup process.'.format(
                     domain=journal.domain

--- a/src/utils/management/commands/install_janeway.py
+++ b/src/utils/management/commands/install_janeway.py
@@ -48,7 +48,7 @@ class Command(BaseCommand):
         )
         parser.add_argument(
             '--press_domain',
-            action='store_true',
+            dest='press_domain',
             default=os.getenv("JANEWAY_PRESS_DOMAIN", default='localhost'),
             help='Specifies the Press Domain to use when installing Janeway'
         )


### PR DESCRIPTION
- Add arguments for the install_janeway command for press_name, press_domain, press_contact, journal_name, journal_description, journal_code, journal_domain
- Use environment variables for default values
- Hard code the existing default values into the getenv method invocation for each env, so the script behaves the same as previous versions of Janeway