### PR TITLE
#3428 revives the contact_info attrbiture as a Setting and uses it on the Contact page.

### DIFF
--- a/src/core/logic.py
+++ b/src/core/logic.py
@@ -416,7 +416,7 @@ def get_settings_to_edit(display_group, journal):
         journal_settings = [
             'journal_name', 'journal_issn', 'print_issn', 'journal_theme',
             'journal_description', 'main_contact', 'publisher_name',
-            'publisher_url', 'privacy_policy_url', 'auto_signature',
+            'publisher_url', 'contact_info', 'privacy_policy_url', 'auto_signature',
             'slack_logging', 'slack_webhook', 'twitter_handle',
             'switch_language', 'enable_language_text', 'google_analytics_code',
             'use_ga_four', 'display_login_page_notice', 'login_page_notice', 

--- a/src/templates/admin/elements/forms/group_journal.html
+++ b/src/templates/admin/elements/forms/group_journal.html
@@ -13,6 +13,7 @@
     {% include "admin/elements/forms/field.html" with field=edit_form.publisher_name %}
     {% include "admin/elements/forms/field.html" with field=edit_form.publisher_url %}
     {% include "admin/elements/forms/field.html" with field=edit_form.main_contact %}
+    {% include "admin/elements/forms/field.html" with field=edit_form.contact_info %}
     {% include "admin/elements/forms/field.html" with field=edit_form.privacy_policy_url %}
 </div>
 

--- a/src/themes/OLH/templates/journal/contact.html
+++ b/src/themes/OLH/templates/journal/contact.html
@@ -17,9 +17,9 @@
                     <h5>{{ contact.name }}</h5>
                     <p>{{ contact.role }}</p>
                 {% endfor %}
-                {% if request.journal and request.journal.contact_info %}
+                {% if journal_settings.general.contact_info %}
                     <h4>{% trans 'Contact Information' %}</h4>
-                    {{ request.journal.contact_info|safe }}
+                    {{ journal_settings.general.contact_info|safe }}
                 {% endif %}
             </div>
             <div class="large-8 columns">

--- a/src/themes/clean/templates/journal/contact.html
+++ b/src/themes/clean/templates/journal/contact.html
@@ -12,9 +12,9 @@
                 <h3 class="card-title editor-name">{{ contact.name }}</h3>
                 <p>{{ contact.role }}</p>
             {% endfor %}
-            {% if request.journal and request.journal.contact_info %}
-                <h4>{% trans 'Contact Information' %}</h4>
-                {{ request.journal.contact_info|safe }}
+            {% if journal_settings.general.contact_info %}
+                <h2>{% trans 'Contact Information' %}</h2>
+                {{ journal_settings.general.contact_info|safe }}
             {% endif %}
         </div>
         <div class="col-md-8">

--- a/src/themes/material/templates/journal/contact.html
+++ b/src/themes/material/templates/journal/contact.html
@@ -24,12 +24,11 @@
                         <h5>{{ contact.name }}</h5>
                         <p>{{ contact.role }}</p>
                     {% endfor %}
-                    {% if request.journal and request.journal.contact_info %}
+                    {% if journal_settings.general.contact_info %}
                         <span class="card-title">
                             {% trans 'Contact Information' %}
                          </span>
-                            {{ request.journal.contact_info|safe }}
-
+                        {{ journal_settings.general.contact_info|safe }}
                     {% endif %}
                 </div>
             </div>

--- a/src/utils/install/journal_defaults.json
+++ b/src/utils/install/journal_defaults.json
@@ -3733,7 +3733,25 @@
         "value": {
             "default": ""
         }
+    },
+    {
+        "group": {
+            "name": "general"
+        },
+        "setting": {
+            "description": "Can include information such as the physical contact address for the journal.",
+            "is_translatable": true,
+            "name": "contact_info",
+            "pretty_name": "Contact Information",
+            "type": "rich-text"
+        },
+        "value": {
+            "default": ""
+        },
+        "editable_by": [
+            "editor",
+            "journal-manager"
+        ]
     }
-
 ]
 


### PR DESCRIPTION
- Adds a new setting called contact_info
- Replaces the old attribute on Contact page which is now defunct
- Closes #3428 