### PR TITLE
Refactor tests to eliminate naive datetime warnings

### DIFF
--- a/src/api/tests/test_oai.py
+++ b/src/api/tests/test_oai.py
@@ -7,6 +7,7 @@ from urllib.parse import unquote_plus
 from django.test import RequestFactory, TestCase, override_settings
 from django.urls import reverse
 from django.utils.http import urlencode
+from django.utils import timezone
 
 from freezegun import freeze_time
 from lxml import etree
@@ -15,6 +16,9 @@ from api.oai.base import OAIPaginationMixin
 from submission import models as sm_models
 from utils.testing import helpers
 
+FROZEN_DATETIME_2012 = timezone.make_aware(timezone.datetime(2012, 1, 14, 0, 0, 0))
+FROZEN_DATETIME_1990 = timezone.make_aware(timezone.datetime(1990, 1, 1, 0, 0, 0))
+FROZEN_DATETIME_1976 = timezone.make_aware(timezone.datetime(1976, 1, 2, 0, 0, 0))
 
 class TestOAIViews(TestCase):
 
@@ -49,16 +53,15 @@ class TestOAIViews(TestCase):
         xml_dom = etree.XML(xml)
         return xml_schema.validate(xml_dom)
 
-
     @override_settings(URL_CONFIG="domain")
-    @freeze_time("2012-01-14")
+    @freeze_time(FROZEN_DATETIME_2012)
     def test_list_records_dc(self):
         expected = LIST_RECORDS_DATA_DC
         response = self.client.get(reverse('OAI_list_records'), SERVER_NAME="testserver")
         self.assertEqual(str(response.rendered_content).split(), expected.split())
 
     @override_settings(URL_CONFIG="domain")
-    @freeze_time("2012-01-14")
+    @freeze_time(FROZEN_DATETIME_2012)
     def test_list_records_jats(self):
         expected = LIST_RECORDS_DATA_JATS
         path = reverse('OAI_list_records')
@@ -75,7 +78,7 @@ class TestOAIViews(TestCase):
         self.assertEqual(result.split(), expected.split())
 
     @override_settings(URL_CONFIG="domain")
-    @freeze_time("2012-01-14")
+    @freeze_time(FROZEN_DATETIME_2012)
     def test_get_record_dc(self):
         expected = GET_RECORD_DATA_DC
 
@@ -95,7 +98,7 @@ class TestOAIViews(TestCase):
         self.assertEqual(str(response.rendered_content).split(), expected.split())
 
     @override_settings(URL_CONFIG="domain")
-    @freeze_time("1976-01-02")
+    @freeze_time(FROZEN_DATETIME_1976)
     def test_get_records_until(self):
         expected = GET_RECORD_DATA_UNTIL
 
@@ -103,7 +106,7 @@ class TestOAIViews(TestCase):
         query_params = dict(
             verb="ListRecords",
             metadataPrefix="oai_dc",
-            until="1976-01-02",
+            until=timezone.make_aware(timezone.datetime(1976, 1, 2, 0, 0, 0)),
         )
         query_string = urlencode(query_params)
 
@@ -130,7 +133,7 @@ class TestOAIViews(TestCase):
         self.assertEqual(str(response.rendered_content).split(), expected.split())
 
     @override_settings(URL_CONFIG="domain")
-    @freeze_time("2012-01-14")
+    @freeze_time(FROZEN_DATETIME_2012)
     def test_get_record_jats(self):
         expected = GET_RECORD_DATA_JATS
         # Add a non correspondence author
@@ -157,7 +160,7 @@ class TestOAIViews(TestCase):
         self.assertEqual(str(response.rendered_content).split(), expected.split())
 
     @override_settings(URL_CONFIG="domain")
-    @freeze_time("2012-01-14")
+    @freeze_time(FROZEN_DATETIME_2012)
     def test_list_identifiers_jats(self):
         expected = LIST_IDENTIFIERS_JATS
 
@@ -176,7 +179,7 @@ class TestOAIViews(TestCase):
         self.assertEqual(str(response.rendered_content).split(), expected.split())
 
     @override_settings(URL_CONFIG="domain")
