### PR TITLE
Fixes mutable_cache_property for django 3.2

### DIFF
--- a/src/journal/models.py
+++ b/src/journal/models.py
@@ -273,7 +273,7 @@ class Journal(AbstractSiteModel):
         return setting_handler.get_setting('Identifiers', 'title_doi', self, default=True).value or None
 
     @doi.setter
-    def doi(self, value):
+    def doi_setter(self, value):
         setting_handler.save_setting('Identifiers', 'title_doi', self, value)
 
     @property

--- a/src/utils/function_cache.py
+++ b/src/utils/function_cache.py
@@ -40,10 +40,10 @@ class mutable_cached_property(cached_property):
         if self.fsetter is None:
             raise AttributeError(f"property '{self.name}' has no setter")
         self.fsetter(obj, value)
-        obj.__dict__[self.name] = self.func(obj)
+        obj.__dict__[self.name] = self.real_func(obj)
 
     def setter(self, fsetter):
         prop = type(self)(self.func, self.name)
-        prop.setter = fsetter
+        prop.setter = self.fsetter = fsetter
         return prop
 


### PR DESCRIPTION
Copes with the changes introduced in https://github.com/django/django/commit/06076999026