### PR TITLE
Fixes an issue with redirection from middleware in Django 3.2

### DIFF
--- a/src/utils/middleware.py
+++ b/src/utils/middleware.py
@@ -27,7 +27,9 @@ class BaseMiddleware():
         """
 
         if hasattr(self, 'process_request'):
-            self.process_request(request)
+            response = self.process_request(request)
+            if response is not None:
+                return response
 
         response = self.get_response(request)
 


### PR DESCRIPTION
The new BaseMiddleware was ignoring potential returned `HttpRequest` by the legacy `process_request` methods 