### PR TITLE
Issue assignment clarity

### DIFF
--- a/src/core/locales/fr/LC_MESSAGES/django.po
+++ b/src/core/locales/fr/LC_MESSAGES/django.po
@@ -1842,8 +1842,11 @@ msgstr ""
 
 #: src/templates/admin/review/projected_issue.html:31
 msgid ""
-"The projected issue setting helps you track which issue an article is "
-"intended to be published with."
+"The projected issue field is for journals that add articles "
+"to issues on a rolling basis and publish them individually, "
+"rather than publishing them all at once. It helps you track "
+"internally which issue an article is intended to be published with, "
+"without displaying an unpublished article under a published issue."
 msgstr ""
 
 #: src/templates/admin/review/projected_issue.html:32
@@ -1852,8 +1855,8 @@ msgstr ""
 
 #: src/templates/admin/review/projected_issue.html:33
 msgid ""
-"Select an issue from the drop down on the left and press save, this articles "
-"projected issue will now be set."
+"Select an issue from the drop down on the left and press save. "
+"This article's projected issue will now be set."
 msgstr ""
 
 #: src/templates/admin/review/projected_issue.html:34
@@ -1861,7 +1864,7 @@ msgid "Can I unset a projected issue?"
 msgstr ""
 
 #: src/templates/admin/review/projected_issue.html:35
-msgid "Yes, simply select the blank option (-------) from the drop down."
+msgid "Yes, you can select the blank option (-------) from the dropdown."
 msgstr ""
 
 #: src/templates/admin/review/revision/do_revision.html:106

--- a/src/core/locales/fr/LC_MESSAGES/django.po
+++ b/src/core/locales/fr/LC_MESSAGES/django.po
@@ -1842,11 +1842,11 @@ msgstr ""
 
 #: src/templates/admin/review/projected_issue.html:31
 msgid ""
-"The projected issue field is for journals that add articles "
-"to issues on a rolling basis and publish them individually, "
-"rather than publishing them all at once. It helps you track "
-"internally which issue an article is intended to be published with, "
-"without displaying an unpublished article under a published issue."
+"The projected issue field can be used internally to keep "
+"track of plans and communicate with typesetters, without "
+"affecting issue assignment or displaying anything publicly. "
+"It is helpful for journals that add articles to issues on a "
+"rolling basis and publish them individually."
 msgstr ""
 
 #: src/templates/admin/review/projected_issue.html:32

--- a/src/submission/migrations/0040_article_projected_issue.py
+++ b/src/submission/migrations/0040_article_projected_issue.py
@@ -17,6 +17,16 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='article',
             name='projected_issue',
-            field=models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.SET_NULL, related_name='projected_issue', to='journal.Issue'),
+            field=models.ForeignKey(
+                to='journal.Issue',
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                related_name='projected_issue',
+                help_text='This field is for internal purposes only '
+                          'before publication. You can use it to '
+                          'track likely issue assignment before formally '
+                          'assigning an issue.',
+            ),
         ),
     ]

--- a/src/submission/migrations/0042_auto_20200423_1534.py
+++ b/src/submission/migrations/0042_auto_20200423_1534.py
@@ -16,6 +16,15 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='article',
             name='primary_issue',
-            field=models.ForeignKey(blank=True, help_text='You can only assign an Issue that this Article is part of.You can add this article to and Issue from the Issue Manager.', null=True, on_delete=django.db.models.deletion.SET_NULL, to='journal.Issue'),
+            field=models.ForeignKey(
+                to='journal.Issue',
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                help_text='You can only assign an issue '
+                          'that this article is part of. '
+                          'You can add this article to an '
+                          'issue from the Issue Manager.',
+            ),
         ),
     ]

--- a/src/submission/models.py
+++ b/src/submission/models.py
@@ -750,8 +750,10 @@ class Article(AbstractLastModifiedModel):
         blank=True,
         null=True,
         on_delete=models.SET_NULL,
