### PR TITLE
#3240 when a mailgun email is logged as failed or bounced it will now send an email to the actor (if they are staff, editor or repo manger) and log that it was sent

### DIFF
--- a/src/submission/views.py
+++ b/src/submission/views.py
@@ -383,7 +383,6 @@ def delete_funder(request, article_id, funder_id):
     return redirect(reverse('submit_funding', kwargs={'article_id': article_id}))
 
 
-
 @login_required
 @article_edit_user_required
 def delete_author(request, article_id, author_id):

--- a/src/utils/install/journal_defaults.json
+++ b/src/utils/install/journal_defaults.json
@@ -4782,5 +4782,43 @@
         "editable_by": [
             "journal-manager"
         ]
+    },
+    {
+        "group": {
+            "name": "email"
+        },
+        "setting": {
+            "description": "Email sent when an outgoing email bounces.",
+            "is_translatable": true,
+            "name": "bounced_email_notification",
+            "pretty_name": "Bounced Email Notification",
+            "type": "rich-text"
+        },
+        "value": {
+            "default": "<p>An email sent to {% for email in event.to %}{{ email }}{% if not forloop.last %}, {% endif %}{% endfor %} has not been delivered.{% if target %} This message was in regards to {{ event.content_type.model }} #{{ target.pk }} \"{{ target.title|safe }}\".{% endif %}</p><p>Kind Regards,</p>"
+        },
+        "editable_by": [
+            "editor",
+            "journal-manager"
+        ]
+    },
+    {
+        "group": {
+            "name": "email_subject"
+        },
+        "setting": {
+            "description": "Subject for Bounced Email Notification.",
+            "is_translatable": true,
+            "name": "subject_bounced_email_notification",
+            "pretty_name": "Subject Bounced Email Notification",
+            "type": "char"
+        },
+        "value": {
+            "default": "Email Bounced"
+        },
+        "editable_by": [
+            "editor",
+            "journal-manager"
+        ]
     }
 ]

--- a/src/utils/logic.py
+++ b/src/utils/logic.py
@@ -35,7 +35,7 @@ def parse_mailgun_webhook(post):
     if event and (mailgun_event == 'dropped' or mailgun_event == 'bounced'):
         event.message_status = 'failed'
         event.save()
-        attempt_actor_email(event)
+        send_bounce_notification_to_event_actor(event)
         return 'Message dropped, actor notified.'
     elif event and mailgun_event == 'delivered':
         event.message_status = 'delivered'
@@ -56,7 +56,7 @@ def verify_webhook(token, timestamp, signature):
     return hmac.compare_digest(signature, hmac_digest.encode('utf-8'))
 
 
-def attempt_actor_email(event):
+def send_bounce_notification_to_event_actor(event):
     """
     Attempts to send a notification email to an actor when a message bounces.
     Messages are only send to staff, editors and repository managers.

--- a/src/utils/management/commands/check_mailgun_stat.py
+++ b/src/utils/management/commands/check_mailgun_stat.py
@@ -1,11 +1,10 @@
 import requests
-from pprint import pprint
 
 from django.contrib.contenttypes.models import ContentType
 from django.core.management.base import BaseCommand
 from django.conf import settings
 
-from utils import models
+from utils import models, logic
 from submission import models as submission_models
 
 
@@ -73,10 +72,11 @@ class Command(BaseCommand):
                 if 'delivered' in events:
                     log.message_status = 'delivered'
                     log.status_checks_complete = True
-                elif 'failed' in events:
+                elif 'failed' in events or 'bounced' in events:
                     if check_for_perm_failure(event_dict, log):
                         log.message_status = 'failed'
                         log.status_checks_complete = True
+                        logic.attempt_actor_email(log)
                     else:
                         log.message_status = 'accepted'
 

--- a/src/utils/management/commands/check_mailgun_stat.py
+++ b/src/utils/management/commands/check_mailgun_stat.py
@@ -76,7 +76,7 @@ class Command(BaseCommand):
                     if check_for_perm_failure(event_dict, log):
                         log.message_status = 'failed'
                         log.status_checks_complete = True
-                        logic.attempt_actor_email(log)
+                        logic.send_bounce_notification_to_event_actor(log)
                     else:
                         log.message_status = 'accepted'
 

--- a/src/utils/management/commands/test_bounce_notification.py
+++ b/src/utils/management/commands/test_bounce_notification.py
@@ -19,4 +19,4 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         log_id = options.get('log_id')
         log_entry = models.LogEntry.objects.get(pk=log_id)
-        logic.attempt_actor_email(log_entry)
+        logic.send_bounce_notification_to_event_actor(log_entry)

--- a/src/utils/management/commands/test_bounce_notification.py
+++ b/src/utils/management/commands/test_bounce_notification.py
@@ -1,0 +1,22 @@
+from django.core.management.base import BaseCommand
+
+from utils import models, logic
+
+
+class Command(BaseCommand):
+    """Attempts to update mailgun status for log entries"""
+
+    help = "Attempts to update delivery status for mailgun emails."
+
+    def add_arguments(self, parser):
+        """Adds arguments to Django's management command-line parser.
+
+        :param parser: the parser to which the required arguments will be added
+        :return: None
+        """
+        parser.add_argument('log_id', type=int)
+
+    def handle(self, *args, **options):
+        log_id = options.get('log_id')
+        log_entry = models.LogEntry.objects.get(pk=log_id)
+        logic.attempt_actor_email(log_entry)

--- a/src/utils/render_template.py
+++ b/src/utils/render_template.py
@@ -10,9 +10,17 @@ from utils import setting_handler
 
 def get_message_content(request, context, template, plugin=False, template_is_setting=False):
     if plugin:
-        template = setting_handler.get_plugin_setting(plugin, template, None).value
+        template = setting_handler.get_plugin_setting(
+            plugin,
+            template,
+            None
+        ).value
     elif not template_is_setting:
-        template = setting_handler.get_setting('email', template, request.journal).value
+        template = setting_handler.get_setting(
+            'email',
+            template,
+            request.journal,
+        ).value
 
     template = Template(template)
     con = RequestContext(request)


### PR DESCRIPTION
- `check_mailgun_stat` now triggers actor message
- `attempt_actor_email` has been renamed `send_bounce_notification_to_event_actor`
- Notification now works for both journal articles and repository preprints
- Bounce notifications are logged
- Closes #3240 