### PR TITLE
Remove recaptcha_init templatetag

### DIFF
--- a/src/themes/material/templates/journal/contact.html
+++ b/src/themes/material/templates/journal/contact.html
@@ -4,10 +4,6 @@
 
 {% block title %}{% trans "Contact" %}{% endblock %}
 
-{% block head %}
-    {% recaptcha_init %}
-{% endblock %}
-
 {% block body %}
     <div class="row">
         <div class="col m5">


### PR DESCRIPTION
Recaptcha templatetag loading has been removed in https://github.com/BirkbeckCTP/janeway/issues/1683 but the templatetag call must be removed too