-        help_text='You can only assign an Issue that this Article is part of.'
-                  'You can add this article to and Issue from the Issue Manager.'
+        help_text='You can only assign an issue '
+                  'that this article is part of. '
+                  'You can add this article to an '
+                  'issue from the Issue Manager.',
     )
     projected_issue = models.ForeignKey(
         'journal.Issue',
@@ -759,6 +761,10 @@ class Article(AbstractLastModifiedModel):
         null=True,
         on_delete=models.SET_NULL,
         related_name='projected_issue',
+        help_text='This field is for internal purposes only '
+                  'before publication. You can use it to '
+                  'track likely issue assignment before formally '
+                  'assigning an issue.',
     )
 
     # Meta

--- a/src/templates/admin/elements/metadata.html
+++ b/src/templates/admin/elements/metadata.html
@@ -248,7 +248,9 @@
             <th>Volume</th>
             <th>Number</th>
             <th>Published</th>
-            <th></th>
+            {% if user_is_editor %}
+                <th></th>
+            {% endif %}
         </tr>
         {% if article.primary_issue %}
         <tr>
@@ -257,12 +259,21 @@
             <td>{{ article.primary_issue.volume }}</td>
             <td>{{ article.primary_issue.issue }}</td>
             <td>{{ article.primary_issue.date }}</td>
-            <td><a href="{% url 'manage_issues_id' article.primary_issue.pk %}">Issue Manager</a></td>
+            {% if user_is_editor %}
+                <td>
+                    <a href="{% url 'manage_issues_id' article.primary_issue.pk %}">
+                        Issue Manager
+                    </a>
+                </td>
+            {% endif %}
         </tr>
         {% else %}
         <tr>
             <td colspan="6">
-                <p>This article does not have a primary issue yet.{% if user_is_editor or request.user.is_staff %} You can assign one now using the <a target='_blank' href="{% url 'manage_issues' %}">issue manager</a>, or wait and assign one during the pre-publication checklist.{% endif %}</p>
+                <p>This article does not have a primary issue yet.</p>
+                {% if user_is_editor %}
+                    <p>You can assign one now using the <a target='_blank' href="{% url 'manage_issues' %}">issue manager</a>, or wait and assign one during the pre-publication checklist.</p>
+                {% endif %}
             </td>
         </tr>
         {% endif %}

--- a/src/templates/admin/elements/metadata.html
+++ b/src/templates/admin/elements/metadata.html
@@ -213,8 +213,8 @@
 <div class="content">
     <table class="scroll">
         <tr>
-            <th>Issue ID</th>
-            <th>Issue Title</th>
+            <th>ID</th>
+            <th>Title</th>
             <th>Volume</th>
             <th>Number</th>
             <th>Published</th>
@@ -238,45 +238,51 @@
 </div>
 
 <div class="title-area">
-    <h2>Primary Issue</h2>
+    <h2>Issues and Collections</h2>
 </div>
 <div class="content">
     <table class="scroll">
         <tr>
-            <th>Issue ID</th>
-            <th>Issue Title</th>
+            <th>ID</th>
+            <th>Title</th>
             <th>Volume</th>
             <th>Number</th>
             <th>Published</th>
+            <th>Primary</th>
             {% if user_is_editor %}
                 <th></th>
             {% endif %}
         </tr>
-        {% if article.primary_issue %}
+        {% for issue in article.issues_list %}
         <tr>
-            <td>{{ article.primary_issue.id }}</td>
-            <td>{{ article.primary_issue.issue_title }}</td>
-            <td>{{ article.primary_issue.volume }}</td>
-            <td>{{ article.primary_issue.issue }}</td>
-            <td>{{ article.primary_issue.date }}</td>
+            <td>{{ article.issue.id }}</td>
+            <td>{{ article.issue.issue_title }}</td>
+            <td>{{ article.issue.volume }}</td>
+            <td>{{ article.issue.issue }}</td>
+            <td>{{ article.issue.date }}</td>
+            <td>
+                {% if issue == article.primary_issue %}
+                    <i class="fa fa-check"></i>
+                {% endif %}
+            </td>
             {% if user_is_editor %}
                 <td>
