### PR TITLE
#3230 removes broken button on revision and copyedit replace file screens

### DIFF
--- a/src/templates/admin/copyediting/author_update_file.html
+++ b/src/templates/admin/copyediting/author_update_file.html
@@ -2,61 +2,63 @@
 {% load static %}
 
 
-{% block title %}Revisions for {{ revision_request.article.title }}{% endblock title %}
-{% block title-section %}Revisions for {{ revision_request.article.title }}{% endblock %}
+{% block title %}Replacing Article File for {{ copyedit.article.title }}{% endblock title %}
+{% block title-section %}Replacing Article File for {{ copyedit.article.title }}{% endblock %}
 
 {% block breadcrumbs %}
-{{ block.super }}
-{% include "elements/breadcrumbs/copyeditor_base.html" %}
+    {{ block.super }}
+    {% include "elements/breadcrumbs/copyeditor_base.html" %}
 {% endblock breadcrumbs %}
 
 {% block body %}
     {% csrf_token %}
     <div class="large-12 columns">
-        {% if error %}
-            <div class="alert alert-warning" role="alert">{{ error }}</div>
-        {% endif %}
-        <p><strong>Submission guidelines</strong>: To upload a file, select it using one of the "Choose file" buttons,
-            then upload it with the "Upload file" button. You can add a label to help the editor identify the file.</p>
-        <h5>Replacement File</h5>
-        <p>Please upload your replacement file.</p>
-        <div class="row">
-            <div class="large-6 columns">
-                <form method="POST" enctype="multipart/form-data">
-                    {% csrf_token %}
-                    <h4></h4>
-                    <input name="label" type="text" placeholder="Add a file label">
-                    <input name="replacement-file" type="file" class="filestyle" data-placeholder="No file"
-                           data-buttonName="btn-primary">
-                    <br/>
-                    <button type="submit" class="button success" name="replacement"><i class="fa fa-upload">&nbsp;</i>Upload
-                    </button>
-                </form>
-            </div>
-            <div class="large-6 columns">
-                <table class="scroll small">
-                    <tr>
-                        <th>Label</th>
-                        <th>File Name</th>
-                    </tr>
-                    <tr>
-                        <td>{{ file.label }}</td>
-                        <td><a href="?file_id={{ file.id }}"><i
-                                class="fa fa-download">&nbsp;{{ file }}</i></a></td>
-                    </tr>
-                </table>
-            </div>
-            <div class="large-4 columns"></div>
-        </div>
+        <div class="box">
+            <div class="content">
+                <div class="row expanded">
+                    <div class="large-12 columns">
+                        <div class="title-area">
+                            <h2>Upload Guidelines</h2>
+                        </div>
+                        {% if error %}
+                            <div class="alert alert-warning" role="alert">{{ error }}</div>
+                        {% endif %}
+                        Add a label, select a file and use the Upload and Continue button to upload the file.</p>
+                    </div>
 
-
-        <div class="large-12 columns">
-            <form method="POST">
-                {% csrf_token %}
-                <button class="button success pull-right" type="submit" name="next_step"><i class="fa fa-check">
-                    &nbsp;</i>Save &amp; Continue
-                </button>
-            </form>
+                    <div class="large-6 columns">
+                        <div class="title-area">
+                            <h2>Upload Replacement File</h2>
+                        </div>
+                        <form method="POST" enctype="multipart/form-data">
+                            {% csrf_token %}
+                            <input name="label" type="text" placeholder="Add a file label">
+                            <input name="replacement-file" type="file" class="filestyle" data-placeholder="No file"
+                                   data-buttonName="btn-primary">
+                            <br/>
+                            <button type="submit" class="button success" name="replacement"><i
+                                    class="fa fa-upload">&nbsp;</i>Upload and Continue
+                            </button>
+                        </form>
+                    </div>
+                    <div class="large-6 columns">
+                        <div class="title-area">
+                            <h2>Current File</h2>
+                        </div>
+                        <table class="scroll small">
+                            <tr>
+                                <th>Label</th>
+                                <th>File Name</th>
+                            </tr>
+                            <tr>
+                                <td>{{ file.label }}</td>
+                                <td><a href="?file_id={{ file.id }}"><i
+                                        class="fa fa-download">&nbsp;{{ file }}</i></a></td>
+                            </tr>
+                        </table>
+                    </div>
+                </div>
+            </div>
         </div>
     </div>
 

--- a/src/templates/admin/copyediting/author_update_file.html
+++ b/src/templates/admin/copyediting/author_update_file.html
@@ -23,7 +23,8 @@
                         {% if error %}
                             <div class="alert alert-warning" role="alert">{{ error }}</div>
                         {% endif %}
-                        Add a label, select a file and use the Upload and Continue button to upload the file.</p>
+                        <p>You are reviewing copyediting of article #{{ copyedit.article.pk }}, {{ copyedit.article.title|safe }}.</p>
+                        <p>Add a label, select a file and use the Upload and Continue button to upload the file.</p>
                     </div>
 
                     <div class="large-6 columns">

--- a/src/templates/admin/review/revision/replace_file.html
+++ b/src/templates/admin/review/revision/replace_file.html
@@ -23,7 +23,7 @@
                         <h2>Upload Guidelines</h2>
                     </div>
                     <div class="content">