-    @freeze_time("2012-01-14")
+    @freeze_time(FROZEN_DATETIME_2012)
     def test_identify_dc(self):
         expected = IDENTIFY_DATA_DC
 
@@ -194,7 +197,7 @@ class TestOAIViews(TestCase):
         self.assertEqual(str(response.rendered_content).split(), expected.split())
 
     @override_settings(URL_CONFIG="domain")
-    @freeze_time("2012-01-14")
+    @freeze_time(FROZEN_DATETIME_2012)
     def test_list_sets(self):
         expected = LIST_SETS_DATA_DC
 
@@ -232,7 +235,7 @@ class TestOAIViews(TestCase):
         )
 
     @override_settings(URL_CONFIG="domain")
-    @freeze_time("1990-01-01")
+    @freeze_time(FROZEN_DATETIME_1990)
     def test_oai_resumption_token_encode(self):
         custom_param = {"custom-param": "custom-value"}
         expected = {

--- a/src/api/tests/test_preprint_oai.py
+++ b/src/api/tests/test_preprint_oai.py
@@ -2,20 +2,21 @@
 from django.test import TestCase, override_settings
 from django.urls import reverse
 from django.utils.http import urlencode
+from django.utils import timezone
 
 from freezegun import freeze_time
 
 from utils.testing import helpers
 from repository import models as repo_models
-import datetime
-import pytz
 
 REPO_DOMAIN = 'repo.domain.com'
+FROZEN_DATETIME_202209 = timezone.make_aware(timezone.datetime(2022, 9, 1, 0, 0, 0))
+FROZEN_DATETIME_202208 = timezone.make_aware(timezone.datetime(2022, 8, 31, 0, 0, 0))
 
 class TestPreprintOAIViews(TestCase):
 
     @classmethod
-    @freeze_time("2022-08-31")
+    @freeze_time(FROZEN_DATETIME_202208)
     def setUpTestData(cls):
         cls.press = helpers.create_press()
         cls.repo, cls.subject = helpers.create_repository(cls.press, [], [])
@@ -27,7 +28,7 @@ class TestPreprintOAIViews(TestCase):
 
         cls.preprint = helpers.create_preprint(cls.repo, cls.author, cls.subject)
         cls.preprint.stage = repo_models.STAGE_PREPRINT_PUBLISHED
-        cls.preprint.date_published = datetime.datetime(2022, 8, 31, tzinfo=pytz.UTC) 
+        cls.preprint.date_published = timezone.make_aware(timezone.datetime(2022, 8, 31, 0, 0, 0)) 
         cls.preprint.make_new_version(cls.preprint.submission_file)
         cls.preprint.save()
 
@@ -35,19 +36,19 @@ class TestPreprintOAIViews(TestCase):
 
         cls.older_preprint = helpers.create_preprint(cls.repo, cls.author, cls.subject, title="Older Test Preprint")
         cls.older_preprint.stage = repo_models.STAGE_PREPRINT_PUBLISHED
-        cls.older_preprint.date_published = datetime.datetime(2022, 8, 29, tzinfo=pytz.UTC)
+        cls.older_preprint.date_published = timezone.make_aware(timezone.datetime(2022, 8, 29, 0, 0, 0))
         cls.older_preprint.make_new_version(cls.older_preprint.submission_file)
         cls.older_preprint.save()
 
     @override_settings(URL_CONFIG="domain")
-    @freeze_time("2022-09-01")
+    @freeze_time(FROZEN_DATETIME_202209)
     def test_list_records_dc(self):
         expected = LIST_RECORDS_DATA_DC
         response = self.client.get(reverse('OAI_list_records'), SERVER_NAME=REPO_DOMAIN)
         self.assertEqual(str(response.rendered_content).split(), expected.split())
 
     @override_settings(URL_CONFIG="domain")
-    @freeze_time("2022-09-01")
+    @freeze_time(FROZEN_DATETIME_202209)
     def test_list_records_jats(self):
         expected = LIST_RECORDS_DATA_JATS
         path = reverse('OAI_list_records')
@@ -63,7 +64,7 @@ class TestPreprintOAIViews(TestCase):
         self.assertEqual(str(response.rendered_content).split(), expected.split())
 
     @override_settings(URL_CONFIG="domain")
-    @freeze_time("2022-09-01")
+    @freeze_time(FROZEN_DATETIME_202209)
     def test_list_sets(self):
         expected = LIST_SETS_DATA_DC
 
@@ -83,7 +84,7 @@ class TestPreprintOAIViews(TestCase):
 
 
     @override_settings(URL_CONFIG="domain")
-    @freeze_time("2022-09-01")
+    @freeze_time(FROZEN_DATETIME_202209)
     def test_get_record_dc(self):
         expected = GET_RECORD_DATA_DC
 
@@ -103,7 +104,7 @@ class TestPreprintOAIViews(TestCase):
         self.assertEqual(str(response.rendered_content).split(), expected.split())
 
     @override_settings(URL_CONFIG="domain")
-    @freeze_time("2022-09-01")
+    @freeze_time(FROZEN_DATETIME_202209)
     def test_get_record_jats(self):
         expected = GET_RECORD_DATA_JATS
 
@@ -123,7 +124,7 @@ class TestPreprintOAIViews(TestCase):
         self.assertEqual(str(response.rendered_content).split(), expected.split())
 
     @override_settings(URL_CONFIG="domain")
-    @freeze_time("2022-09-01")
+    @freeze_time(FROZEN_DATETIME_202209)
     def test_list_identifiers_jats(self):
         expected = LIST_IDENTIFIERS_JATS
 
@@ -142,7 +143,7 @@ class TestPreprintOAIViews(TestCase):
         self.assertEqual(str(response.rendered_content).split(), expected.split())
 
     @override_settings(URL_CONFIG="domain")
-    @freeze_time("2022-09-01")
+    @freeze_time(FROZEN_DATETIME_202209)
     def test_identify_dc(self):
         expected = IDENTIFY_DATA_DC
 
@@ -160,7 +161,7 @@ class TestPreprintOAIViews(TestCase):
         self.assertEqual(str(response.rendered_content).split(), expected.split())
 
     @override_settings(URL_CONFIG="domain")
-    @freeze_time("2022-09-01")
+    @freeze_time(FROZEN_DATETIME_202209)
     def test_get_records_until(self):
         expected = GET_RECORD_DATA_UNTIL
 
@@ -168,7 +169,8 @@ class TestPreprintOAIViews(TestCase):
         query_params = dict(
             verb="ListRecords",
             metadataPrefix="oai_dc",
-            until=str(datetime.datetime(2022, 8, 30, tzinfo=pytz.UTC)),
+            # until=str(datetime.datetime(2022, 8, 30, tzinfo=pytz.UTC)),
+            until=timezone.make_aware(timezone.datetime(2022, 8, 30, 0, 0, 0))
         )
         query_string = urlencode(query_params)
 

--- a/src/core/homepage_elements/carousel/tests.py
+++ b/src/core/homepage_elements/carousel/tests.py
@@ -2,7 +2,6 @@ __copyright__ = "Copyright 2017 Birkbeck, University of London"
 __author__ = "Martin Paul Eve & Andy Byers"
 __license__ = "AGPL v3"
 __maintainer__ = "Birkbeck Centre for Technology and Publishing"
-import datetime
 from dateutil.relativedelta import relativedelta
 
 from django.contrib.contenttypes.models import ContentType
@@ -15,8 +14,8 @@ from journal import models as journal_models
 from submission import models as sm_models
 from utils.testing.helpers import create_journals
 
-FROZEN_DATETIME_20180628 = timezone.make_aware(timezone.datetime(2018, 6, 28, 8, 15, 27))
-FROZEN_DATETIME_20180629 = timezone.make_aware(timezone.datetime(2018, 6, 29, 8, 15, 27))
+FROZEN_DATETIME_20180628 = timezone.make_aware(timezone.datetime(2018, 6, 28, 8, 15, 27, 243860))
+FROZEN_DATETIME_20180629 = timezone.make_aware(timezone.datetime(2018, 6, 29, 8, 15, 27, 243860))
 
 # Create your tests here.
 class TestCarousel(TestCase):
@@ -34,7 +33,7 @@ class TestCarousel(TestCase):
         cls.article = sm_models.Article.objects.create(
             journal=cls.journal_one,
             stage=sm_models.STAGE_PUBLISHED,
-            date_published=FROZEN_DATETIME_20180629,
+            date_published=FROZEN_DATETIME_20180628,
             title='Carousel Article One',
         )
         cls.article = sm_models.Article.objects.create(

--- a/src/core/homepage_elements/carousel/tests.py
+++ b/src/core/homepage_elements/carousel/tests.py
@@ -7,6 +7,7 @@ from dateutil.relativedelta import relativedelta
 
 from django.contrib.contenttypes.models import ContentType
 from django.test import TestCase
+from django.utils import timezone
 
 from core.homepage_elements.carousel import models
 from comms import models as comms_models
@@ -14,6 +15,8 @@ from journal import models as journal_models
 from submission import models as sm_models
 from utils.testing.helpers import create_journals
 
+FROZEN_DATETIME_20180628 = timezone.make_aware(timezone.datetime(2018, 6, 28, 8, 15, 27))
+FROZEN_DATETIME_20180629 = timezone.make_aware(timezone.datetime(2018, 6, 29, 8, 15, 27))
 
 # Create your tests here.
 class TestCarousel(TestCase):
@@ -23,9 +26,7 @@ class TestCarousel(TestCase):
         cls.journal_one, cls.journal_2 = create_journals()
         cls.issue = journal_models.Issue.objects.create(journal=cls.journal_one)
         cls.news_item = comms_models.NewsItem.objects.create(
-            posted=datetime.datetime.strptime(
-                '2018-06-28 08:15:27.243860', '%Y-%m-%d %H:%M:%S.%f',
-            ),
+            posted=FROZEN_DATETIME_20180628,
         )
         cls.news_item.content_type = ContentType.objects.get_for_model(
             cls.journal_one)
@@ -33,17 +34,13 @@ class TestCarousel(TestCase):
         cls.article = sm_models.Article.objects.create(
             journal=cls.journal_one,
             stage=sm_models.STAGE_PUBLISHED,
-            date_published=datetime.datetime.strptime(
-                '2018-06-29 08:15:27.243860', '%Y-%m-%d %H:%M:%S.%f',
-            ),
+            date_published=FROZEN_DATETIME_20180629,
             title='Carousel Article One',
         )
         cls.article = sm_models.Article.objects.create(
             journal=cls.journal_one,
             stage=sm_models.STAGE_PUBLISHED,
-            date_published=datetime.datetime.strptime(
-                '2019-06-29 08:15:27.243860', '%Y-%m-%d %H:%M:%S.%f',
-            ),
+            date_published=FROZEN_DATETIME_20180629,
             title='Carousel Article Two',
         )
 
@@ -97,9 +94,7 @@ class TestCarousel(TestCase):
     def test_selected_news(self):
         carousel = models.Carousel.objects.create(latest_articles=False)
         news_item = comms_models.NewsItem.objects.create(
-            posted=datetime.datetime.strptime(
-                '2018-06-28 08:15:27.243860', '%Y-%m-%d %H:%M:%S.%f',
-            ),
+            posted=FROZEN_DATETIME_20180628,
         )
         carousel.news_articles.add(news_item)
         self.journal_one.carousel = carousel

--- a/src/core/tests/test_models.py
+++ b/src/core/tests/test_models.py
@@ -13,6 +13,10 @@ from journal import models as journal_models
 from utils.testing import helpers
 from submission import models as submission_models
 
+FROZEN_DATETIME_20210101 = timezone.make_aware(timezone.datetime(2021, 1, 1, 0, 0, 0))
+FROZEN_DATETIME_20210102 = timezone.make_aware(timezone.datetime(2021, 1, 2, 0, 0, 0))
+FROZEN_DATETIME_20210103 = timezone.make_aware(timezone.datetime(2021, 1, 3, 0, 0, 0))
+
 
 class TestAccount(TestCase):
     def test_creation(self):
@@ -290,12 +294,12 @@ class TestLastModifiedModel(TestCase):
 
     def test_last_modified_model(self):
         # prepare
-        with freeze_time("2021-01-02"):
+        with freeze_time(FROZEN_DATETIME_20210102):
             issue_date = self.issue.last_modified = (
                 timezone.now() - timedelta(days=1)
             )
             self.issue.save()
-        with freeze_time("2021-01-01"):
+        with freeze_time(FROZEN_DATETIME_20210101):
             self.article.last_modified = (
                 timezone.now() - timedelta(days=2)
             )
@@ -307,17 +311,17 @@ class TestLastModifiedModel(TestCase):
     def test_last_modified_model_recursive(self):
         # prepare
 
-        with freeze_time("2021-01-03"):
+        with freeze_time(FROZEN_DATETIME_20210103):
             file_obj = models.File.objects.create()
             file_date = file_obj.las_modified = timezone.now()
             file_obj.save()
 
-        with freeze_time("2021-01-02"):
+        with freeze_time(FROZEN_DATETIME_20210102):
             galley = helpers.create_galley(self.article, file_obj)
             galley.last_modified = timezone.now()
             galley.save()
 
-        with freeze_time("2021-01-01"):
+        with freeze_time(FROZEN_DATETIME_20210101):
             self.article.last_modified = timezone.now()
             self.article.save()
 
@@ -327,18 +331,18 @@ class TestLastModifiedModel(TestCase):
     def test_last_modified_model_recursive_circular(self):
         # prepare
 
-        with freeze_time("2021-01-03"):
+        with freeze_time(FROZEN_DATETIME_20210103):
             file_obj = models.File.objects.create()
             file_date = file_obj.las_modified = timezone.now()
             file_obj.save()
 
-        with freeze_time("2021-01-02"):
+        with freeze_time(FROZEN_DATETIME_20210102):
             galley = helpers.create_galley(self.article, file_obj)
             galley.article = self.article
             galley.last_modified = timezone.now()
             galley.save()
 
-        with freeze_time("2021-01-01"):
+        with freeze_time(FROZEN_DATETIME_20210101):
             self.article.last_modified = timezone.now()
             self.article.save()
 
@@ -346,18 +350,18 @@ class TestLastModifiedModel(TestCase):
         self.assertEqual(self.article.best_last_modified_date(), file_date)
 
     def test_last_modified_model_recursive_doubly_linked(self):
-        with freeze_time("2021-01-03"):
+        with freeze_time(FROZEN_DATETIME_20210103):
             file_obj = models.File.objects.create()
             file_date = file_obj.las_modified = timezone.now()
             file_obj.save()
 
-        with freeze_time("2021-01-02"):
+        with freeze_time(FROZEN_DATETIME_20210102):
             galley = helpers.create_galley(self.article, file_obj)
             galley.article = self.article
             galley.last_modified = timezone.now()
             galley.save()
 
-        with freeze_time("2021-01-01"):
+        with freeze_time(FROZEN_DATETIME_20210101):
             self.article.render_galley = galley
             self.article.last_modified = timezone.now()
             self.article.save()

--- a/src/submission/tests.py
+++ b/src/submission/tests.py
@@ -10,11 +10,12 @@ import os
 from django.core.management import call_command
 from django.http import Http404
 from django.test import TestCase, TransactionTestCase
-from django.utils import translation
+from django.utils import translation, timezone
 from django.urls.base import clear_script_prefix
 from django.conf import settings
 from django.shortcuts import reverse
 from django.test.utils import override_settings
+
 import swapper
 
 from core.models import Account, File, Galley
@@ -31,6 +32,8 @@ from utils.install import update_xsl_files, update_settings, update_issue_types
 from utils.testing import helpers
 from utils.testing.helpers import create_galley, request_context
 
+FROZEN_DATETIME_2020 = timezone.make_aware(timezone.datetime(2020, 1, 1, 0, 0, 0))
+FROZEN_DATETIME_1990 = timezone.make_aware(timezone.datetime(1990, 1, 1, 12, 0, 0))
 
 # Create your tests here.
 class SubmissionTests(TestCase):
@@ -98,7 +101,7 @@ class SubmissionTests(TestCase):
     def test_article_image_galley(self):
         article = models.Article.objects.create(
             journal=self.journal_one,
-            date_published=dateparser.parse("2020-01-01"),
+            date_published=FROZEN_DATETIME_2020,
             stage=models.STAGE_PUBLISHED,
         )
         galley_file = File.objects.create(
@@ -124,7 +127,7 @@ class SubmissionTests(TestCase):
             journal = self.journal_one,
             title="Test article: a test article",
             primary_issue=issue,
-            date_published=dateparser.parse("2020-01-01"),
+            date_published=FROZEN_DATETIME_2020,
             page_numbers = "2-4"
         )
         author = models.FrozenAuthor.objects.create(
@@ -151,7 +154,7 @@ class SubmissionTests(TestCase):
             journal = self.journal_one,
             title="Test article: a test article",
             primary_issue=issue,
-            date_published=dateparser.parse("2020-01-01"),
+            date_published=FROZEN_DATETIME_2020,
             page_numbers = "2-4",
             custom_how_to_cite = "Banana",
         )
@@ -552,7 +555,7 @@ class SubmissionTests(TestCase):
             title="Test article: a test article",
             stage="Published",
             abstract="test_abstract",
-            date_published=datetime(1990, 1, 1, 12, 00),
+            date_published=FROZEN_DATETIME_1990,
         )
         helpers.create_issue(self.journal_one, 2, 1, articles=[article])
         author_a, author_b = self.create_authors()
@@ -591,7 +594,7 @@ class SubmissionTests(TestCase):
             title="Test article: A RIS export test case",
             stage="Published",
             abstract="test_abstract",
-            date_published=datetime(1990, 1, 1, 12, 00),
+            date_published=FROZEN_DATETIME_1990,
         )
         helpers.create_issue(self.journal_one, 2, 2, articles=[article])
         author_a, author_b = self.create_authors()
