### PR TITLE
Fixed an issue where author emails were being exposed via OAI unintentionally

### DIFF
--- a/src/api/tests/test_oai.py
+++ b/src/api/tests/test_oai.py
@@ -133,6 +133,11 @@ class TestOAIViews(TestCase):
     @freeze_time("2012-01-14")
     def test_get_record_jats(self):
         expected = GET_RECORD_DATA_JATS
+        # Add a non correspondence author
+        author_2 = helpers.create_author(self.journal, email="no@email.com")
+        self.article.authors.add(author_2)
+        self.article.snapshot_authors()
+
 
         path = reverse('OAI_list_records')
         query_params = dict(
@@ -147,11 +152,13 @@ class TestOAIViews(TestCase):
             SERVER_NAME="testserver"
         )
 
+
+        self.maxDiff = None
         self.assertEqual(str(response.rendered_content).split(), expected.split())
 
     @override_settings(URL_CONFIG="domain")
     @freeze_time("2012-01-14")
-    def test_get_record_jats(self):
+    def test_list_identifiers_jats(self):
         expected = LIST_IDENTIFIERS_JATS
 
         path = reverse('OAI_list_records')
@@ -479,7 +486,7 @@ GET_RECORD_DATA_JATS = """
                 <journal-id journal-id-type="issn">0000-0000</journal-id>
                 <journal-title-group>
                     <journal-title>Journal One</journal-title>
-                </journal-title-group1986-07-12T15:00:00Z>
+                </journal-title-group>
                 <issn pub-type="epub">0000-0000</issn>
                 <publisher>
                     <publisher-name></publisher-name>
@@ -504,8 +511,16 @@ GET_RECORD_DATA_JATS = """
                         <email>authoruser@martineve.com</email>
                         <xref ref-type="aff" rid="aff-1"/>
                     </contrib>
+                    <contrib contrib-type="author">
+                        <name>
+                            <surname>User</surname>
+                            <given-names>Author A</given-names>
+                        </name>
+                        <xref ref-type="aff" rid="aff-2"/>
+                    </contrib>
                 </contrib-group>
                 <aff id="aff-1">Author Department, Author institution</aff>
+                <aff id="aff-2">Author Department, Author institution</aff>
                 <pub-date date-type="pub" iso-8601-date="1986-07-12" publication-format="electronic">
                     <day>12</day>
                     <month>07</month>

--- a/src/api/tests/test_preprint_oai.py
+++ b/src/api/tests/test_preprint_oai.py
@@ -297,7 +297,6 @@ LIST_RECORDS_DATA_JATS = """
                                             <surname>Author</surname>
                                             <given-names>Preprint</given-names>
                                         </name>
-                                        <email>preprintauthor@test.edu</email>
                                         <xref ref-type="aff" rid="aff-1"/>
                                     </contrib>
                                 </contrib-group>
@@ -369,7 +368,6 @@ LIST_RECORDS_DATA_JATS = """
                                             <surname>Author</surname>
                                             <given-names>Preprint</given-names>
                                         </name>
-                                        <email>preprintauthor@test.edu</email>
                                         <xref ref-type="aff" rid="aff-1"/>
                                     </contrib>
                                 </contrib-group>
@@ -534,7 +532,6 @@ GET_RECORD_DATA_JATS = """
                                         <surname>Author</surname>
                                         <given-names>Preprint</given-names>
                                     </name>
-                                    <email>preprintauthor@test.edu</email>
                                     <xref ref-type="aff" rid="aff-1"/>
                                 </contrib>
                             </contrib-group>

--- a/src/templates/common/apis/OAI_preprint_record_jats_stub.xml
+++ b/src/templates/common/apis/OAI_preprint_record_jats_stub.xml
@@ -49,8 +49,7 @@ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
                         <surname>{{ author.account.last_name }}</surname>
                         <given-names>{{ author.account.first_name }}{% if author.middle_name %} {{ author.middle_name }}{% endif %}</given-names>
                     </name>
-                    <email>{{ author.account.email }}</email>
-                    {% if author.affiliation %}                 
+                    {% if author.affiliation %}
                     <xref ref-type="aff" rid="aff-{{ forloop.counter }}"/>
                     {% endif %}
                 </contrib>

--- a/src/templates/common/encoding/article_jats_1_2.xml
+++ b/src/templates/common/encoding/article_jats_1_2.xml
@@ -43,7 +43,9 @@
                         <surname>{{ author.last_name }}</surname>
                         <given-names>{{ author.given_names }}</given-names>
                     </name>
+                    {% if author.is_correspondence_author %}
                     <email>{{ author.author.email }}</email>
+                    {% endif %}
                     <xref ref-type="aff" rid="aff-{{ forloop.counter }}"/>
                 </contrib>
             {% endfor %}


### PR DESCRIPTION
fixes #3361 

- On journal articles, author email addresses will only be marshalled following correspondence author logic
- On Preprint articles, no author emails are marshalled