### PR TITLE
Switched to a production version of django-bootstrap4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ colorlog==3.1.4
 chardet==3.0.4
 crossrefapi==1.5.0
 Django==3.2.16
--e git+https://github.com/GabrielUlici/django-bootstrap4@d230ec23d9f8f08c1505e0679ce0c6dba8090f0a#egg=django_bootstrap4
+django-bootstrap4==22.3
 -e git+https://github.com/BirkbeckCTP/django-foundation-form.git@284fc5f08e58d8655c7301eddb49f920fda516d2#egg=foundationform
 -e git+https://github.com/BirkbeckCTP/django-materialize.git@ca97451d96cab4b2c83797f34c32dfb69af08e0a#egg=django_materialize
 django-debug-toolbar==3.7.0

--- a/src/templates/admin/core/manager/settings/edit_setting.html
+++ b/src/templates/admin/core/manager/settings/edit_setting.html
@@ -67,7 +67,7 @@
 
                             {% buttons %}
                                 <button type="submit" class="button success" style="margin-right:5px">
-                                    {% bootstrap_icon "ok" %} {% if setting_value == None %} Create Override {% else %}
+                                    <span class="fa fa-check"> </span> {% if setting_value == None %} Create Override {% else %}
                                     Submit {% endif %}
                                 </button>
                                 {% if setting_value != setting.default_setting_value and setting_value != None %}


### PR DESCRIPTION
In this PR I've switched us over to a production version of Django Bootstrap 4. This version and the version we were using have a common ancestor and other than bootstrap_icon being deprecated are compatible and render the same but the newer version works with Django 3.2+.