-                        <p>Add a label, select a file and use the Upload and Continue button to upload the file</p>
+                        <p>You are revising article #{{ article.pk }}, {{ article.title|safe }}. </p><p>Add a label, select a file and use the Upload and Continue button to upload the file</p>
                         {% if error %}
                             <div class="alert alert-warning" role="alert">{{ error }}</div>
                         {% endif %}

--- a/src/templates/admin/review/revision/replace_file.html
+++ b/src/templates/admin/review/revision/replace_file.html
@@ -2,8 +2,8 @@
 {% load static %}
 
 
-{% block title %}Revisions for {{ revision_request.article.title }}{% endblock title %}
-{% block title-section %}Revisions for {{ revision_request.article.title }}{% endblock %}
+{% block title %}Replacing Article File for {{ revision_request.article.title }}{% endblock title %}
+{% block title-section %}Replacing Article File for {{ revision_request.article.title }}{% endblock %}
 
 {% block breadcrumbs %}
     {{ block.super }}
@@ -16,61 +16,51 @@
 {% block body %}
     {% csrf_token %}
     <div class="large-12 columns">
-
         <div class="box">
-            <div class="title-area">
-                <h2>Submission Guidelines</h2>
-            </div>
-            <div class="content">
-                <p>To upload a file, select it using one of the "Choose file" buttons,
-                    then upload it with the "Upload file" button. You can add a label to help the editor identify the
-                    file.</p>
-                {% if error %}
-                    <div class="alert alert-warning" role="alert">{{ error }}</div>
-                {% endif %}
-
-                <div class="row expanded">
-                    <div class="large-6 columns">
-                        <form method="POST" enctype="multipart/form-data">
-                            {% csrf_token %}
-                            <p>Upload Your File</p>
-                            <input name="label" type="text" value="Revised Manuscript">
-                            <input name="replacement-file" type="file" class="filestyle" data-placeholder="No file"
-                                   data-buttonName="btn-primary">
-                            <br/>
-                            <button type="submit" class="button success" name="replacement"><i class="fa fa-upload">
-                                &nbsp;</i>Upload
-                            </button>
-                        </form>
-                    </div>
-                    <div class="large-6 columns">
-                        <table class="scroll small">
-                            <tr>
-                                <th>Label</th>
-                                <th>File Name</th>
-                            </tr>
-                            <tr>
-                                <td>{{ file.label }}</td>
-                                <td><a href="?download=true"><i
-                                        class="fa fa-download">&nbsp;{{ file }}</i></a></td>
-                            </tr>
-                        </table>
-                    </div>
-                    <div class="large-4 columns">
-
-                    </div>
-
-
-
+            <div class="row expanded">
                 <div class="large-12 columns">
-                    <form method="POST">
+                    <div class="title-area">
+                        <h2>Upload Guidelines</h2>
+                    </div>
+                    <div class="content">
+                        <p>Add a label, select a file and use the Upload and Continue button to upload the file</p>
+                        {% if error %}
+                            <div class="alert alert-warning" role="alert">{{ error }}</div>
+                        {% endif %}
+                    </div>
+                </div>
+
+                <div class="large-6 columns">
+                    <form method="POST" enctype="multipart/form-data">
                         {% csrf_token %}
-                        <button class="button success float-right" type="submit" name="next_step"><i class="fa fa-check">
-                            &nbsp;</i>Save &amp; Continue
+                        <div class="title-area">
+                            <h2>Upload Revised File</h2>
+                        </div>
+                        <input name="label" type="text" value="Revised Manuscript">
+                        <input name="replacement-file" type="file" class="filestyle" data-placeholder="No file"
+                               data-buttonName="btn-primary">
+                        <br/>
+                        <button type="submit" class="button success" name="replacement"><i class="fa fa-upload">
+                            &nbsp;</i>Upload and Continue
                         </button>
                     </form>
                 </div>
+                <div class="large-6 columns">
+                    <div class="title-area">
+                        <h2>Current File</h2>
                     </div>
+                    <table class="scroll small">
+                        <tr>
+                            <th>Label</th>
+                            <th>File Name</th>
+                        </tr>
+                        <tr>
+                            <td>{{ file.label }}</td>
+                            <td><a href="?download=true"><i
+                                    class="fa fa-download">&nbsp;{{ file }}</i></a></td>
+                        </tr>
+                    </table>
+                </div>
             </div>
         </div>
     </div>


### PR DESCRIPTION
- Removes the Continue button (as per #3230)
- Renames the Upload button to Upload and Continue (as per #3230)
- Additionally updates the Copyedit replace file screen (this template appears to be a copy of the revise one and even had a broken title, which has been fixed)
- Makes both of these interfaces similar in layout
- Updated guide text which was specific to Chrome (Firefox says "Browse" Chrome says "Choose file" so its now generic)
- Closes #3230 


![image](https://user-images.githubusercontent.com/8321378/222432811-0ad67b6b-aaa1-42c2-b8e0-7eb331f26da9.png)
![image](https://user-images.githubusercontent.com/8321378/222432900-e62a8094-7b60-4017-8bd6-d6ef6d54e0f4.png)

