### PR TITLE
#3402 use publication_title in how to cite if a given article has this field set.

### DIFF
--- a/src/submission/models.py
+++ b/src/submission/models.py
@@ -774,7 +774,7 @@ class Article(AbstractLastModifiedModel):
         year_str = ""
         if self.date_published:
             year_str = "({:%Y})".format(self.date_published)
-        journal_str = "<i>%s</i>" % self.journal.name
+        journal_str = "<i>%s</i>" % self.publication_title if self.publication_title else self.journal.name
         issue_str = ""
         issue = self.issue
         if issue:


### PR DESCRIPTION
Reasoning:

The purpose of this field is to override the default journal name, so this should include the how to cite display.

Note:

Requested in ticket #6382