### PR TITLE
Rewrites last_modified calculation to rely on a DB call to GREATEST()

### DIFF
--- a/src/submission/models.py
+++ b/src/submission/models.py
@@ -37,7 +37,7 @@ from core.model_utils import(
     BaseSearchManagerMixin,
     M2MOrderedThroughField,
 )
-from core import workflow, model_utils, files
+from core import workflow, model_utils, files, models as core_models
 from core.templatetags.truncate import truncatesmart
 from identifiers import logic as id_logic
 from identifiers import models as identifier_models
@@ -45,7 +45,6 @@ from metrics.logic import ArticleMetrics
 from review import models as review_models
 from utils.function_cache import cache
 from utils.logger import get_logger
-from utils import setting_handler
 
 logger = get_logger(__name__)
 
@@ -948,8 +947,6 @@ class Article(AbstractLastModifiedModel):
                 'graphic': 'xlink:href'
             }
 
-            from core import models as core_models
-
             # iterate over all found elements
             for element, attribute in elements.items():
                 images = souped_xml.findAll(element)
@@ -1049,7 +1046,6 @@ class Article(AbstractLastModifiedModel):
         return self.get_identifier('pubid')
 
     def is_accepted(self):
-        from core import models as core_models
         if self.date_published:
             return True
 
@@ -1574,12 +1570,10 @@ class Article(AbstractLastModifiedModel):
 
     @cache(600)
     def workflow_stages(self):
-        from core import models as core_models
         return core_models.WorkflowLog.objects.filter(article=self)
 
     @property
     def current_workflow_element(self):
-        from core import models as core_models
         try:
             workflow_element_name = workflow.STAGES_ELEMENTS.get(
                 self.stage,

--- a/src/utils/logic.py
+++ b/src/utils/logic.py
@@ -2,6 +2,7 @@ import os
 import hashlib
 import hmac
 from urllib.parse import SplitResult, quote_plus, urlencode
+from tqdm import tqdm
 
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
@@ -304,26 +305,22 @@ def write_all_sitemaps(cli=False):
         file.close()
 
     # Generate Journal Sitemaps
-    for journal in journals:
-        if cli:
-            print("Generating sitemaps for {}".format(journal.name))
+    if cli:
+        print("Generating sitemaps for journals")
+    for journal in tqdm(journals):
         write_journal_sitemap(journal)
 
         # Generate Issue Sitemap
         for issue in journal.published_issues:
-            if cli:
-                print("Generating sitemap for issue {}".format(issue))
             write_issue_sitemap(issue)
 
     # Generate Repo Sitemap
-    for repo in repos:
-        if cli:
-            print("Generating sitemaps for {}".format(repo.name))
+    if cli:
+        print("Generating sitemaps for repositories")
+    for repo in tqdm(repos):
         write_repository_sitemap(repo)
 
         for subject in repo.subject_set.all():
-            if cli:
-                print("Generating sitemap for subject {}".format(subject.name))
             write_subject_sitemap(subject)
 
 


### PR DESCRIPTION
Turns out traversing the model tree as python objects was slow and didn't scale particularly well.
This rewrite relies on a call to the database function greatest (support added to the ORM in Django 3.2) which should run faster.

Calculation of the tree nodes related to a given model is now done only once in `AbstractLastModifiedModel` and cached in a class variable