### PR TITLE
The manage workflow stage link is now available to editors

### DIFF
--- a/src/templates/admin/elements/article_jump.html
+++ b/src/templates/admin/elements/article_jump.html
@@ -21,15 +21,13 @@
         <li><a href="{% url 'document_management' article.pk %}?return={{ request.path }}">Document Management</a></li>
         <li><a href="{% url 'article_identifiers' article.pk %}">Identifiers</a></li>
         <li><a href="{% url 'manage_archive_article' article.pk %}">Archive Page</a></li>
+        <li><a href="{% url 'manage_article_workflow' article.pk %}" target="_blank">Manage Workflow Stage</a></li>
         {% if article.is_published %}
             <li><a href="{{ article.url }}">Live Article</a></li>
         {% endif %}
         {% if request.user.is_superuser %}
             <li><a target="_blank" href="/admin/submission/article/{{ article.pk }}/">Admin <i
                     class="fa fa-cogs"></i></a></li>
-            <li>
-                <a href="{% url 'manage_article_workflow' article.pk %}" target="_blank">Manage Workflow Stage</a>
-            </li>
         {% endif %}
     </ul>
 </div>


### PR DESCRIPTION
This view has been protected by `@editor_user_required` for a while so has been available for editors to use if the know the path. Editors want to make use of the archive function that appears on this view so we should make the page available.