### PR TITLE
Fixes a number of issues with Janeway version missmatches

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -48,6 +48,7 @@ python-dateutil==2.8.1
 python-docx==0.8.6
 python-magic==0.4.13
 requests==2.25.1
+semver==3.0.0
 six==1.14.0
 sqlparse==0.2.3
 swapper==1.3.0

--- a/src/core/model_utils.py
+++ b/src/core/model_utils.py
@@ -513,14 +513,23 @@ class BaseSearchManagerMixin(Manager):
     def get_search_lookups(self):
         return self.search_lookups
 
-
 class SearchVector(DjangoSearchVector):
     """ An Extension of SearchVector that works with SearchVectorField
 
     Django's implementation assumes that the `to_tsvector` function needs
     to be called with the provided column, except that when the field is already
-    a SearchVectorField, there is no need.
+    a SearchVectorField, there is no need. Django's implementation in 2.2
+    (405c8363362063542e9e79beac53c8437d389520) also attempts to cast the
+    column data into a TextField, prior to casting to the tsvector, which we
+    override under `set_source_expressions`
+
     """
+    def set_source_expressions(self, _):
+        """ Ignore Django's implementation
+        We don't require the expressions to be re-casted during the as_sql call
+        """
+        pass
+
     # Override template to ignore function
     function = None
     template = '%(expressions)s'

--- a/src/janeway/__init__.py
+++ b/src/janeway/__init__.py
@@ -1,0 +1,2 @@
+from semver import Version
+__version__ = Version.parse("1.5.0")

--- a/src/utils/logic.py
+++ b/src/utils/logic.py
@@ -12,6 +12,7 @@ from cron.models import Request
 from utils import models, notify_helpers
 from utils.logger import get_logger
 from utils.function_cache import cache
+from janeway import __version__ as janeway_version
 from journal import models as journal_models
 from repository import models as repo_models
 from press import models as press_models
@@ -152,19 +153,11 @@ def get_current_request():
         return None
 
 
-@cache(seconds=600)
 def get_janeway_version():
     """ Returns the installed version of janeway
     :return: `string` version
     """
-    v = models.Version.objects.filter(rollback=None).order_by("-pk").first()
-    if v:
-        return v.number
-    else:
-        logger.error(
-            'No version record found.',
-        )
-        return "9.9.9"
+    return str(janeway_version)
 
 
 def get_log_entries(object):


### PR DESCRIPTION
Due to how Janeway versioning currently works, it is impossible to upgrade Janeway and plugins at the same time (see #3462 for context)

The version should live statically in the codebase rather than just in the database. This PR does still preserve those models so that version changes can still be tracked.

It also makes use of the semver library rather than parsing version numbers ad-hoc during startup checks

closes #3462 