### PR TITLE
Tweaks utils.0030 to avoid multiple leaf nodes error

### DIFF
--- a/src/utils/migrations/0030_upgrade_1_5_0.py
+++ b/src/utils/migrations/0030_upgrade_1_5_0.py
@@ -19,7 +19,7 @@ def upgrade(apps, schema_editor):
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('utils', '0028_upgrade_1_4_4'),
+        ('utils', '0029_alter_toaddress_options'),
         ('core', '0080_merge_20230317_1530'),
     ]
 


### PR DESCRIPTION
@joemull noted he was seeing a multiple leaf nodes error when running `migrate` for 1.5. I saw this also this morning.