-                    <a href="{% url 'manage_issues_id' article.primary_issue.pk %}">
+                    <a href="{% url 'manage_issues_id' article.issue.pk %}">
                         Issue Manager
                     </a>
                 </td>
             {% endif %}
         </tr>
-        {% else %}
+        {% empty %}
         <tr>
             <td colspan="6">
-                <p>This article does not have a primary issue yet.</p>
+                <p>This article is not yet assigned to any issues or collections.</p>
                 {% if user_is_editor %}
                     <p>You can assign one now using the <a target='_blank' href="{% url 'manage_issues' %}">issue manager</a>, or wait and assign one during the pre-publication checklist.</p>
                 {% endif %}
             </td>
         </tr>
-        {% endif %}
+        {% endfor %}
     </table>
 </div>
 

--- a/src/templates/admin/elements/metadata.html
+++ b/src/templates/admin/elements/metadata.html
@@ -227,11 +227,43 @@
             <td>{{ article.projected_issue.volume }}</td>
             <td>{{ article.projected_issue.issue }}</td>
             <td>{{ article.projected_issue.date }}</td>
-            <td><a href="{% url 'manage_issues_id' article.projected_issue.pk %}">Issue Manager</a></td>
+            <td><a href="{% url 'review_projected_issue' article.pk %}">Projected Issue Assignment</a></td>
         </tr>
         {% else %}
         <tr>
             <td colspan="6">This article does not have a projected issue.{% if user_is_editor or request.user.is_staff %} You can <a href="{% url 'review_projected_issue' article.pk %}?return={{ request.path|urlencode }}">assign one</a>.{% endif %}</td>
+        </tr>
+        {% endif %}
+    </table>
+</div>
+
+<div class="title-area">
+    <h2>Primary Issue</h2>
+</div>
+<div class="content">
+    <table class="scroll">
+        <tr>
+            <th>Issue ID</th>
+            <th>Issue Title</th>
+            <th>Volume</th>
+            <th>Number</th>
+            <th>Published</th>
+            <th></th>
+        </tr>
+        {% if article.primary_issue %}
+        <tr>
+            <td>{{ article.primary_issue.id }}</td>
+            <td>{{ article.primary_issue.issue_title }}</td>
+            <td>{{ article.primary_issue.volume }}</td>
+            <td>{{ article.primary_issue.issue }}</td>
+            <td>{{ article.primary_issue.date }}</td>
+            <td><a href="{% url 'manage_issues_id' article.primary_issue.pk %}">Issue Manager</a></td>
+        </tr>
+        {% else %}
+        <tr>
+            <td colspan="6">
+                <p>This article does not have a primary issue yet.{% if user_is_editor or request.user.is_staff %} You can assign one now using the <a target='_blank' href="{% url 'manage_issues' %}">issue manager</a>, or wait and assign one during the pre-publication checklist.{% endif %}</p>
+            </td>
         </tr>
         {% endif %}
     </table>

--- a/src/templates/admin/elements/summary_modal.html
+++ b/src/templates/admin/elements/summary_modal.html
@@ -16,7 +16,7 @@
             {% if user_is_editor %}
                 {% if article.ithenticate_id %}
                 <div class="title-area">
-                    <h2>Similarty Check</h2>
+                    <h2>Similarity Check</h2>
                 </div>
                 <div class="content">
                     <p><a href="{% url 'review_crosscheck' article.pk %}" target="_blank"><i class="fa fa-book">&nbsp;</i>View Report {% if article.ithenticate_score %} (Score: {{ article.ithenticate_score }}%){% endif %}</a></p>

--- a/src/templates/admin/production/assign_typesetter.html
+++ b/src/templates/admin/production/assign_typesetter.html
@@ -18,11 +18,11 @@
                 {% include "elements/forms/errors.html" with form=form %}
                 {% csrf_token %}
             </div>
-            {% if not article.projected_issue %}
+            {% if not article.primary_issue and not article.projected_issue %}
             <div class="callout alert" data-closable style="background-color: #f7e4e1; color: #0a0a0a">
