### PR TITLE
Update docs/requirements.txt to pin a few module versions

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,5 @@
 recommonmark
 Sphinx==1.8.2
 sphinx-rtd-theme
+jinja2==2.11.3
+markupsafe==2.0.1


### PR DESCRIPTION
- without the pinning, the Makefile throws errors
- pin jinja2 to 2.11.3
- pin markupsafe to 2.0.1