### PR TITLE
Add templates missing from material theme

### DIFF
--- a/src/themes/material/templates/elements/article_meta_tags.html
+++ b/src/themes/material/templates/elements/article_meta_tags.html
@@ -1,0 +1,59 @@
+
+    <!-- Commented out meta fields are TODO -->
+
+    <!-- <meta name="DC.Coverage.spatial" xml:lang="en" content="London"/> -->
+
+    <!-- <meta name="DC.Coverage.temporal" xml:lang="en" content="long-eighteenth century"/> -->
+
+
+    {% if article.date_published %}<meta name="DC.Date.created" scheme="ISO8601" content="{{ article.date_published|date:"Y-m-d" }}"/>{% endif %}
+    {% if article.date_submitted %}<meta name="DC.Date.dateSubmitted" scheme="ISO8601" content="{{ article.date_submitted|date:"Y-m-d" }}"/>{% endif %}
+    {% if article.date_published %}<meta name="DC.Date.issued" scheme="ISO8601" content="{{ article.date_published|date:"Y-m-d" }}"/>{% endif %}
+    {% if article.date_published %}<meta name="DC.Date.modified" scheme="ISO8601" content="{{ article.date_published|date:"Y-m-d"  }}"/>{% endif %}
+
+
+    <meta name="DC.Description" xml:lang="en" content="{{ article.abstract | striptags }}"/>
+
+    <meta name="DC.Format" scheme="IMT" content="xml"/>
+    <meta name="DC.Format" scheme="IMT" content="pdf"/>
+    {% if article.page_number %}<meta name="DC.Identifier.pageNumber" content="{{ article.page_number }}"/>{% endif %}
+    {% if article.identifier.id_type == "doi" %}<meta name="DC.Identifier.DOI" content="{{ article.identifier.identifier }}"/>{% endif %}
+
+    <meta name="DC.Identifier.URI" content="{{ article.url }}"/>
+    <meta name="DC.Language" scheme="ISO639-1" content="{{ article.language }}"/>
+    <meta name="DC.Rights" content="{{ article.licence.text | striptags }}"/>
+    <meta name="DC.Source" content="{{ journal_settings.general.journal_name }}"/>
+    <meta name="DC.Source.ISSN" content="{{ article.journal.issn }}"/>
+    {% if article.issue.isbn %}<meta name="DC.Source.ISBN" content="{{ article.issue.isbn }}"/>{% endif %}
+    {% if article.issue.issue %}<meta name="DC.Source.Issue" content="{{ article.issue.issue }}"/>{% endif %}
+    {% if article.issue.volume %}<meta name="DC.Source.Volume" content="{{ article.issue.volume }}"/>{% endif %}
+    <meta name="DC.Source.URI" content="{% journal_url 'website_index' %}"/>
+    <meta name="DC.Title" content="{{ article.title | striptags }}"/>
+
+    {% if article.publisher_name%}<meta name="citation_publisher" content="{{ article.publisher_name }}"/>
+    {% elif journal_settings.general.publisher_name %}<meta name="citation_publisher" content="{{ journal_settings.general.publisher_name }}"/>
+    {% endif %}
+    <meta name="citation_journal_title" content="{{ article.journal_title }}"/>
+    <meta name="citation_issn" content="{{ article.journal_issn }}"/>
+    {% for author in article.frozen_authors.all %}
+        <meta name="citation_author" content="{{ author.full_name }}"/>
+        {% if not '@journal.org' in author.author.email %}
+            <meta name="citation_author_email" content="{{ author.author.email }}"/>{% endif %}
+        <meta name="citation_author_institution" content="{{ author.institution }}"/>{% endfor %}
+    <meta name="citation_title" content="{{ article.title | striptags }}"/>
+    {% if article.date_published %}<meta name="citation_publication_date" content="{{ article.date_published|date:"Y-m-d" }}"/>{% endif %}
+    {% if article.issue.volume %}<meta name="citation_volume" content="{{ article.issue.volume }}"/>{% endif %}
+    {% if article.issue.issue %}<meta name="citation_issue" content="{{ article.issue.issue }}"/>{% endif %}
+    {% if article.page_number %}<meta name="citation_firstpage" content="{{ article.page_number }}"/>{% endif %}
+    {% if article.identifier.id_type == "doi" %}<meta name="citation_doi" content="{{ article.identifier.identifier }}"/>{% endif %}
+    <meta name="citation_abstract_html_url" content="{{ article.url }}"/>
+    {% if article.language %}<meta name="citation_language" content="{{ article.language }}"/>{% endif %}
+
+    {% if article.keywords.count > 0 %}
+    <meta name="citation_keywords" xml:lang="en" content="{% for keyword in article.keywords.all %}{{ keyword.word }}{% if not forloop.last %}, {% endif %}{% endfor %}"/>
+    {% endif %}
+
+    {% if article.pdfs.exists %}
+    <meta name="citation_pdf_url" content="{% journal_url 'serve_article_pdf' 'id' article.id %}"/>
+    {% endif %}
+    {% include "elements/journal/social_meta.html" %}

