### PR TITLE
Add a test for whether /usr/bin/crontab exists, before attempting to run install_cron. Warn if crontab not found.

### DIFF
--- a/.update.sh
+++ b/.update.sh
@@ -13,11 +13,7 @@ python3 src/manage.py update_repository_settings
 python3 src/manage.py install_plugins
 python3 src/manage.py update_translation_fields
 python3 src/manage.py clear_cache
-if [ -f "/usr/bin/crontab" ]; then
-  python3 src/manage.py install_cron
-else
-  echo "WARNING: /usr/bin/crontab not found, skipping crontab configuration, please investigate."
-fi
+python3 src/manage.py install_cron
 
 echo "REMINDER: don't forget to restart your webserver!"
 exit 0

--- a/.update.sh
+++ b/.update.sh
@@ -13,6 +13,11 @@ python3 src/manage.py update_repository_settings
 python3 src/manage.py install_plugins
 python3 src/manage.py update_translation_fields
 python3 src/manage.py clear_cache
-python3 src/manage.py install_cron
+if [ -f "/usr/bin/crontab" ]; then
+  python3 src/manage.py install_cron
+else
+  echo "WARNING: /usr/bin/crontab not found, skipping crontab configuration, please investigate."
+fi
+
 echo "REMINDER: don't forget to restart your webserver!"
 exit 0

--- a/src/cron/management/commands/install_cron.py
+++ b/src/cron/management/commands/install_cron.py
@@ -33,8 +33,12 @@ class Command(BaseCommand):
         :param options: None
         :return: None
         """
+        if not os.path.isfile('/usr/bin/crontab'):
+            print("WARNING: /usr/bin/crontab not found, skipping crontab config.")
+            return
+
         if not crontab:
-            print("crontab not is not installed")
+            print("WARNING: crontab module is not installed, skipping crontab config.")
             return
 
         action = options.get('action')


### PR DESCRIPTION
Crontab might be missing from certain environments (especially local developer environments). This PR makes running install_cron optional, and dependent on the existence of /usr/bin/crontab. Warns if the file isn't found.