@@ -725,13 +728,13 @@ class ArticleSearchTests(TransactionTestCase):
         article = models.Article.objects.create(
             journal=self.journal_one,
             title="Testing the search of articles",
-            date_published=dateparser.parse("2020-01-01"),
+            date_published=FROZEN_DATETIME_2020,
             stage=models.STAGE_PUBLISHED,
         )
         _other_article = models.Article.objects.create(
             journal=self.journal_one,
             title="This article should not appear",
-            date_published=dateparser.parse("2020-01-01"),
+            date_published=FROZEN_DATETIME_2020,
         )
         file_obj = File.objects.create(article_id=article.pk)
         create_galley(article, file_obj)
@@ -765,14 +768,14 @@ class ArticleSearchTests(TransactionTestCase):
         article = models.Article.objects.create(
             journal=self.journal_one,
             title="Test searching abstract",
-            date_published=dateparser.parse("2020-01-01"),
+            date_published=FROZEN_DATETIME_2020,
             stage=models.STAGE_PUBLISHED,
             abstract=text_to_search,
         )
         other_article = models.Article.objects.create(
             journal=self.journal_one,
             title="This article should not appear",
-            date_published=dateparser.parse("2020-01-01"),
+            date_published=FROZEN_DATETIME_2020,
             abstract="Random abstract crawl text",
         )
 
@@ -793,13 +796,13 @@ class ArticleSearchTests(TransactionTestCase):
         article = models.Article.objects.create(
             journal=self.journal_one,
             title=text_to_search,
-            date_published=dateparser.parse("2020-01-01"),
+            date_published=FROZEN_DATETIME_2020,
             stage=models.STAGE_PUBLISHED,
         )
         other_article = models.Article.objects.create(
             journal=self.journal_one,
             title="This article should not appear",
-            date_published=dateparser.parse("2020-01-01"),
+            date_published=FROZEN_DATETIME_2020,
         )
 
         # Mysql can't search at all without FULLTEXT indexes installed


### PR DESCRIPTION
The tests currently issue a number of warnings about "naive datetimes" ... warnings are distracting. This pull request eliminates them by using timezone.make_aware and timezone.datetime, to work with built-in methods for Django to generate datetimes with expected timezone information.