### PR TITLE
Pre-sanitize MAIL.FROM before sending notifications

### DIFF
--- a/src/utils/notify_plugins/notify_email.py
+++ b/src/utils/notify_plugins/notify_email.py
@@ -1,9 +1,11 @@
 import re
 
 from collections.abc import Iterable
+from email.utils import parseaddr
 
 from django.conf import settings
 from django.core.mail import EmailMultiAlternatives
+from django.utils.encoding import force_str
 from django.utils.html import strip_tags
 
 from utils import setting_handler
@@ -39,6 +41,11 @@ def send_email(subject, to, html, journal, request, bcc=None, cc=None, attachmen
     if request and request.user and not request.user.is_anonymous and request.user.email not in to:
         reply_to = [request.user.email]
         full_from_string = "{0} <{1}>".format(request.user.full_name(), from_email)
+        # handle django 3.2 raising an exception during sanitization
+        # This call is ported from django 1.11
+        full_from_string = parseaddr(force_str(full_from_string))
+
+
     else:
         reply_to = []
         if request:


### PR DESCRIPTION
Resolves a problem in Django 3.2 where MAIL FROM values with invalid characters would raise an exception.

I ported the logic from django 1.11 where the email will still be sent with the correct email address, rather than throwing an error to the end-user. We might want to clean up the invalid characters instead, after I'm done reading the 95 pages of RFC 5321...