--- a/src/themes/material/templates/elements/journal/article_issue_list.html
+++ b/src/themes/material/templates/elements/journal/article_issue_list.html
@@ -1,0 +1,22 @@
+
+{% with issue_length=article.issues_list|length %}
+    <h4>{% if issue_length > 1 %}Issues{% else %}Issue{% endif %}</h4>
+{% endwith %}
+<ul>
+    {% if article.primary_issue %}
+        <li>
+            <a href="{% url 'journal_issue' article.primary_issue.pk %}">
+                {% if article.issues_list.count > 1 %}{% trans 'Primary: ' %}{% endif %}{{ article.primary_issue.display_title }}
+            </a>
+            {% if journal_settings.article.display_guest_editors %}
+                <br/>
+                {% include "common/elements/guest_editors.html" with issue=article.primary_issue small="small" %}
+            {% endif %}
+        </li>
+    {% endif %}
+    {% for issue in article.issues_list %}
+        {% if not issue == article.primary_issue %}<li><a href="{% url 'journal_issue' issue.pk %}">{{ issue.issue_type.pretty_name }}: {{ issue.display_title }}</a></li>{% endif %}
+        {% empty %}
+        <li>This article is not a part of any issues.</li>
+    {% endfor %}
+</ul>

--- a/src/themes/material/templates/elements/journal/social_meta.html
+++ b/src/themes/material/templates/elements/journal/social_meta.html
@@ -1,0 +1,17 @@
+    {% load truncate %}
+    <meta name="twitter:card" content="summary">
+    <meta name="twitter:title" content="{{ news_item.title }}">
+    <meta name="twitter:description" content="{{ news_item.body|striptags|truncatesmart:400 }}">
+    {% if news_item.best_image_url %}
+        <meta name="twitter:image" content="{{ news_item.best_image_url }}">
+    {% endif %}
+
+    <meta property="og:title" content="{{ news_item.title }}" />
+    <meta property="og:type" content="article" />
+    <meta property="og:url" content="{{ request.build_absolute_uri }}" />
+    {% if news_item.best_image_url %}
+        <meta name="og:image" content="{{ news_item.best_image_url }}">
+    {% endif %}
+
+    <meta property="og:description" content="{{ news_item.body|striptags|truncatesmart:400 }}" />
+    <meta property="og:site_name" content="{{ request.press.name }}" />


### PR DESCRIPTION
The following files are missing from material theme:

- themes/material/templates/elements/journal/article_issue_list.html
- themes/material/templates/elements/journal/social_meta.html
- themes/material/templates/elements/article_meta_tags.html

If one is using `INSTALLATION_BASE_THEME` other than material the theme system is capable of fallback to the files in the base theme, but if `INSTALLATION_BASE_THEME = "material"` the fallback mechanism fails and `TemplateDoesNotExist` exception is raised