### PR TITLE
Bugfix in Galley.unlink_files() and related test.

### DIFF
--- a/src/core/models.py
+++ b/src/core/models.py
@@ -815,7 +815,7 @@ class File(AbstractLastModifiedModel):
 
     def journal_path(self, journal):
         return os.path.join(settings.BASE_DIR, 'files', 'journals', str(journal.pk), str(self.uuid_filename))
-    
+
     def self_article_path(self):
         if self.article_id:
             return os.path.join(settings.BASE_DIR, 'files', 'articles', str(self.article_id), str(self.uuid_filename))
@@ -1079,7 +1079,7 @@ class Galley(AbstractLastModifiedModel):
         if self.file and self.file.article_id:
             self.file.unlink_file()
         for image_file in self.images.all():
-            if  not image_file.images.exclude(galley=self).exists():
+            if not image_file.images.exclude(pk=self.pk).exists():
                 image_file.unlink_file()
 
     def __str__(self):


### PR DESCRIPTION
This should fix an error that the function gives now: `...FieldError: Cannot resolve keyword 'galley' into field...`.

But I'm not sure how best to test it. At the moment I'm creating a "complete" galley, with files in the filesystem for the galley itself and for one of the galley.images. I must still check if this leaves "dirty" files in the filesystem in case of errors during the test or if the cleanup is good. But maybe there is some better way to do it that anyone wants to suggest? :)