### PR TITLE
Fixes a 500 raised error when a galley has no file associated with it

### DIFF
--- a/src/security/logic.py
+++ b/src/security/logic.py
@@ -69,7 +69,9 @@ def can_view_file_history(request, user, file_object, article_object):
     return can_edit_file(request, user, file_object, article_object)
 
 
-def can_view_file(request, user, file_object):
+def can_view_file(request, user, file_object=None):
+    if not file_object:
+        return True
     # general conditions under which a file can be viewed
     if file_object.privacy == 'public':
         return True


### PR DESCRIPTION
Closes #3508