-                <h5>Article missing projected issue</h5>
+                <h5>Article missing primary or projected issue</h5>
                 <p>
-                    This Article doesn't have a projected issue, the typesetter won't know what issue this article belongs to. You can
+                    This Article doesn't have a primary or projected issue, so the typesetter won't know what issue this article belongs to. You can
                     <a href="{% url 'review_projected_issue' article.pk %}?return={{ request.path|urlencode }}">
                         assign one here.
                     </a>

--- a/src/templates/admin/production/assign_typesetter.html
+++ b/src/templates/admin/production/assign_typesetter.html
@@ -18,7 +18,7 @@
                 {% include "elements/forms/errors.html" with form=form %}
                 {% csrf_token %}
             </div>
-            {% if not article.primary_issue and not article.projected_issue %}
+            {% if not article.issue and not article.projected_issue %}
             <div class="callout alert" data-closable style="background-color: #f7e4e1; color: #0a0a0a">
                 <h5>Article missing primary or projected issue</h5>
                 <p>

--- a/src/templates/admin/review/projected_issue.html
+++ b/src/templates/admin/review/projected_issue.html
@@ -28,7 +28,7 @@
 				</div>
 				<div class="content">
 					<p><strong>{% trans "What is this for?" %}</strong></p>
-					<p>{% trans "The projected issue field is for journals that add articles to issues on a rolling basis and publish them individually, rather than publishing them all at once. It helps you track internally which issue an article is intended to be published with, without displaying an unpublished article under a published issue."%}</p>
+					<p>{% trans "The projected issue field can be used internally to keep track of plans and communicate with typesetters, without affecting issue assignment or displaying anything publicly. It is helpful for journals that add articles to issues on a rolling basis and publish them individually." %}</p>
 					<p><strong>{% trans "How does it work?" %}</strong></p>
 					<p>{% trans "Select an issue from the drop down on the left and press save. This article's projected issue will now be set." %}</p>
 					<p><strong>{% trans "Can I unset a projected issue?" %}</strong></p>

--- a/src/templates/admin/review/projected_issue.html
+++ b/src/templates/admin/review/projected_issue.html
@@ -28,11 +28,11 @@
 				</div>
 				<div class="content">
 					<p><strong>{% trans "What is this for?" %}</strong></p>
-					<p>{% trans "The projected issue setting helps you track which issue an article is intended to be published with."%}</p>
+					<p>{% trans "The projected issue field is for journals that add articles to issues on a rolling basis and publish them individually, rather than publishing them all at once. It helps you track internally which issue an article is intended to be published with, without displaying an unpublished article under a published issue."%}</p>
 					<p><strong>{% trans "How does it work?" %}</strong></p>
-					<p>{% trans "Select an issue from the drop down on the left and press save, this articles projected issue will now be set." %}</p>
+					<p>{% trans "Select an issue from the drop down on the left and press save. This article's projected issue will now be set." %}</p>
 					<p><strong>{% trans "Can I unset a projected issue?" %}</strong></p>
-					<p>{% trans "Yes, simply select the blank option (-------) from the drop down." %}</p>
+					<p>{% trans "Yes, you can select the blank option (-------) from the dropdown." %}</p>
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
The issue described in #2750 has likely been fixed, but in investigating it, I found a bug in the View Metadata modal that meant users could not change Projected Issue after it was set, because they were sent to the Issue Manager instead of the Projected Issue assignment form.

I changed the link to the correct form, but I did not want to get rid of the link between View Metadata and the Issue Manager, because even if it was the "wrong" link, some people might be using it to manage primary issue assignment before pre-publication. So I added a table for Primary Issue to View Metadata below Projected Issue, and I clarified the text around these forms so that new editors could more easily get up to speed on the difference between Projected and Primary and manage both flexibly.

![image](https://user-images.githubusercontent.com/47217308/235670362-86a5bedc-2c60-4a0c-8123-c758bf0fa5e8.png)

![Projected Issue Assignment](https://user-images.githubusercontent.com/47217308/235670095-97256ae7-5be1-4452-9e9f-2eade8c0115c.png)

Closes #2750 