### PR TITLE
Ensure article titles are marked as safe consistently

### DIFF
--- a/src/core/homepage_elements/featured/templates/featured_setup.html
+++ b/src/core/homepage_elements/featured/templates/featured_setup.html
@@ -28,7 +28,7 @@
                                             class="tiny alert button"><i class="fa fa-trash"></i></button>
                                 </div>
                                 <small>
-                                    {{ fa.article.title|safe }}<br/>
+                                    {{ fa.article.safe_title }}<br/>
                                     Added on {{ fa.added }} by {{ fa.added_by.full_name }}<br/>
                                 </small>
                             </li>
@@ -50,7 +50,7 @@
                         <tbody>
                         {% for article in articles %}
                             <tr>
-                                <td>{{ article.title|safe }}</td>
+                                <td>{{ article.safe_title }}</td>
                                 <td>{{ article.date_published }}</td>
                                 <td>{{ article.author_list }}</td>
                                 <td>

--- a/src/core/migrations/0082_mark_safe_article_title.py
+++ b/src/core/migrations/0082_mark_safe_article_title.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+import re
+from django.conf import settings
+from django.db import migrations
+
+REGEX = re.compile("{{\ ?([a-z\._-]*)article.title\ ?}}")
+OUTPUT_FMT = "{{ %sarticle.safe_title }}"
+
+def replace_matches( match):
+    prefix = match.group(1)
+    return OUTPUT_FMT % prefix
+
+def replace_article_title(apps, schema_editor):
+    SettingValue = apps.get_model('core', 'SettingValue')
+    setting_values= SettingValue.objects.all()
+    for setting in setting_values:
+        for language in settings.LANGUAGES:
+            value_string = 'value_{}'.format(language[0])
+            if setting and getattr(setting, value_string, None):
+                setattr(
+                    setting, value_string,
+                    re.sub(REGEX, replace_matches, getattr(setting, value_string))
+                )
+                setting.save()
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('core', '0081_alter_account_preferred_timezone'),
+    ]
+
+    operations = [
+        migrations.RunPython(replace_article_title, reverse_code=migrations.RunPython.noop),
+    ]

--- a/src/discussion/models.py
+++ b/src/discussion/models.py
@@ -41,9 +41,9 @@ class Thread(models.Model):
 
     def object_title(self):
         if self.article:
-            return self.article.title
+            return self.article.safe_title
         elif self.preprint:
-            return self.preprint.title
+            return self.preprint.safe_title
 
     def object_string(self):
         if self.article:

--- a/src/repository/models.py
+++ b/src/repository/models.py
@@ -11,6 +11,7 @@ from django.db import models
 from django.db.models import Q
 from django.utils import timezone
 from django.conf import settings
+from django.utils.html import mark_safe
 from django.utils.translation import gettext_lazy as _
 from django.dispatch import receiver
 from django.shortcuts import reverse
@@ -507,6 +508,13 @@ class Preprint(models.Model):
         return [pa.account for pa in preprint_authors]
 
     @property
+    def safe_title(self):
+        if self.title:
+            return mark_safe(self.title)
+        else:
+            return "<Untitled>"
+
+    @property
     def supplementaryfiles(self):
         return PreprintSupplementaryFile.objects.filter(
             preprint=self,
@@ -969,6 +977,13 @@ class PreprintVersion(models.Model):
         else:
             return ''
 
+    @property
+    def safe_title(self):
+        if self.title:
+            return mark_safe(self.title)
+        else:
+            return "<Untitled>"
+
     def __str__(self):
         return f'{self.preprint} (version {self.version})'
 
@@ -1162,6 +1177,13 @@ class VersionQueue(models.Model):
             return _('Under Review')
         else:
             return _('Declined')
+
+    @property
+    def safe_title(self):
+        if self.title:
+            return mark_safe(self.title)
+        else:
+            return "<Untitled>"
 
 
 def review_status_choices():

--- a/src/repository/models.py
+++ b/src/repository/models.py
@@ -512,7 +512,7 @@ class Preprint(models.Model):
         if self.title:
             return mark_safe(self.title)
         else:
-            return "<Untitled>"
+            return "[Untitled]"
 
     @property
     def supplementaryfiles(self):
@@ -982,7 +982,7 @@ class PreprintVersion(models.Model):
         if self.title:
             return mark_safe(self.title)
         else:
-            return "<Untitled>"
+            return "[Untitled]"
 
     def __str__(self):
         return f'{self.preprint} (version {self.version})'
@@ -1183,7 +1183,7 @@ class VersionQueue(models.Model):
         if self.title:
             return mark_safe(self.title)
         else:
-            return "<Untitled>"
+            return "[Untitled]"
 
 
 def review_status_choices():

--- a/src/submission/models.py
+++ b/src/submission/models.py
@@ -785,7 +785,7 @@ class Article(AbstractLastModifiedModel):
         if self.title:
             return mark_safe(self.title)
         else:
-            return "<Untitled>"
+            return "[Untitled]"
 
     @property
     def how_to_cite(self):

--- a/src/submission/models.py
+++ b/src/submission/models.py
@@ -781,6 +781,13 @@ class Article(AbstractLastModifiedModel):
         ordering = ('-date_published', 'title')
 
     @property
+    def safe_title(self):
+        if self.title:
+            return mark_safe(self.title)
+        else:
+            return "<Untitled>"
+
+    @property
     def how_to_cite(self):
         if self.custom_how_to_cite:
             return self.custom_how_to_cite
@@ -821,7 +828,7 @@ class Article(AbstractLastModifiedModel):
         context = {
             "author_str": author_str,
             "year_str": year_str,
-            "title": mark_safe(self.title),
+            "title": self.safe_title,
             "journal_str": journal_str,
             "issue_str": issue_str,
             "doi_str": doi_str,
@@ -903,7 +910,7 @@ class Article(AbstractLastModifiedModel):
 
     @property
     def carousel_title(self):
-        return self.title
+        return self.safe_title
 
     @property
     def carousel_image_resolver(self):

--- a/src/templates/admin/copyediting/add_copyeditor_assignment.html
+++ b/src/templates/admin/copyediting/add_copyeditor_assignment.html
@@ -4,7 +4,7 @@
 
 {% block title %}Add Copyeditor{% endblock %}
 {% block title-section %}Add Copyeditor{% endblock %}
-{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.title }}{% endblock %}
+{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.safe_title }}{% endblock %}
 
 {% block breadcrumbs %}
     {{ block.super }}

--- a/src/templates/admin/copyediting/article_copyediting.html
+++ b/src/templates/admin/copyediting/article_copyediting.html
@@ -3,7 +3,7 @@
 
 {% block title %}Copyediting {{ article.title }}{% endblock %}
 {% block title-section %}Copyediting{% endblock %}
-{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.title }}{% endblock %}
+{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.safe_title }}{% endblock %}
 
 {% block breadcrumbs %}
     {{ block.super }}

--- a/src/templates/admin/copyediting/author_review.html
+++ b/src/templates/admin/copyediting/author_review.html
@@ -6,7 +6,7 @@
 
 {% block title %}Copyediting Review{% endblock %}
 {% block title-section %}Copyediting Review{% endblock %}
-{% block title-sub %}{{ copyedit.article.title }}{% endblock %}
+{% block title-sub %}{{ copyedit.article.safe_title }}{% endblock %}
 
 {% block css %}
     <link href="{% static "common/css/jquery-te-1.4.0.css" %}" rel="stylesheet">{% endblock %}

--- a/src/templates/admin/copyediting/author_update_file.html
+++ b/src/templates/admin/copyediting/author_update_file.html
@@ -3,7 +3,7 @@
 
 
 {% block title %}Replacing Article File for {{ copyedit.article.title }}{% endblock title %}
-{% block title-section %}Replacing Article File for {{ copyedit.article.title }}{% endblock %}
+{% block title-section %}Replacing Article File for {{ copyedit.article.safe_title }}{% endblock %}
 
 {% block breadcrumbs %}
     {{ block.super }}
@@ -23,7 +23,7 @@
                         {% if error %}
                             <div class="alert alert-warning" role="alert">{{ error }}</div>
                         {% endif %}
-                        <p>You are reviewing copyediting of article #{{ copyedit.article.pk }}, {{ copyedit.article.title|safe }}.</p>
+                        <p>You are reviewing copyediting of article #{{ copyedit.article.pk }}, {{ copyedit.article.safe_title }}.</p>
                         <p>Add a label, select a file and use the Upload and Continue button to upload the file.</p>
                     </div>
 

--- a/src/templates/admin/copyediting/copyediting.html
+++ b/src/templates/admin/copyediting/copyediting.html
@@ -31,7 +31,7 @@
                 {% for article in articles_in_copyediting %}
                     <tr>
                         <td>{{ article.pk }}</td>
-                        <td>{{ article.title }}</td>
+                        <td>{{ article.safe_title }}</td>
                         <td>{{ article.date_submitted }}</td>
                         <td>{{ article.correspondence_author.full_name }}</td>
                         <td>{{ article.section.name }}</td>

--- a/src/templates/admin/copyediting/delete_author_review.html
+++ b/src/templates/admin/copyediting/delete_author_review.html
@@ -5,7 +5,7 @@
 {% block title-section %}
     Delete Author Copyedit Request #{{ author_review.id }}
 {% endblock %}
-{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.title }}{% endblock %}
+{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.safe_title }}{% endblock %}
 
 {% block breadcrumbs %}
     {{ block.super }}

--- a/src/templates/admin/copyediting/edit_assignment.html
+++ b/src/templates/admin/copyediting/edit_assignment.html
@@ -3,7 +3,7 @@
 
 {% block title %}Edit Assignment{% endblock %}
 {% block title-section %}Edit Assignment{% endblock %}
-{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.title }}{% endblock %}
+{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.safe_title }}{% endblock %}
 
 {% block breadcrumbs %}
     {{ block.super }}

--- a/src/templates/admin/copyediting/editor_review.html
+++ b/src/templates/admin/copyediting/editor_review.html
@@ -4,7 +4,7 @@
 {% block title %}Editor Review Copyedit{% endblock %}
 {% block title-section %}Review Copyedit Assignment #{{ copyedit.id }} by
     {{ copyedit.copyeditor.full_name }}{% endblock %}
-{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.title }}{% endblock %}
+{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.safe_title }}{% endblock %}
 
 {% block breadcrumbs %}
     {{ block.super }}

--- a/src/templates/admin/copyediting/notify_copyeditor_assignment.html
+++ b/src/templates/admin/copyediting/notify_copyeditor_assignment.html
@@ -5,7 +5,7 @@
 
 {% block css %}<link href="{% static "common/css/jquery-te-1.4.0.css" %}" rel="stylesheet">{% endblock %}
 {% block title %}Editor Assignment Notification{% endblock %}
-{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.title }}{% endblock %}
+{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.safe_title }}{% endblock %}
 
 {% block body %}
 

--- a/src/templates/admin/copyediting/request_author_copyedit.html
+++ b/src/templates/admin/copyediting/request_author_copyedit.html
@@ -5,7 +5,7 @@
 {% block title-section %}
     Request Author Copyedit #{{ author_review.id }}
 {% endblock %}
-{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.title }}{% endblock %}
+{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.safe_title }}{% endblock %}
 
 {% block breadcrumbs %}
     {{ block.super }}

--- a/src/templates/admin/copyediting/upload_file.html
+++ b/src/templates/admin/copyediting/upload_file.html
@@ -4,7 +4,7 @@
 
 {% block title %}Copyedit for {{ copyedit.article.title }}{% endblock title %}
 {% block title-section %}Copyedit{% endblock %}
-{% block title-sub %}{{ copyedit.article.title }}{% endblock %}
+{% block title-sub %}{{ copyedit.article.safe_title }}{% endblock %}
 
 {% block breadcrumbs %}
     {{ block.super }}

--- a/src/templates/admin/core/article.html
+++ b/src/templates/admin/core/article.html
@@ -5,14 +5,14 @@
 {% block breadcrumbs %}
     {{ block.super }}
     <li>Author</li>
-    <li>{{ article.title }}</li>
+    <li>{{ article.safe_title }}</li>
 {% endblock %}
 
 {% block body %}
 
     <div class="box">
         <div class="title-area">
-            <h2>{{ article.title }}</h2>
+            <h2>{{ article.safe_title }}</h2>
         </div>
         {% if article.stage == "Published" %}
             {% hook 'edit_article' %}

--- a/src/templates/admin/core/dashboard.html
+++ b/src/templates/admin/core/dashboard.html
@@ -186,7 +186,7 @@
                                 <tr>
                                     <td>{{ assignment.article.pk }}</td>
                                     <td>
-                                        <a href="{{ assignment.article.current_workflow_element_url }}">{{ assignment.article.title }}</a>
+                                        <a href="{{ assignment.article.current_workflow_element_url }}">{{ assignment.article.safe_title }}</a>
                                     </td>
                                     <td>{{ assignment.article.author_list }}</td>
                                     <td>{{ assignment.article.date_submitted }}</td>

--- a/src/templates/admin/core/email_user.html
+++ b/src/templates/admin/core/email_user.html
@@ -3,7 +3,7 @@
 
 {% block title %}Resend Logged Email{% endblock %}
 {% block title-section %}Resend Logged Email ID #{{ log_entry.pk }}{% endblock %}
-{% block title-sub %}Log entry for article #{{ article.pk }}: {{ article.title|safe }}{% endblock %}
+{% block title-sub %}Log entry for article #{{ article.pk }}: {{ article.safe_title }}{% endblock %}
 
 {% block breadcrumb %}
     {{ block.super }}

--- a/src/templates/admin/core/manager/article_list.html
+++ b/src/templates/admin/core/manager/article_list.html
@@ -38,9 +38,9 @@
                             <td>{{ article.pk }}</td>
                             <td>
                                 {% if article.stage and article.stage != 'Rejected' and article.stage != 'Published' %}
-                                    <a href="{{ article.current_workflow_element_url }}" target="_blank">{{ article.title|safe }}</a>
+                                    <a href="{{ article.current_workflow_element_url }}" target="_blank">{{ article.safe_title }}</a>
                                 {% else %}
-                                    <a href="{% external_journal_url article.journal 'manage_archive_article' article.pk %}" target="_blank">{{ article.title|safe }}</a>
+                                    <a href="{% external_journal_url article.journal 'manage_archive_article' article.pk %}" target="_blank">{{ article.safe_title }}</a>
                                 {% endif %}
                             </td>
                             <td>{{ article.author_list }}</td>

--- a/src/templates/admin/core/manager/identifier_manager.html
+++ b/src/templates/admin/core/manager/identifier_manager.html
@@ -91,9 +91,9 @@
                             <td>{{ article.pk }}</td>
                             <td>
                                 {% if article.stage and article.stage != 'Rejected' and article.stage != 'Published' %}
-                                    <a href="{{ article.current_workflow_element_url }}" target="_blank">{{ article.title|safe }}</a>
+                                    <a href="{{ article.current_workflow_element_url }}" target="_blank">{{ article.safe_title }}</a>
                                 {% else %}
-                                    <a href="{% external_journal_url article_journal 'manage_archive_article' article.pk %}" target="_blank">{{ article.title|safe }}</a>
+                                    <a href="{% external_journal_url article_journal 'manage_archive_article' article.pk %}" target="_blank">{{ article.safe_title }}</a>
                                 {% endif %}
                             </td>
                             {% if not journal %}

--- a/src/templates/admin/core/manager/images/article_image.html
+++ b/src/templates/admin/core/manager/images/article_image.html
@@ -9,7 +9,7 @@
     {{ block.super }}
     <li><a href="{% url 'core_manager_index' %}">Manager</a></li>
     <li><a href="{% url 'core_article_images' %}">Article Images Manager</a></li>
-    <li>Image for {{ article.title|safe }}</li>
+    <li>Image for {{ article.safe_title }}</li>
 {% endblock %}
 
 {% block body %}

--- a/src/templates/admin/core/manager/images/articles.html
+++ b/src/templates/admin/core/manager/images/articles.html
@@ -30,7 +30,7 @@
                     <tbody>
                     {% for article in articles %}
                     <tr>
-                        <td>{{ article.title|safe }}</td>
+                        <td>{{ article.safe_title }}</td>
                         <td>{{ article.date_published }}</td>
                         <td>{{ article.author_list }}</td>
                         <td><a href="{% url 'core_article_image_edit' article.pk %}">Edit Image</a></td>

--- a/src/templates/admin/core/manager/index.html
+++ b/src/templates/admin/core/manager/index.html
@@ -166,7 +166,7 @@
                             <tbody>
                             {% for article in published_articles %}
                                 <tr>
-                                    <td>{{ article.title|safe }}</td>
+                                    <td>{{ article.safe_title }}</td>
                                     <td>{{ article.metrics.views }}</td>
                                     <td>{{ article.metrics.downloads }}</td>
                                     <td>{{ article.date_published }}</td>

--- a/src/templates/admin/core/manager/pinned_articles.html
+++ b/src/templates/admin/core/manager/pinned_articles.html
@@ -38,7 +38,7 @@
                     {% for pin in pinned_articles %}                       
                         <tr id="orders-{{ pin.pk }}">
                             <td>{{ pin.sequence }}</td>
-                            <td>{{ pin.article.title|safe }}</td>
+                            <td>{{ pin.article.safe_title }}</td>
                             <td>{{ pin.article.doi }}</td>
                             <td>{{ pin.article.correspondence_author.full_name }}</td>
                             <td>{{ pin.article.date_published }}</td>
@@ -73,7 +73,7 @@
                         {% for article in published_articles %}
                             {% if article.is_published %}                         
                             <tr>
-                                <td>{{ article.title|safe }}</td>
+                                <td>{{ article.safe_title }}</td>
                                 <td>{{ article.doi }}</td>
                                 <td>{{ article.correspondence_author.full_name }}</td>
                                 <td>{{ article.date_published }}</td>

--- a/src/templates/admin/core/manager/sections/section_articles.html
+++ b/src/templates/admin/core/manager/sections/section_articles.html
@@ -38,7 +38,7 @@
                     <tbody>
                         {% for article in section.article_set.all %}
                             <tr>
-                                <td>{{ article.title|safe }}</td>
+                                <td>{{ article.safe_title }}</td>
                                 <td>{{ article.date_submitted }}</td>
                                 <td>{{ article.stage }}</td>
                                 <td>{{ article.correspondence_author.full_name }}</td>

--- a/src/templates/admin/core/manager/users/history.html
+++ b/src/templates/admin/core/manager/users/history.html
@@ -29,7 +29,7 @@
                         </tr>
                         {% for assignment in user.editorassignment_set.all %}
                             <tr>
-                                <td>{{ assignment.article.title }}</td>
+                                <td>{{ assignment.article.safe_title }}</td>
                                 <td>{{ assignment.assigned }}</td>
                                 <td>{{ assignment.notified }}</td>
                                 <td>{{ assignment.editor_type|capfirst }}</td>
@@ -56,7 +56,7 @@
                         </tr>
                         {% for assignment in review_assignments %}
                             <tr>
-                                <td>{{ assignment.article.title }}</td>
+                                <td>{{ assignment.article.safe_title }}</td>
                                 <td>{{ assignment.date_requested }}</td>
                                 <td>{{ assignment.date_due }}</td>
                                 <td>{{ assignment.date_complete }}</td>
@@ -85,7 +85,7 @@
                         </tr>
                         {% for assignment in copyedit_assignments %}
                             <tr>
-                                <td>{{ assignment.article.title }}</td>
+                                <td>{{ assignment.article.safe_title }}</td>
                                 <td>{{ assignment.assigned }}</td>
                                 <td>{{ assignment.due }}</td>
                                 <td>{{ assignment.copyeditor_completed }}</td>
@@ -112,7 +112,7 @@
                         </tr>
                         {% for assignment in user.typesettask_set.all %}
                             <tr>
-                                <td>{{ assignment.assignment.article.title }}</td>
+                                <td>{{ assignment.assignment.article.safe_title }}</td>
                                 <td>{{ assignment.assigned }}</td>
                                 <td>{{ assignment.accepted }}</td>
                                 <td>{{ assignment.completed }}</td>
@@ -141,7 +141,7 @@
                         </tr>
                         {% for assignment in user.productionassignment_set.all %}
                             <tr>
-                                <td>{{ assignment.article.title }}</td>
+                                <td>{{ assignment.article.safe_title }}</td>
                                 <td>{{ assignment.assigned }}</td>
                                 <td>{{ assignment.notified }}</td>
                                 <td>{{ assignment.closed }}</td>
@@ -168,7 +168,7 @@
                         </tr>
                         {% for assignment in user.proofingtask_set.all %}
                             <tr>
-                                <td>{{ assignment.round.assignment.article.title }}</td>
+                                <td>{{ assignment.round.assignment.article.safe_title }}</td>
                                 <td>{{ assignment.assigned }}</td>
                                 <td>{{ assignment.due }}</td>
                                 <td>{{ assignment.completed }}</td>

--- a/src/templates/admin/elements/breadcrumbs/copyediting_base.html
+++ b/src/templates/admin/elements/breadcrumbs/copyediting_base.html
@@ -1,3 +1,3 @@
 <li><a href="{% url 'copyediting' %}">Articles in Copyediting</a></li>
-{% if article %}<li><a href="{% url 'article_copyediting' article.pk %}">{{ article.title }}</a></li>{% endif %}
+{% if article %}<li><a href="{% url 'article_copyediting' article.pk %}">{{ article.safe_title }}</a></li>{% endif %}
 {% if assignment %} <li><a href="{% url 'review_view_review' assignment.article.id assignment.id %}">Copyeditor Assignment</a></li>{% endif %}

--- a/src/templates/admin/elements/breadcrumbs/copyeditor_base.html
+++ b/src/templates/admin/elements/breadcrumbs/copyeditor_base.html
@@ -1,2 +1,2 @@
 <li><a href="{% url 'copyedit_requests' %}">Copyediting Requests</a></li>
-{% if copyedit %}<li><a href="{% url 'do_copyedit' copyedit.pk %}">Copyedit for {{ copyedit.article.title }}</a></li>{% endif %}
+{% if copyedit %}<li><a href="{% url 'do_copyedit' copyedit.pk %}">Copyedit for {{ copyedit.article.safe_title }}</a></li>{% endif %}

--- a/src/templates/admin/elements/breadcrumbs/preprints_galley.html
+++ b/src/templates/admin/elements/breadcrumbs/preprints_galley.html
@@ -1,3 +1,3 @@
 <li><a href="{% url 'core_manager_index' %}">Press Manager</a></li>
 <li><a href="{% url 'preprints_manager' %}">Preprint Manager</a></li>
-<li><a href="{% url 'prepringot ts_manager_article' article.pk %}">{{ article.title|safe }}</a></li>
+<li><a href="{% url 'prepringot ts_manager_article' article.pk %}">{{ article.safe_title }}</a></li>

--- a/src/templates/admin/elements/breadcrumbs/production_manager_base.html
+++ b/src/templates/admin/elements/breadcrumbs/production_manager_base.html
@@ -1,6 +1,6 @@
 <li><a href="{% url 'production_list' %}">Articles in Production</a></li>
-{% if article %}<li><a href="{% url 'production_article' article.pk %}">{{ article.title }}</a></li>{% endif %}
+{% if article %}<li><a href="{% url 'production_article' article.pk %}">{{ article.safe_title }}</a></li>{% endif %}
 {% if typeset_task and not article %}
-<li><a href="{% url 'production_article' typeset_task.assignment.article.pk %}">{{ typeset_task.assignment.article.title }}</a></li>
+<li><a href="{% url 'production_article' typeset_task.assignment.article.pk %}">{{ typeset_task.assignment.article.safe_title }}</a></li>
 {% endif %}
 

--- a/src/templates/admin/elements/breadcrumbs/proofing_manager_base.html
+++ b/src/templates/admin/elements/breadcrumbs/proofing_manager_base.html
@@ -1,2 +1,2 @@
 <li><a href="{% url 'proofing_list' %}">Articles in Proofing</a></li>
-{% if article %}<li><a href="{% url 'proofing_article' article.pk %}">{{ article.title|safe }}</a></li>{% endif %}
+{% if article %}<li><a href="{% url 'proofing_article' article.pk %}">{{ article.safe_title }}</a></li>{% endif %}

--- a/src/templates/admin/elements/breadcrumbs/proofreader_base.html
+++ b/src/templates/admin/elements/breadcrumbs/proofreader_base.html
@@ -1,2 +1,2 @@
 <li><a href="{% url 'proofing_requests' %}">Proofing Requests</a></li>
-{% if article %}<li><a href="{% url 'proofing_article' article.pk %}">{{ article.title|safe }}</a></li>{% endif %}
+{% if article %}<li><a href="{% url 'proofing_article' article.pk %}">{{ article.safe_title }}</a></li>{% endif %}

--- a/src/templates/admin/elements/breadcrumbs/review_base.html
+++ b/src/templates/admin/elements/breadcrumbs/review_base.html
@@ -1,3 +1,3 @@
 <li><a href="{% url 'review_home' %}">Articles in Review</a></li>
-{% if article %}<li><a href="{% url 'review_in_review' article.pk %}">{{ article.title }}</a></li>{% endif %}
+{% if article %}<li><a href="{% url 'review_in_review' article.pk %}">{{ article.safe_title }}</a></li>{% endif %}
 {% if review or assignment %} <li><a href="{% if review %}{% url 'review_view_review' review.article.id review.id %}{% elif assignment %}{% url 'review_view_review' assignment.article.id assignment.id %}{% endif %}">Review</a></li>{% endif %}

--- a/src/templates/admin/elements/copyediting/card.html
+++ b/src/templates/admin/elements/copyediting/card.html
@@ -1,6 +1,6 @@
 <div class="card">
     <div class="card-divider">
-        <h4>#{{ request.article.pk }} {{ request.article.title|safe }}</h4>
+        <h4>#{{ request.article.pk }} {{ request.article.safe_title }}</h4>
     </div>
     <div class="card-section">
         <p>A request for copyediting has been made.</p>

--- a/src/templates/admin/elements/core/author_dashboard.html
+++ b/src/templates/admin/elements/core/author_dashboard.html
@@ -20,7 +20,7 @@
                     <tbody>
                     {% for article in progress_submissions %}
                         <tr>
-                            <td>{% if article.title %}{{ article.title|safe }}{% else %}No Title
+                            <td>{% if article.title %}{{ article.safe_title }}{% else %}No Title
                                 Assigned{% endif %}</td>
                             <td>{{ article.step_name }}</td>
                             <td>{{ article.date_started }}</td>
@@ -50,7 +50,7 @@
                     <tbody>
                     {% for article in active_submissions %}
                         <tr>
-                            <td>{% if article.title %}{{ article.title|safe }}{% else %}No Title
+                            <td>{% if article.title %}{{ article.safe_title }}{% else %}No Title
                                 Assigned{% endif %}</td>
                             <td>{{ article.get_stage_display }}</td>
                             <td>{{ article.date_submitted }}</td>
@@ -95,7 +95,7 @@
                     <tbody>
                     {% for article in published_submissions %}
                         <tr>
-                            <td>{{ article.title|safe }}</td>
+                            <td>{{ article.safe_title }}</td>
                             <td>{{ article.get_stage_display }}</td>
                             <td>{{ article.date_published }}</td>
                             <td>

--- a/src/templates/admin/elements/core/kanban/card.html
+++ b/src/templates/admin/elements/core/kanban/card.html
@@ -1,6 +1,6 @@
 <div class="card">
     <div class="card-divider">
-        <h5>{{ article.pk }} - {{ article.title|safe }}</h5>
+        <h5>{{ article.pk }} - {{ article.safe_title }}</h5>
     </div>
     <div class="card-section">
         {% if type == "unassigned" %}

--- a/src/templates/admin/elements/issue/table_of_contents.html
+++ b/src/templates/admin/elements/issue/table_of_contents.html
@@ -39,7 +39,7 @@
                             <tr id="articles-{{ article.pk }}">
                                 <td><i class="fa fa-sort"></i> {{ article.id }}</td>
                                 <td>
-                                    <a href="{% url 'manage_archive_article' article.pk %}">{{ article.title|safe }}</a>
+                                    <a href="{% url 'manage_archive_article' article.pk %}">{{ article.safe_title }}</a>
                                 </td>
                                 <td>{{ article.date_published }}</td>
                                 <td>{{ article.author_list }}</td>

--- a/src/templates/admin/elements/metadata.html
+++ b/src/templates/admin/elements/metadata.html
@@ -11,7 +11,7 @@
     <a class="float-right" href="{% url 'edit_metadata' article.pk %}?return={{ request.path|urlencode }}"><i
             class="fa fa-edit">&nbsp;</i>Edit Metadata</a>
 {% endif %}
-<h4>{{ article.title|safe }}</h4>
+<h4>{{ article.safe_title }}</h4>
 <table class="scroll small">
     <tr>
         <th>Section</th>

--- a/src/templates/admin/elements/production/card.html
+++ b/src/templates/admin/elements/production/card.html
@@ -3,7 +3,7 @@
 
 <div class="card">
     <div class="card-divider">
-        <h4>{{ article.pk }} - {{ article.title|safe }}</h4>
+        <h4>{{ article.pk }} - {{ article.safe_title }}</h4>
     </div>
     <div class="card-section">
         {% if type == "assignment" %}

--- a/src/templates/admin/elements/production/typesetter_card.html
+++ b/src/templates/admin/elements/production/typesetter_card.html
@@ -1,6 +1,6 @@
 <div class="card">
     <div class="card-divider">
-        <h4>{{ task.assignment.article.title|safe }}</h4>
+        <h4>{{ task.assignment.article.safe_title }}</h4>
     </div>
     <div class="card-section">
         <p>Requested due date: {{ task.due|date:"Y-m-d" }}</p>

--- a/src/templates/admin/elements/proofing/card.html
+++ b/src/templates/admin/elements/proofing/card.html
@@ -1,6 +1,6 @@
 <div class="card">
     <div class="card-divider">
-        <h4>{{ article.pk }} - {{ article.title|safe }}</h4>
+        <h4>{{ article.pk }} - {{ article.safe_title }}</h4>
     </div>
     <div class="card-section">
         {% if type == "assignment" %}

--- a/src/templates/admin/elements/proofing/proofreader_card.html
+++ b/src/templates/admin/elements/proofing/proofreader_card.html
@@ -2,9 +2,9 @@
 <div class="card">
     <div class="card-divider">
         {% if task.assignment %}
-            <h4>{{ task.assignment.article.title|safe }}</h4>
+            <h4>{{ task.assignment.article.safe_title }}</h4>
         {% else %}
-            <h4>{{ task.proofing_task.assignment.article.title|safe }}</h4>
+            <h4>{{ task.proofing_task.assignment.article.safe_title }}</h4>
         {% endif %}
     </div>
     <div class="card-section">

--- a/src/templates/admin/elements/proofing/proofreader_correction_card.html
+++ b/src/templates/admin/elements/proofing/proofreader_correction_card.html
@@ -3,9 +3,9 @@
     <div class="card-divider">
         <h4>
         {% if task.assignment %}
-            {{ task.assignment.article.title|safe }}
+            {{ task.assignment.article.safe_title }}
         {% else %}
-            {{ task.proofing_task.assignment.article.title|safe }}
+            {{ task.proofing_task.assignment.article.safe_title }}
         {% endif %}
         </h4>
     </div>

--- a/src/templates/admin/elements/publish/author.html
+++ b/src/templates/admin/elements/publish/author.html
@@ -13,7 +13,7 @@
                     <p>
                         <i>To: </i> {{ article.correspondence_author.full_name }} ({{ article.correspondence_author.email }})<br />
                         <i>From: </i> {{ request.user.full_name }}({{ request.user.email }})<br />
-                        <i>Subject: </i>{{ article.title }} Publication
+                        <i>Subject: </i>{{ article.safe_title }} Publication
                     </p>
                     <textarea name="notify_author_email">{{ notify_author_text|linebreaksbr }}</textarea>
 

--- a/src/templates/admin/elements/review/card.html
+++ b/src/templates/admin/elements/review/card.html
@@ -1,6 +1,6 @@
 <div class="card">
     <div class="card-divider">
-        <h4>{{ request.article.title|safe }}</h4>
+        <h4>{{ request.article.safe_title }}</h4>
     </div>
     <div class="card-section">
         <p>A request for review has been made.</p>

--- a/src/templates/admin/elements/review/review_request_metadata.html
+++ b/src/templates/admin/elements/review/review_request_metadata.html
@@ -4,7 +4,7 @@
      data-animation-out="slide-out-down">
     <div class="card">
         <div class="card-divider">
-            <h4>Review Request for: {{ review_request.article.title|safe }}</h4>
+            <h4>Review Request for: {{ review_request.article.safe_title }}</h4>
         </div>
         <div class="card-section">
             <p>We request that this review be done by <strong>{{ review_request.date_due|date:"Y-m-d" }}</strong>.</p>

--- a/src/templates/admin/identifiers/article_identifiers.html
+++ b/src/templates/admin/identifiers/article_identifiers.html
@@ -7,7 +7,7 @@
 {% block breadcrumbs %}
 {{ block.super }}
 <li>Edit</li>
-<li>{{ article.title }}</li>
+<li>{{ article.safe_title }}</li>
 <li>Identifiers</li>
 {% endblock breadcrumbs %}
 

--- a/src/templates/admin/identifiers/manage_identifier.html
+++ b/src/templates/admin/identifiers/manage_identifier.html
@@ -9,7 +9,7 @@
 {% block breadcrumbs %}
 {{ block.super }}
 <li>Edit</li>
-<li>{{ article.title }}</li>
+<li>{{ article.safe_title }}</li>
 <li><a href="{% url 'article_identifiers' article.pk %}">Identifiers</a></li>
 {% endblock breadcrumbs %}
 

--- a/src/templates/admin/journal/article_log.html
+++ b/src/templates/admin/journal/article_log.html
@@ -3,7 +3,7 @@
 
 {% block title %}Article {{ article.pk }} Log{% endblock %}
 {% block title-section %}Article {{ article.pk }} Log{% endblock %}
-{% block title-sub %}{{ article.title|safe }}{% endblock %}
+{% block title-sub %}{{ article.safe_title }}{% endblock %}
 
 {% block body %}
     <div class="box">

--- a/src/templates/admin/journal/document_management.html
+++ b/src/templates/admin/journal/document_management.html
@@ -6,14 +6,14 @@
 
 {% block title %}Article Document Management{% endblock title %}
 {% block title-section %}Article Document Management{% endblock %}
-{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.title }}{% endblock %}
+{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.safe_title }}{% endblock %}
 
 {% block body %}
     {% csrf_token %}
     <div class="row expanded box">
         <div class="large-12 columns">
             <div class="title-area">
-                Article #{{ article.pk }} {{ article.title }} Files
+                Article #{{ article.pk }} {{ article.safe_title }} Files
             </div>
             <table id="files" class="small files">
                 <thead>

--- a/src/templates/admin/journal/manage/archive.html
+++ b/src/templates/admin/journal/manage/archive.html
@@ -34,7 +34,7 @@
                     {% for article in published_articles %}
                         <tr>
                             <td>{{ article.pk }}</td>
-                            <td><a href="{% url 'manage_archive_article' article.pk %}">{{ article.title|safe }}</a></td>
+                            <td><a href="{% url 'manage_archive_article' article.pk %}">{{ article.safe_title }}</a></td>
                             <td>{{ article.date_published }}</td>
                             <td>{{ article.identifier }}</td>
                         </tr>
@@ -65,7 +65,7 @@
                     {% for article in rejected_articles %}
                         <tr>
                             <td>{{ article.pk }}</td>
-                            <td><a href="{% url 'manage_archive_article' article.pk %}">{{ article.title|safe }}</a></td>
+                            <td><a href="{% url 'manage_archive_article' article.pk %}">{{ article.safe_title }}</a></td>
                             <td>{{ article.date_declined|default_if_none:"Archived" }}</td>
                             <td>{{ article.identifier }}</td>
                         </tr>

--- a/src/templates/admin/journal/manage/archive_article.html
+++ b/src/templates/admin/journal/manage/archive_article.html
@@ -9,7 +9,7 @@
 
 {% block title %}Article Archive {{ article.pk }}{% endblock title %}
 {% block title-section %}{% if article.stage == 'Rejected' %}Rejected Article {% else %}Article Archive{% endif %} {{ article.pk }}{% endblock %}
-{% block title-sub %}{{ article.title|safe }}{% endblock %}
+{% block title-sub %}{{ article.safe_title }}{% endblock %}
 
 {% block breadcrumbs %}
     {{ block.super }}

--- a/src/templates/admin/journal/manage/issue_add_article.html
+++ b/src/templates/admin/journal/manage/issue_add_article.html
@@ -65,7 +65,7 @@
                         {% for article in articles %}
                         <tr id="articles-{{ dict.article.pk }}">
                             <td>{{ article.id }}</td>
-                            <td>{{ article.title|safe }}</td>
+                            <td>{{ article.safe_title }}</td>
                             <td>{{ article.date_submitted }}</td>
                             <td>{{ article.author_list }}</td>
                             <td>{{ article.section.name }}</td>

--- a/src/templates/admin/journal/manage/publication_schedule.html
+++ b/src/templates/admin/journal/manage/publication_schedule.html
@@ -33,7 +33,7 @@
                         <tbody>
                             {% for article in articles %}
                                 <tr>
-                                    <td><a href="{% url 'manage_archive_article' article.pk %}">{{ article.title|safe }}</a></td>
+                                    <td><a href="{% url 'manage_archive_article' article.pk %}">{{ article.safe_title }}</a></td>
                                     <td>{{ article.section.name }}</td>
                                     <td><a href="{% url 'edit_identifiers' article.pk %}" target="_blank">{{ article.get_doi }}</a></td>
                                     <td>{{ article.date_published|date:"Y-m-d H:i" }}</td>

--- a/src/templates/admin/journal/publish.html
+++ b/src/templates/admin/journal/publish.html
@@ -31,7 +31,7 @@
                 {% for article in articles %}
                     <tr>
                         <td>{{ article.pk }}</td>
-                        <td>{{ article.title }}</td>
+                        <td>{{ article.safe_title }}</td>
                         <td>{{ article.date_submitted }}</td>
                         <td>{{ article.correspondence_author.full_name }}</td>
                         <td>{{ article.section.name }}</td>

--- a/src/templates/admin/journal/publish_article.html
+++ b/src/templates/admin/journal/publish_article.html
@@ -6,7 +6,7 @@
 
 {% block title %}Pre Publication - {{ article.pk }}{% endblock title %}
 {% block title-section %}Pre Publication Checklist{% endblock %}
-{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.title }}{% endblock %}
+{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.safe_title }}{% endblock %}
 
 {% block breadcrumbs %}
 {{ block.super }}

--- a/src/templates/admin/journal/resend_logged_email.html
+++ b/src/templates/admin/journal/resend_logged_email.html
@@ -3,7 +3,7 @@
 
 {% block title %}Resend Logged Email{% endblock %}
 {% block title-section %}Resend Logged Email ID #{{ log_entry.pk }}{% endblock %}
-{% block title-sub %}Log entry for article #{{ article.pk }}: {{ article.title|safe }}{% endblock %}
+{% block title-sub %}Log entry for article #{{ article.pk }}: {{ article.safe_title }}{% endblock %}
 
 {% block breadcrumb %}
     {{ block.super }}

--- a/src/templates/admin/press/press_manager_index.html
+++ b/src/templates/admin/press/press_manager_index.html
@@ -114,7 +114,7 @@
                             <tbody>
                             {% for article in published_articles %}
                                 <tr>
-                                    <td>{{ article.title|safe }}</td>
+                                    <td>{{ article.safe_title }}</td>
                                     <td>{{ article.journal.name }}</td>
                                     <td>{{ article.metrics.views }}</td>
                                     <td>{{ article.metrics.downloads }}</td>

--- a/src/templates/admin/production/assigned_article.html
+++ b/src/templates/admin/production/assigned_article.html
@@ -8,7 +8,7 @@
 
 {% block title %}Article Production{% endblock title %}
 {% block admin-header %}}Article Production{% endblock %}
-{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.title }}{% endblock %}
+{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.safe_title }}{% endblock %}
 
 {% block breadcrumbs %}
     {{ block.super }}

--- a/src/templates/admin/production/edit_galley.html
+++ b/src/templates/admin/production/edit_galley.html
@@ -5,7 +5,7 @@
 
 {% block title %}Edit Galley - {{ galley.pk }}{% endblock title %}
 {% block title-section %}Edit Galley - {{ galley.pk }}{% endblock %}
-{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.title }}{% endblock %}
+{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.safe_title }}{% endblock %}
 
 {% block breadcrumbs %}
     {{ block.super }}

--- a/src/templates/admin/production/edit_typesetter_assignment.html
+++ b/src/templates/admin/production/edit_typesetter_assignment.html
@@ -5,7 +5,7 @@
     {{ typeset.typesetter.full_name }}{% endblock %}
 {% block title-section %}#{{ typeset.pk }} -
     {{ typeset.typesetter.full_name }}{% endblock %}
-{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.title }}{% endblock %}
+{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.safe_title }}{% endblock %}
 
 {% block breadcrumbs %}
     {{ block.super }}

--- a/src/templates/admin/production/index.html
+++ b/src/templates/admin/production/index.html
@@ -63,7 +63,7 @@
          data-animation-out="slide-out-down">
         <div class="card">
             <div class="card-divider">
-                <h4><i class="fa fa-pencil-square">&nbsp;</i>{{ article.title|safe }}</h4>
+                <h4><i class="fa fa-pencil-square">&nbsp;</i>{{ article.safe_title }}</h4>
             </div>
             <div class="card-section">
                 <div class="large-10 columns">

--- a/src/templates/admin/production/non_workflow_assign.html
+++ b/src/templates/admin/production/non_workflow_assign.html
@@ -6,7 +6,7 @@
 
 {% block title %}Article - {{ article.pk }}{% endblock title %}
 {% block admin-header %}Article - {{ article.pk }}{% endblock %}
-{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.title }}{% endblock %}
+{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.safe_title }}{% endblock %}
 
 {% block breadcrumbs %}
     {{ block.super }}
@@ -20,7 +20,7 @@
     <div class="box">
         <div class="title-area">
             <h2>No Production Assignment Found
-                for {{ article.title|safe }}</h2>
+                for {{ article.safe_title }}</h2>
         </div>
         <div class="content">
             <p>

--- a/src/templates/admin/production/notify_typesetter.html
+++ b/src/templates/admin/production/notify_typesetter.html
@@ -3,7 +3,7 @@
 
 {% block title %}Notify Typesetter{% endblock title %}
 {% block title-section %}Notify Typesetter{% endblock %}}
-{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.title }}{% endblock %}
+{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.safe_title }}{% endblock %}
 
 {% block breadcrumbs %}
 {{ block.super }}

--- a/src/templates/admin/production/typeset_task.html
+++ b/src/templates/admin/production/typeset_task.html
@@ -6,7 +6,7 @@
 
 {% block title %}Typeset Task - {{ typeset_task.pk }}{% endblock title %}
 {% block title-section %}Typeset Task - {{ typeset_task.pk }}{% endblock %}
-{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.title }}{% endblock %}
+{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.safe_title }}{% endblock %}
 
 {% block breadcrumbs %}
     {{ block.super }}

--- a/src/templates/admin/proofing/acknowledge.html
+++ b/src/templates/admin/proofing/acknowledge.html
@@ -3,7 +3,7 @@
 
 {% block css %}<link href="{% static "common/css/jquery-te-1.4.0.css" %}" rel="stylesheet">{% endblock %}
 {% block title %}Acknowledge Task{% endblock title %}
-{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.title }}{% endblock %}
+{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.safe_title }}{% endblock %}
 
 {% block breadcrumbs %}
 {{ block.super }}

--- a/src/templates/admin/proofing/complete_proofing.html
+++ b/src/templates/admin/proofing/complete_proofing.html
@@ -5,7 +5,7 @@
     <link href="{% static "common/css/jquery-te-1.4.0.css" %}" rel="stylesheet">{% endblock %}
 {% block title %}Complete Proofing{% endblock title %}
 {% block title-section %}Complete Proofing{% endblock %}
-{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.title }}{% endblock %}
+{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.safe_title }}{% endblock %}
 
 {% block breadcrumbs %}
     {{ block.super }}

--- a/src/templates/admin/proofing/delete_proofing_round.html
+++ b/src/templates/admin/proofing/delete_proofing_round.html
@@ -5,7 +5,7 @@
 
 {% block title %}Deleting Proofing Round #{{ round.number }}{% endblock %}
 {% block title-section %}Deleting Proofing Round #{{ round.number }}{% endblock %}
-{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.title }}{% endblock %}
+{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.safe_title }}{% endblock %}
 
 {% block breadcrumbs %}
     {{ block.super }}

--- a/src/templates/admin/proofing/do_proofing.html
+++ b/src/templates/admin/proofing/do_proofing.html
@@ -5,7 +5,7 @@
 
 {% block title %}Proofing Requests{% endblock title %}
 {% block title-section %}Proofing{% endblock %}
-{% block title-sub %}{{ article.title }}{% endblock %}
+{% block title-sub %}{{ article.safe_title }}{% endblock %}
 
 {% block breadcrumbs %}
     {{ block.super }}

--- a/src/templates/admin/proofing/edit_proofing_assignment.html
+++ b/src/templates/admin/proofing/edit_proofing_assignment.html
@@ -5,7 +5,7 @@
 
 {% block title %}#{{ proofing_task.pk }} - {{ proofing_task.proofreader.full_name }}{% endblock %}
 {% block title-section %}#{{ proofing_task.pk }} - {{ proofing_task.proofreader.full_name }}{% endblock %}
-{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.title }}{% endblock %}
+{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.safe_title }}{% endblock %}
 
 {% block breadcrumbs %}
     {{ block.super }}

--- a/src/templates/admin/proofing/index.html
+++ b/src/templates/admin/proofing/index.html
@@ -54,7 +54,7 @@
          data-animation-out="slide-out-down">
         <div class="card">
             <div class="card-divider">
-                <h4><i class="fa fa-pencil-square">&nbsp;</i>{{ article.title|safe }}</h4>
+                <h4><i class="fa fa-pencil-square">&nbsp;</i>{{ article.safe_title }}</h4>
             </div>
             <div class="card-section">
                 <div class="large-10 columns">
@@ -93,7 +93,7 @@
 
 
         <div class="reveal" id="modal{{ article.pk }}" data-reveal style="width:100%">
-            <h4 class="modal-title">{{ article.title|safe }}<br/>
+            <h4 class="modal-title">{{ article.safe_title }}<br/>
                 <small>{{ article.section.name }}, submitted {{ article.date_submitted }}</small>
             </h4>
 

--- a/src/templates/admin/proofing/notify_proofreader.html
+++ b/src/templates/admin/proofing/notify_proofreader.html
@@ -4,7 +4,7 @@
 {% block css %}<link href="{% static "common/css/jquery-te-1.4.0.css" %}" rel="stylesheet">{% endblock %}
 {% block title %}Notify Proofreader{% endblock title %}
 {% block title-section %}Notify Proofreader{% endblock %}
-{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.title }}{% endblock %}
+{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.safe_title }}{% endblock %}
 
 {% block breadcrumbs %}
 {{ block.super }}

--- a/src/templates/admin/proofing/notify_typesetter_changes.html
+++ b/src/templates/admin/proofing/notify_typesetter_changes.html
@@ -4,7 +4,7 @@
 {% block css %}<link href="{% static "common/css/jquery-te-1.4.0.css" %}" rel="stylesheet">{% endblock %}
 {% block title %}Notify Typesetter{% endblock title %}
 {% block admin-header %}Notify Typesetter{% endblock %}
-{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.title }}{% endblock %}
+{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.safe_title }}{% endblock %}
 
 {% block breadcrumbs %}
 {{ block.super }}

--- a/src/templates/admin/proofing/preview/rendered.html
+++ b/src/templates/admin/proofing/preview/rendered.html
@@ -35,7 +35,7 @@
                                     {% for author in article.authors.all %}{{ author.last_name }},
                                         {{ author.first_name|slice:"1" }}{% if forloop.last %}.{% else %},
                                         {% endif %} {% endfor %}
-                                    ({{ article.date_published.year }}) '{{ article.title|safe }}',
+                                    ({{ article.date_published.year }}) '{{ article.safe_title }}',
                                     <i>{{ journal.name }}</i>. 0(0).
                                     doi: {{ article.identifier.identifier }}</p>
 
@@ -57,7 +57,7 @@
         <h2 id="HarvardModalTitle">Harvard-Style Citation</h2>
         <p>{% for author in article.authors.all %}{{ author.last_name }},
             {{ author.first_name|slice:"1" }}{% if forloop.last %}.{% else %},{% endif %} {% endfor %}
-            ({{ article.date_published.year }}) '{{ article.title|safe }}',
+            ({{ article.date_published.year }}) '{{ article.safe_title }}',
             <i>{{ journal.name }}</i>. 0(0):{{ article.page_range }}.
             doi: {{ article.identifier.identifier }}</p>
         <p>Show: <a data-open="VancouverModal">Vancouver Citation Style</a> | <a data-open="APAModal">APA Citation
@@ -72,7 +72,7 @@
         <h2 id="VancouverModalTitle">Vancouver-Style Citation</h2>
         <p>{% for author in article.authors.all %}{{ author.last_name }},
             {{ author.first_name|slice:"1" }}{% if forloop.last %}.{% else %},{% endif %} {% endfor %}
-            {{ article.title|safe }}. {{ journal.name }}. {{ article.date_published.year }} {{ article.date_published.month }};0(0):{{ article.page_range }}.
+            {{ article.safe_title }}. {{ journal.name }}. {{ article.date_published.year }} {{ article.date_published.month }};0(0):{{ article.page_range }}.
             doi: {{ article.identifier.identifier }}</p>
         <p>Show: <a data-open="HarvardModal">Harvard Citation Style</a> | <a data-open="APAModal">APA Citation Style</a>
         </p>
@@ -87,7 +87,7 @@
         <p>{% for author in article.authors.all %}{% if forloop.last and not forloop.first %}
             &amp; {% endif %}{{ author.last_name }},
             {{ author.first_name|slice:"1" }}{% if forloop.last %}.{% else %},{% endif %} {% endfor %}
-            ({{ article.date_published.year }}, {{ article.date_published.month }} {{ article.date_published.day }}). {{ article.title|safe }}.
+            ({{ article.date_published.year }}, {{ article.date_published.month }} {{ article.date_published.day }}). {{ article.safe_title }}.
             <i>{{ journal.name }}</i> 0(0):{{ article.page_range }}.
             doi: {{ article.identifier.identifier }}</p>
         <p>Show: <a data-open="HarvardModal">Harvard Citation Style</a> | <a data-open="VancouverModal">Vancouver

--- a/src/templates/admin/proofing/proofing_article.html
+++ b/src/templates/admin/proofing/proofing_article.html
@@ -9,7 +9,7 @@
 
 {% block title %}Proofing - {{ article.pk }}{% endblock title %}
 {% block title-section %}Proofing{% endblock %}
-{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.title }}{% endblock %}
+{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.safe_title }}{% endblock %}
 
 {% block breadcrumbs %}
     {{ block.super }}

--- a/src/templates/admin/proofing/request_typesetting_changes.html
+++ b/src/templates/admin/proofing/request_typesetting_changes.html
@@ -8,7 +8,7 @@
 
 {% block title %}Request Corrections{% endblock title %}
 {% block title-section %}Request Corrections{% endblock %}
-{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.title }}{% endblock %}
+{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.safe_title }}{% endblock %}
 
 {% block breadcrumbs %}
     {{ block.super }}

--- a/src/templates/admin/proofing/typesetting/typesetting_corrections.html
+++ b/src/templates/admin/proofing/typesetting/typesetting_corrections.html
@@ -6,7 +6,7 @@
 
 {% block title %}Proofing Corrections{% endblock title %}
 {% block title-section %}Proofing Corrections{% endblock %}
-{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.title }}{% endblock %}
+{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.safe_title }}{% endblock %}
 
 {% block breadcrumbs %}
     {{ block.super }}

--- a/src/templates/admin/reports/dois.html
+++ b/src/templates/admin/reports/dois.html
@@ -31,7 +31,7 @@
                     <tbody>
                         {% for bd in broken_dois %}
                             <tr>
-                                <td><a href="{% url 'manage_archive_article' bd.article.pk %}">{{ bd.article.title|safe }} <i class="fa fa-edit"></i></a></td>
+                                <td><a href="{% url 'manage_archive_article' bd.article.pk %}">{{ bd.article.safe_title }} <i class="fa fa-edit"></i></a></td>
                                 <td>{{ bd.checked }}</td>
                                 <td><a href="{{ bd.resolves_to }}">{{ bd.resolves_to }} <i class="fa fa-external-link"></i></a></td>
                                 <td>{{ bd.expected_to_resolve_to }}</td>

--- a/src/templates/admin/reports/metrics.html
+++ b/src/templates/admin/reports/metrics.html
@@ -43,7 +43,7 @@
                 <tbody>
                 {% for article in articles %}
                     <tr>
-                        <td>{{ article.title|safe }}</td>
+                        <td>{{ article.safe_title }}</td>
                         <td>{{ article.date_published }}</td>
                         <td>{{ article.metrics.views }}</td>
                         <td>{{ article.metrics.downloads }}</td>

--- a/src/templates/admin/repository/comments.html
+++ b/src/templates/admin/repository/comments.html
@@ -2,7 +2,7 @@
 
 {% block title %}{{ preprint.title|striptags }}{% endblock %}
 {% block title-section %}Preprint Comments{% endblock %}
-{% block title-sub %}Management interface for {{ article.title|safe }} comments{% endblock %}
+{% block title-sub %}Management interface for {{ article.safe_title }} comments{% endblock %}
 
 {% block breadcrumbs %}
     <li><a href="{% url 'repository_dashboard' %}">{{ request.repository.object_name }} Dashboard</a></li>

--- a/src/templates/admin/review/add_files.html
+++ b/src/templates/admin/review/add_files.html
@@ -3,7 +3,7 @@
 
 {% block title %}Add Review Files{% endblock title %}
 {% block title-section %}Add Files{% endblock %}
-{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.title }}{% endblock %}
+{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.safe_title }}{% endblock %}
 
 {% block breadcrumbs %}
     {{ block.super }}

--- a/src/templates/admin/review/add_review_assignment.html
+++ b/src/templates/admin/review/add_review_assignment.html
@@ -2,7 +2,7 @@
 {% load foundation %}
 {% block title %}Add Review Assignment{% endblock title %}
 {% block title-section %}Add Review Assignment{% endblock %}
-{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.title }}{% endblock %}
+{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.safe_title }}{% endblock %}
 
 {% block breadcrumbs %}
     {{ block.super }}

--- a/src/templates/admin/review/assignment_notification.html
+++ b/src/templates/admin/review/assignment_notification.html
@@ -3,7 +3,7 @@
 {% load settings %}
 
 {% block css %}<link href="{% static "common/css/jquery-te-1.4.0.css" %}" rel="stylesheet">{% endblock %}
-{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.title }}{% endblock %}
+{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.safe_title }}{% endblock %}
 
 {% block body %}
 

--- a/src/templates/admin/review/decision.html
+++ b/src/templates/admin/review/decision.html
@@ -3,7 +3,7 @@
 
 {% block title %}{{ decision|capfirst }} Article{% endblock title %}
 {% block title-section %}{{ decision|capfirst }} Article{% endblock %}
-{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.title }}{% endblock %}
+{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.safe_title }}{% endblock %}
 
 {% block breadcrumbs %}
     {{ block.super }}
@@ -18,7 +18,7 @@
                 <h2>Article Decision</h2>
             </div>
             <div class="content">
-                <p>Are you sure you want to {{ decision }} {{ article.title }}?</p>
+                <p>Are you sure you want to {{ decision }} {{ article.safe_title }}?</p>
                 {% if decision == 'accept' %}
                     {% if article.journal.use_crossref %}
                         <div class="bs-callout">

--- a/src/templates/admin/review/decision_helper.html
+++ b/src/templates/admin/review/decision_helper.html
@@ -5,7 +5,7 @@
 
 {% block title %}#{{ article.pk }} Decision Helper{% endblock title %}
 {% block title-section %}#{{ article.pk }} Decision Helper{% endblock %}
-{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.title }}{% endblock %}
+{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.safe_title }}{% endblock %}
 
 {% block breadcrumbs %}
     {{ block.super }}

--- a/src/templates/admin/review/delete_review.html
+++ b/src/templates/admin/review/delete_review.html
@@ -2,7 +2,7 @@
 
 {% block title %}Delete Review{% endblock title %}
 {% block title-section %}Delete Review{% endblock %}
-{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.title }}{% endblock %}
+{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.safe_title }}{% endblock %}
 
 {% block breadcrumbs %}
 {{ block.super }}
@@ -15,7 +15,7 @@
 <div class="large-12 columns">
     <div class="box">
         <div class="title-area">
-            <h2>You are deleting a review assigned to {{ review.reviewer.full_name }} on article {{ article.title }}</h2>
+            <h2>You are deleting a review assigned to {{ review.reviewer.full_name }} on article {{ article.safe_title }}</h2>
         </div>
         <div class="content">
             <p>You can add a note that will be logged next to this deletion: </p>

--- a/src/templates/admin/review/delete_review_round.html
+++ b/src/templates/admin/review/delete_review_round.html
@@ -17,7 +17,7 @@
             </div>
             <div class="content">
                 <p>Are you sure you wish to delete review round {{ round.round_number }} for
-                    article {{ article.title|safe }}? Deleting this review round will also delete the following review
+                    article {{ article.safe_title }}? Deleting this review round will also delete the following review
                     assignments:</p>
                 <ul>
                     {% for assignment in round.reviewassignment_set.all %}

--- a/src/templates/admin/review/draft_decision.html
+++ b/src/templates/admin/review/draft_decision.html
@@ -5,7 +5,7 @@
 
 {% block title %}Draft Decision{% endblock title %}
 {% block admin-header %}Draft Decision{% endblock %}
-{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.title }}{% endblock %}
+{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.safe_title }}{% endblock %}
 
 {% block breadcrumbs %}
     {{ block.super }}

--- a/src/templates/admin/review/edit_review.html
+++ b/src/templates/admin/review/edit_review.html
@@ -3,7 +3,7 @@
 
 {% block title %}Edit Review{% endblock title %}
 {% block title-section %}Edit Review{% endblock %}
-{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.title }}{% endblock %}
+{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.safe_title }}{% endblock %}
 
 {% block breadcrumbs %}
     {{ block.super }}

--- a/src/templates/admin/review/edit_review_answer.html
+++ b/src/templates/admin/review/edit_review_answer.html
@@ -2,7 +2,7 @@
 
 {% block title %}Edit Review Answer{% endblock title %}
 {% block admin-header %}Edit Review Answer{% endblock %}
-{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.title }}{% endblock %}
+{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.safe_title }}{% endblock %}
 
 {% block breadcrumbs %}
     {{ block.super }}

--- a/src/templates/admin/review/home.html
+++ b/src/templates/admin/review/home.html
@@ -45,7 +45,7 @@
                     {% for article in articles %}
                         <tr>
                             <td>{{ article.pk }}</td>
-                            <td><a href="{% url 'review_in_review' article.pk %}">{{ article.title }}</a></td>
+                            <td><a href="{% url 'review_in_review' article.pk %}">{{ article.safe_title }}</a></td>
                             <td>{{ article.date_submitted }}</td>
                             <td>{{ article.correspondence_author.full_name }}</td>
                             <td>{% for editor in article.editors %}{{ editor.editor.full_name }}{% if not forloop.last %}, {% endif %}{% endfor %}</td>

--- a/src/templates/admin/review/in_review.html
+++ b/src/templates/admin/review/in_review.html
@@ -5,7 +5,7 @@
 
 {% block title %}Review {{ article.title }}{% endblock %}
 {% block title-section %}Peer Review{% endblock %}
-{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.title }}{% endblock %}
+{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.safe_title }}{% endblock %}
 
 {% block breadcrumbs %}
     {{ block.super }}

--- a/src/templates/admin/review/notify_reviewer.html
+++ b/src/templates/admin/review/notify_reviewer.html
@@ -5,7 +5,7 @@
 
 {% block title %}Add Review Assignment{% endblock title %}
 {% block title-section %}Add Review Assignment{% endblock %}
-{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.title }}{% endblock %}
+{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.safe_title }}{% endblock %}
 
 {% block css %}
     <link href="{% static "common/css/jquery-te-1.4.0.css" %}" rel="stylesheet">

--- a/src/templates/admin/review/projected_issue.html
+++ b/src/templates/admin/review/projected_issue.html
@@ -5,7 +5,7 @@
 
 {% block title %}Projected Issue {{ article.title }}{% endblock %}
 {% block title-section %}Projected Issue{% endblock %}
-{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.title }}{% endblock %}
+{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.safe_title }}{% endblock %}
 
 {% block body %}
 	<div class="row expanded">

--- a/src/templates/admin/review/rate_reviewer.html
+++ b/src/templates/admin/review/rate_reviewer.html
@@ -2,7 +2,7 @@
 
 {% block title %}Rate Reviewer{% endblock title %}
 {% block title-section %}Rate Review{% endblock %}
-{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.title }}{% endblock %}
+{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.safe_title }}{% endblock %}
 
 {% block breadcrumbs %}
     {{ block.super }}

--- a/src/templates/admin/review/reset.html
+++ b/src/templates/admin/review/reset.html
@@ -3,7 +3,7 @@
 
 {% block title %}Reset Review{% endblock title %}
 {% block title-section %}Reset Review{% endblock %}
-{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.title }}{% endblock %}
+{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.safe_title }}{% endblock %}
 
 {% block breadcrumbs %}
 {{ block.super }}
@@ -16,7 +16,7 @@
 <div class="large-12 columns">
     <div class="box">
         <div class="content">
-            <p>You are resetting a review by {{ review.reviewer.full_name }} for {{ article.title }}. It was due on {{ review.date_due }}.</p>
+            <p>You are resetting a review by {{ review.reviewer.full_name }} for {{ article.safe_title }}. It was due on {{ review.date_due }}.</p>
             <form method="POST">
                 {% csrf_token %}
                 <button type="submit" class="button success" name="send"><i class="fa fa-repeat">&nbsp;</i>Reset Review</button>&nbsp <a href="{% url 'review_in_review' article.pk %}" class="button warning" type="submit">Cancel</a>

--- a/src/templates/admin/review/review_warning.html
+++ b/src/templates/admin/review/review_warning.html
@@ -2,7 +2,7 @@
 
 {% block title %}Permission Denied{% endblock title %}
 {% block admin-header %}Permission Denied{% endblock %}
-{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.title }}{% endblock %}
+{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.safe_title }}{% endblock %}
 
 {% block breadcrumbs %}
     {{ block.super }}

--- a/src/templates/admin/review/revision/do_revision.html
+++ b/src/templates/admin/review/revision/do_revision.html
@@ -4,12 +4,12 @@
 {% load i18n %}
 
 {% block title %}Revision for {{ revision_request.article.title }}{% endblock title %}
-{% block title-section %}Revision for {{ revision_request.article.title }}{% endblock %}
+{% block title-section %}Revision for {{ revision_request.article.safe_title }}{% endblock %}
 
 {% block breadcrumbs %}
     {{ block.super }}
     {% include "elements/breadcrumbs/review_base.html" %}
-    <li>Revisions for {{ revision_request.article.title }}</li>
+    <li>Revisions for {{ revision_request.article.safe_title }}</li>
 {% endblock breadcrumbs %}
 
 {% block body %}

--- a/src/templates/admin/review/revision/edit_revision_request.html
+++ b/src/templates/admin/review/revision/edit_revision_request.html
@@ -3,7 +3,7 @@
 
 {% block title %}Edit Revision{% endblock title %}
 {% block title-section %}Edit Revision{% endblock %}
-{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.title }}{% endblock %}
+{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.safe_title }}{% endblock %}
 
 {% block breadcrumbs %}
     {{ block.super }}

--- a/src/templates/admin/review/revision/replace_file.html
+++ b/src/templates/admin/review/revision/replace_file.html
@@ -3,13 +3,13 @@
 
 
 {% block title %}Replacing Article File for {{ revision_request.article.title }}{% endblock title %}
-{% block title-section %}Replacing Article File for {{ revision_request.article.title }}{% endblock %}
+{% block title-section %}Replacing Article File for {{ revision_request.article.safe_title }}{% endblock %}
 
 {% block breadcrumbs %}
     {{ block.super }}
     {% include "elements/breadcrumbs/review_base.html" %}
     <li><a href="{% url 'do_revisions' revision_request.article.pk revision_request.pk %}">Revisions
-        for {{ revision_request.article.title }}</a></li>
+        for {{ revision_request.article.safe_title }}</a></li>
     <li>Replace File</li>
 {% endblock breadcrumbs %}
 
@@ -23,7 +23,7 @@
                         <h2>Upload Guidelines</h2>
                     </div>
                     <div class="content">
-                        <p>You are revising article #{{ article.pk }}, {{ article.title|safe }}. </p><p>Add a label, select a file and use the Upload and Continue button to upload the file</p>
+                        <p>You are revising article #{{ article.pk }}, {{ article.safe_title }}. </p><p>Add a label, select a file and use the Upload and Continue button to upload the file</p>
                         {% if error %}
                             <div class="alert alert-warning" role="alert">{{ error }}</div>
                         {% endif %}

--- a/src/templates/admin/review/revision/request_revisions.html
+++ b/src/templates/admin/review/revision/request_revisions.html
@@ -3,7 +3,7 @@
 
 {% block title %}Request Revisions{% endblock title %}
 {% block title-section %}Request Revisions{% endblock %}
-{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.title }}{% endblock %}
+{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.safe_title }}{% endblock %}
 
 {% block breadcrumbs %}
     {{ block.super }}

--- a/src/templates/admin/review/revision/request_revisions_notification.html
+++ b/src/templates/admin/review/revision/request_revisions_notification.html
@@ -4,7 +4,7 @@
 
 {% block title %}Request Revisions{% endblock title %}
 {% block title-section %}Request Revisions{% endblock %}
-{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.title }}{% endblock %}
+{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.safe_title }}{% endblock %}
 
 {% block breadcrumbs %}
 {{ block.super }}

--- a/src/templates/admin/review/revision/upload_file.html
+++ b/src/templates/admin/review/revision/upload_file.html
@@ -3,12 +3,12 @@
 
 
 {% block title %}Revisions for {{ revision_request.article.title }}{% endblock title %}
-{% block title-section %}Revisions for {{ revision_request.article.title }}{% endblock %}
+{% block title-section %}Revisions for {{ revision_request.article.safe_title }}{% endblock %}
 
 {% block breadcrumbs %}
 {{ block.super }}
 {% include "elements/breadcrumbs/review_base.html" %}
-<li><a href="{% url 'do_revisions' revision_request.article.pk revision_request.pk %}">Revisions for {{ revision_request.article.title }}</a></li>
+<li><a href="{% url 'do_revisions' revision_request.article.pk revision_request.pk %}">Revisions for {{ revision_request.article.safe_title }}</a></li>
 <li>Replace File</li>
 {% endblock breadcrumbs %}
 

--- a/src/templates/admin/review/revision/view_revision.html
+++ b/src/templates/admin/review/revision/view_revision.html
@@ -4,7 +4,7 @@
 
 {% block title %}Revision Request{% endblock title %}
 {% block admin-header %}Revision Request{% endblock %}
-{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.title }}{% endblock %}
+{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.safe_title }}{% endblock %}
 
 {% block breadcrumbs %}
 {{ block.super }}

--- a/src/templates/admin/review/send_review_reminder.html
+++ b/src/templates/admin/review/send_review_reminder.html
@@ -3,7 +3,7 @@
 
 {% block title %}Review Reminders{% endblock title %}
 {% block title-section %}Review Reminders{% endblock %}
-{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.title }}{% endblock %}
+{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.safe_title }}{% endblock %}
 
 {% block breadcrumbs %}
     {{ block.super }}

--- a/src/templates/admin/review/unassign_editor.html
+++ b/src/templates/admin/review/unassign_editor.html
@@ -3,7 +3,7 @@
 
 {% block title %}Unassign Editor Request{% endblock title %}
 {% block title-section %}Unassign Editor Request{% endblock %}
-{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.title }}{% endblock %}
+{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.safe_title }}{% endblock %}
 
 {% block breadcrumbs %}
     {{ block.super }}
@@ -16,7 +16,7 @@
     <div class="large-12 columns">
         <div class="box">
             <div class="content">
-                <p>You are unassigning {{ assignment.editor.full_name }} from {{ article.title }}.</p>
+                <p>You are unassigning {{ assignment.editor.full_name }} from {{ article.safe_title }}.</p>
                 <p>If you select Skip, the editor will not be notified.</p>
 
                 <div class="card">

--- a/src/templates/admin/review/unassigned.html
+++ b/src/templates/admin/review/unassigned.html
@@ -25,7 +25,7 @@
                             {% for article in articles %}
                             <tr>
                                 <td>{{ article.pk }}</td>
-                                <td>{{ article.title }}</td>
+                                <td>{{ article.safe_title }}</td>
                                 <td>{{ article.date_submitted }}</td>
                                 <td>{{ article.correspondence_author.full_name }}</td>
                                 <td>{{ article.section.name }}</td>

--- a/src/templates/admin/review/unassigned_article.html
+++ b/src/templates/admin/review/unassigned_article.html
@@ -6,7 +6,7 @@
 
 {% block title %}Unassigned {{ article.title }}{% endblock %}
 {% block title-section %}Unassigned{% endblock %}
-{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.title }}{% endblock %}
+{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.safe_title }}{% endblock %}
 
 {% block body %}
     {% user_has_role request 'editor' as is_editor %}

--- a/src/templates/admin/review/view_review.html
+++ b/src/templates/admin/review/view_review.html
@@ -6,7 +6,7 @@
 {% block title %}View Review{% endblock title %}
 {% block title-section %}View Review{% endblock %}
 {% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} /
-    {{ article.title }}{% endblock %}
+    {{ article.safe_title }}{% endblock %}
 
 {% block breadcrumbs %}
     {{ block.super }}

--- a/src/templates/admin/review/withdraw_review.html
+++ b/src/templates/admin/review/withdraw_review.html
@@ -3,7 +3,7 @@
 
 {% block title %}Withdraw Review Request{% endblock title %}
 {% block title-section %}Withdraw Review Request{% endblock %}
-{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.title }}{% endblock %}
+{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.safe_title }}{% endblock %}
 
 {% block breadcrumbs %}
     {{ block.super }}
@@ -16,7 +16,7 @@
     <div class="large-12 columns">
         <div class="box">
             <div class="content">
-                <p>You are withdrawing a review by {{ review.reviewer.full_name }} from {{ article.title }}. It was due
+                <p>You are withdrawing a review by {{ review.reviewer.full_name }} from {{ article.safe_title }}. It was due
                     on {{ review.date_due }}.</p>
                 <p>If you select Skip, the reviewer will not be notified.</p>
 

--- a/src/templates/admin/submission/edit/metadata.html
+++ b/src/templates/admin/submission/edit/metadata.html
@@ -9,7 +9,7 @@
 {% block breadcrumbs %}
     {{ block.super }}
     <li>Edit</li>
-    <li>{{ article.title|safe }}</li>
+    <li>{{ article.safe_title }}</li>
     <li>Metadata</li>
 {% endblock breadcrumbs %}
 

--- a/src/templates/admin/submission/manager/delete_license.html
+++ b/src/templates/admin/submission/manager/delete_license.html
@@ -30,7 +30,7 @@
 
                     <ul>
                         {% for article in license_articles %}
-                        <li>{{ article.title|safe }}</li>
+                        <li>{{ article.safe_title }}</li>
                         {% endfor %}
                     </ul>
                 </div>

--- a/src/templates/admin/submission/submit_review.html
+++ b/src/templates/admin/submission/submit_review.html
@@ -58,7 +58,7 @@
                         </tr>
 
                         <tr>
-                            <td colspan="{% if request.journal.submissionconfiguration.subtitle %}2{% else %}3{% endif %}">{{ article.title }}</td>
+                            <td colspan="{% if request.journal.submissionconfiguration.subtitle %}2{% else %}3{% endif %}">{{ article.safe_title }}</td>
                             {% if request.journal.submissionconfiguration.subtitle %}
                                 <td>{{ article.subtitle }}</td>{% endif %}
                         </tr>

--- a/src/templates/admin/workflow/manage_article_workflow.html
+++ b/src/templates/admin/workflow/manage_article_workflow.html
@@ -5,12 +5,12 @@
 
 {% block title %}Article Workflow Manager{% endblock %}
 {% block title-section %}Article Workflow Manager{% endblock %}
-{% block title-sub %}{{ article.title|safe   }}{% endblock %}
+{% block title-sub %}{{ article.safe_title   }}{% endblock %}
 
 {% block breadcrumbs %}
     {{ block.super }}
     <li><a href="{% url 'core_manager_index' %}">Manager</a></li>
-    <li><a href="">#{{ article.pk }} {{ article.title|safe|truncatesmart }}</a></li>
+    <li><a href="">#{{ article.pk }} {{ article.safe_title|truncatesmart }}</a></li>
     <li>Article Workflow Manager</li>
 {% endblock %}
 

--- a/src/themes/OLH/templates/repository/authors.html
+++ b/src/themes/OLH/templates/repository/authors.html
@@ -13,7 +13,7 @@
             <div class="row column">
                 {% csrf_token %}
                 <h2 class="title-area">{% trans "Preprint Authors" %}</h2>
-                <p>{% trans "Add authors to" %} {{ article.title }}.</p>
+                <p>{% trans "Add authors to" %} {{ article.safe_title }}.</p>
             </div>
             <div class="row">
                 {% include "elements/forms/errors.html" with form=form %}

--- a/src/themes/OLH/templates/repository/review.html
+++ b/src/themes/OLH/templates/repository/review.html
@@ -25,7 +25,7 @@
                 <th colspan="2">{% trans "Title" %}</th>
             </tr>
             <tr>
-                <td colspan="2">{{ article.title }}</td>
+                <td colspan="2">{{ article.safe_title }}</td>
             </tr>
             <tr>
                 <th colspan="3">{% trans "Abstract" %}</th>

--- a/src/utils/install/journal_defaults.json
+++ b/src/utils/install/journal_defaults.json
@@ -218,7 +218,7 @@
             "type": "rich-text"
         },
         "value": {
-            "default": "<p>Dear {{ editor.full_name }}, </p><p>You have been assigned as an editor to \"{{ article.title }}\" in the journal {{ request.journal.name }}.</p><p>If you are unable to be the editor for this article, please reply to this email.</p><p>You can view this article's data on the journal site: {{ review_in_review_url }} </p><p>Regards,</p><p>{{ request.user.signature|safe }}</p>"
+            "default": "<p>Dear {{ editor.full_name }}, </p><p>You have been assigned as an editor to \"{{ article.safe_title }}\" in the journal {{ request.journal.name }}.</p><p>If you are unable to be the editor for this article, please reply to this email.</p><p>You can view this article's data on the journal site: {{ review_in_review_url }} </p><p>Regards,</p><p>{{ request.user.signature|safe }}</p>"
         },
         "editable_by": [
             "editor",
@@ -256,7 +256,7 @@
             "type": "rich-text"
         },
         "value": {
-            "default": "Dear {{ review_assignment.editor.full_name }},<br/><br/>This is a notification that the reviewer {{ review_assignment.reviewer.full_name }} has responded to your review request for \" #{{ article.pk }}: {{ article.title }}\" in {{ article.journal.name }} and have {{ reviewer_decision }} to perform the review. You can view more information on the journal site: {{ review_in_review_url }} "
+            "default": "Dear {{ review_assignment.editor.full_name }},<br/><br/>This is a notification that the reviewer {{ review_assignment.reviewer.full_name }} has responded to your review request for \" #{{ article.pk }}: {{ article.safe_title }}\" in {{ article.journal.name }} and have {{ reviewer_decision }} to perform the review. You can view more information on the journal site: {{ review_in_review_url }} "
         },
         "editable_by": [
             "editor",
@@ -294,7 +294,7 @@
             "type": "rich-text"
         },
         "value": {
-            "default": "Dear {{ review_assignment.reviewer.full_name }}, <br/><br/>Thank you for agreeing to review \"{{ article.title }}\" in {{ article.journal.name }}. <br/><br/>You can now access the manuscript and the review process at: {{ review_url }}  <br/><br/>Regards, <br/>{{ review_assignment.editor.signature|safe }}"
+            "default": "Dear {{ review_assignment.reviewer.full_name }}, <br/><br/>Thank you for agreeing to review \"{{ article.safe_title }}\" in {{ article.journal.name }}. <br/><br/>You can now access the manuscript and the review process at: {{ review_url }}  <br/><br/>Regards, <br/>{{ review_assignment.editor.signature|safe }}"
         },
         "editable_by": [
             "editor",
@@ -313,7 +313,7 @@
             "type": "rich-text"
         },
         "value": {
-            "default": "<p>Dear {{ review_assignment.reviewer.full_name }}, </p><p>Thank you for completing your review of \"{{ article.title }}\" in {{ article.journal.name }}. </p><p>We are extremely grateful for the work of reviewers, which greatly enhances the quality of the journal. </p><p>Thank you again and regards,</p><p>{{ review_assignment.editor.signature|safe }}</p>"
+            "default": "<p>Dear {{ review_assignment.reviewer.full_name }}, </p><p>Thank you for completing your review of \"{{ article.safe_title }}\" in {{ article.journal.name }}. </p><p>We are extremely grateful for the work of reviewers, which greatly enhances the quality of the journal. </p><p>Thank you again and regards,</p><p>{{ review_assignment.editor.signature|safe }}</p>"
         },
         "editable_by": [
             "editor",
@@ -332,7 +332,7 @@
             "type": "rich-text"
         },
         "value": {
-            "default": "Dear {{ review_assignment.editor.full_name }}, <br><br>This is a notification that the reviewer status on \"{{ article.title }}\" in {{ article.journal.name }} has been <a href=\"{% journal_url 'review_in_review' review_assignment.article.pk  %}\">updated</a>. <br><br>Regards, <br>{{ request.user.signature|safe }}"
+            "default": "Dear {{ review_assignment.editor.full_name }}, <br><br>This is a notification that the reviewer status on \"{{ article.safe_title }}\" in {{ article.journal.name }} has been <a href=\"{% journal_url 'review_in_review' review_assignment.article.pk  %}\">updated</a>. <br><br>Regards, <br>{{ request.user.signature|safe }}"
         },
         "editable_by": [
             "editor",
@@ -351,7 +351,7 @@
             "type": "rich-text"
         },
         "value": {
-            "default": "Dear {{ review_assignment.editor.full_name }}, <br/><br/>This is a notification that the reviewer status on \"{{ article.title }}\" in {{ article.journal.name }} has been updated.  You can view more information on the journal site: {{ review_in_review_url }}  <br/><br/>Regards,"
+            "default": "Dear {{ review_assignment.editor.full_name }}, <br/><br/>This is a notification that the reviewer status on \"{{ article.safe_title }}\" in {{ article.journal.name }} has been updated.  You can view more information on the journal site: {{ review_in_review_url }}  <br/><br/>Regards,"
         },
         "editable_by": [
             "editor",
@@ -370,7 +370,7 @@
             "type": "rich-text"
         },
         "value": {
-            "default": "Dear {{ review_assignment.reviewer.full_name }}, \n\nThank you for letting us know that you are unable to review \"{{ article.title }}\" in {{ article.journal.name }}.\n\n We are most grateful for your time.\n\nRegards,\n{{ request.user.signature|safe }}"
+            "default": "Dear {{ review_assignment.reviewer.full_name }}, \n\nThank you for letting us know that you are unable to review \"{{ article.safe_title }}\" in {{ article.journal.name }}.\n\n We are most grateful for your time.\n\nRegards,\n{{ request.user.signature|safe }}"
         },
         "editable_by": [
             "editor",
@@ -389,7 +389,7 @@
             "type": "rich-text"
         },
         "value": {
-            "default": "Dear {{ review_assignment.reviewer.full_name }},<br/><br/>We are requesting that you undertake a review of \"{{ article.title }}\" in {{ article.journal.name }}.<br/><br/>We would be most grateful for your time as the feedback from our reviewers is of the utmost importance to our editorial decision-making processes.<br/><br/>You can let us know your decision or decline to undertake the review: {{ review_url }} <br/><br/>{{ article_details }}<br/><br/>Regards,<br/>{{ request.user.signature|safe }}"
+            "default": "Dear {{ review_assignment.reviewer.full_name }},<br/><br/>We are requesting that you undertake a review of \"{{ article.safe_title }}\" in {{ article.journal.name }}.<br/><br/>We would be most grateful for your time as the feedback from our reviewers is of the utmost importance to our editorial decision-making processes.<br/><br/>You can let us know your decision or decline to undertake the review: {{ review_url }} <br/><br/>{{ article_details }}<br/><br/>Regards,<br/>{{ request.user.signature|safe }}"
         },
         "editable_by": [
             "editor",
@@ -408,7 +408,7 @@
             "type": "rich-text"
         },
         "value": {
-            "default": "Dear {{ review_assignment.reviewer.full_name }},<br/><br/>We recently sent you an email requesting that you undertake a review of \"{{ article.title }}\" in {{ article.journal.name }}.<br/><br/>We would be most grateful for your time as the feedback from our reviewers is of the utmost importance to our editorial decision-making processes.<br/><br/>We would appreciate it if you could let us know your decision or decline to undertake the review: {{ review_url }} <br/><br/>Regards,<br/>{{ request.user.signature|safe }}"
+            "default": "Dear {{ review_assignment.reviewer.full_name }},<br/><br/>We recently sent you an email requesting that you undertake a review of \"{{ article.safe_title }}\" in {{ article.journal.name }}.<br/><br/>We would be most grateful for your time as the feedback from our reviewers is of the utmost importance to our editorial decision-making processes.<br/><br/>We would appreciate it if you could let us know your decision or decline to undertake the review: {{ review_url }} <br/><br/>Regards,<br/>{{ request.user.signature|safe }}"
         },
         "editable_by": [
             "editor",
@@ -427,7 +427,7 @@
             "type": "rich-text"
         },
         "value": {
-            "default": "Dear {{ review_assignment.reviewer.full_name }},<br/><br/>You recently agreed undertake a review of \"{{ article.title }}\" in {{ article.journal.name }}.<br/><br/>We would be most grateful for your time as the feedback from our reviewers is of the utmost importance to our editorial decision-making processes.<br/><br/>Check our site to undertake the review: {{ review_url }} <br/><br/>Regards,<br/>{{ request.user.signature|safe }}"
+            "default": "Dear {{ review_assignment.reviewer.full_name }},<br/><br/>You recently agreed undertake a review of \"{{ article.safe_title }}\" in {{ article.journal.name }}.<br/><br/>We would be most grateful for your time as the feedback from our reviewers is of the utmost importance to our editorial decision-making processes.<br/><br/>Check our site to undertake the review: {{ review_url }} <br/><br/>Regards,<br/>{{ request.user.signature|safe }}"
         },
         "editable_by": [
             "editor",
@@ -446,7 +446,7 @@
             "type": "rich-text"
         },
         "value": {
-            "default": "<p>Dear {{ article.correspondence_author.full_name }},<br/><br/>We are happy to inform you that your article, \"{{ article.title }}\", has been accepted in {{ article.journal.name }}. Thank you for submitting such a strong manuscript.<br/></p><p>Peer review reports and feedback on the manuscript can be viewed at: {{ review_url }} </p><p>We will be back in touch soon to discuss the next stages of production.</p><p><br/>Regards,</p><p><br/>{{ request.user.signature|safe }}</p>"
+            "default": "<p>Dear {{ article.correspondence_author.full_name }},<br/><br/>We are happy to inform you that your article, \"{{ article.safe_title }}\", has been accepted in {{ article.journal.name }}. Thank you for submitting such a strong manuscript.<br/></p><p>Peer review reports and feedback on the manuscript can be viewed at: {{ review_url }} </p><p>We will be back in touch soon to discuss the next stages of production.</p><p><br/>Regards,</p><p><br/>{{ request.user.signature|safe }}</p>"
         },
         "editable_by": [
             "editor",
@@ -465,7 +465,7 @@
             "type": "rich-text"
         },
         "value": {
-            "default": "<p>Dear {{ article.correspondence_author.full_name }},<br><br>We are sorry to inform you that \"{{ article.title }}\" has been declined in {{ article.journal.name }}.<br><br>You can view your reviews and feedback on the manuscript at: {{ review_url }} <br><br>Regards,</p><p>{{ request.user.signature|safe }}</p>"
+            "default": "<p>Dear {{ article.correspondence_author.full_name }},<br><br>We are sorry to inform you that \"{{ article.safe_title }}\" has been declined in {{ article.journal.name }}.<br><br>You can view your reviews and feedback on the manuscript at: {{ review_url }} <br><br>Regards,</p><p>{{ request.user.signature|safe }}</p>"
         },
         "editable_by": [
             "editor",
@@ -484,7 +484,7 @@
             "type": "rich-text"
         },
         "value": {
-            "default": "<p>Dear {{ article.correspondence_author.full_name }},<br><br>We wish to inform you that the earlier decision to decline \"{{ article.title }}\" in {{ article.journal.name }} has been reversed. The article is now being reconsidered.<br><br>Regards,</p><p>{{ request.user.signature|safe }}</p>"
+            "default": "<p>Dear {{ article.correspondence_author.full_name }},<br><br>We wish to inform you that the earlier decision to decline \"{{ article.safe_title }}\" in {{ article.journal.name }} has been reversed. The article is now being reconsidered.<br><br>Regards,</p><p>{{ request.user.signature|safe }}</p>"
         },
         "editable_by": [
             "editor",
@@ -503,7 +503,7 @@
             "type": "rich-text"
         },
         "value": {
-            "default": "<p>Dear {{ assignment.editor.full_name }},</p><p>We are writing to let you know that you have been unassigned from the article \"{{ article.title }}\" in {{ article.journal.name }}.</p><p>Regards,</p>{{ request.user.signature|safe }}"
+            "default": "<p>Dear {{ assignment.editor.full_name }},</p><p>We are writing to let you know that you have been unassigned from the article \"{{ article.safe_title }}\" in {{ article.journal.name }}.</p><p>Regards,</p>{{ request.user.signature|safe }}"
         },
         "editable_by": [
             "editor",
@@ -541,7 +541,7 @@
             "type": "rich-text"
         },
         "value": {
-            "default": "<p>Dear {{ review_assignment.reviewer.full_name }},</p><p>We are writing to let you know that the review request for \"{{ article.title }}\" in {{ article.journal.name }} has been cancelled.</p><p>We thank you for your time but your review is no longer required.</p><p>Regards,</p>{{ request.user.signature|safe }}"
+            "default": "<p>Dear {{ review_assignment.reviewer.full_name }},</p><p>We are writing to let you know that the review request for \"{{ article.safe_title }}\" in {{ article.journal.name }} has been cancelled.</p><p>We thank you for your time but your review is no longer required.</p><p>Regards,</p>{{ request.user.signature|safe }}"
         },
         "editable_by": [
             "editor",
@@ -978,7 +978,7 @@
             "type": "rich-text"
         },
         "value": {
-            "default": "<p>Dear {{ assignment.copyeditor.full_name }},<br/><br/>We are requesting that your undertake a copyedit for the article \"{{ assignment.article.title }}\".<br/><br/>This assignment is due on {{ assignment.due }}. You can access this task on the\u00a0journal site: {{ copyedit_requests_url }} </p><p><br/>Regards,</p><p>{{ request.user.signature|safe }}</p>"
+            "default": "<p>Dear {{ assignment.copyeditor.full_name }},<br/><br/>We are requesting that your undertake a copyedit for the article \"{{ assignment.article.safe_title }}\".<br/><br/>This assignment is due on {{ assignment.due }}. You can access this task on the\u00a0journal site: {{ copyedit_requests_url }} </p><p><br/>Regards,</p><p>{{ request.user.signature|safe }}</p>"
         },
         "editable_by": [
             "editor",
@@ -1035,7 +1035,7 @@
             "type": "rich-text"
         },
         "value": {
-            "default": "Dear {{ assignment.copyeditor.full_name }},<br/><br/>We are requesting further copyedits article \"{{ assignment.article.title }}\". You can access this task on the\u00a0journal site: {{ copyedit_requests_url }} <br/><br/>[ADD FEEDBACK HERE].<br/><br/>Regards, <br/>{{ request.user.signature|safe }}"
+            "default": "Dear {{ assignment.copyeditor.full_name }},<br/><br/>We are requesting further copyedits article \"{{ assignment.article.safe_title }}\". You can access this task on the\u00a0journal site: {{ copyedit_requests_url }} <br/><br/>[ADD FEEDBACK HERE].<br/><br/>Regards, <br/>{{ request.user.signature|safe }}"
         },
         "editable_by": [
             "editor",
@@ -1111,7 +1111,7 @@
             "type": "rich-text"
         },
         "value": {
-            "default": "<p>Dear {{ production_assignment.production_manager.full_name }},</p><p>This is an automatic notification from {{ request.user.full_name }} that you have been assigned to the production of article {{ production_assignment.article.title }}. You can view further information on this here: {{ production_article_url }} </p><p>Regards,</p>"
+            "default": "<p>Dear {{ production_assignment.production_manager.full_name }},</p><p>This is an automatic notification from {{ request.user.full_name }} that you have been assigned to the production of article {{ production_assignment.article.safe_title }}. You can view further information on this here: {{ production_article_url }} </p><p>Regards,</p>"
         },
         "editable_by": [
             "editor",
@@ -1130,7 +1130,7 @@
             "type": "rich-text"
         },
         "value": {
-            "default": "<p>Dear {{ typeset_task.typesetter.full_name }},</p><p>This is a notification from {{ request.user.full_name }} that you have been assigned to the production of article {{ typeset_task.assignment.article.title }}. </p><p>You can view further information on this here: {{ typesetter_requests_url }} </p><p>Regards,</p><p>{{ request.user.signature|safe }}</p>"
+            "default": "<p>Dear {{ typeset_task.typesetter.full_name }},</p><p>This is a notification from {{ request.user.full_name }} that you have been assigned to the production of article {{ typeset_task.assignment.article.safe_title }}. </p><p>You can view further information on this here: {{ typesetter_requests_url }} </p><p>Regards,</p><p>{{ request.user.signature|safe }}</p>"
         },
         "editable_by": [
             "editor",
@@ -1149,7 +1149,7 @@
             "type": "rich-text"
         },
         "value": {
-            "default": "<p>Dear {{ production_assignment.production_manager.salutation_name }},</p><p>This is an notification from {{ request.user.full_name }} that typesetting for article {{ production_assignment.article.title }} has been completed. You can view further information on the journal site.: {{ production_article_url }} /p><p>Regards,<br/></p>"
+            "default": "<p>Dear {{ production_assignment.production_manager.salutation_name }},</p><p>This is an notification from {{ request.user.full_name }} that typesetting for article {{ production_assignment.article.safe_title }} has been completed. You can view further information on the journal site.: {{ production_article_url }} /p><p>Regards,<br/></p>"
         },
         "editable_by": [
             "editor",
@@ -1168,7 +1168,7 @@
             "type": "rich-text"
         },
         "value": {
-            "default": "<p>Dear {{ production_assignment.editor.full_name }},</p><p>Production for article {{ article.title }} has been completed.</p><p>Regards</p><p>{{ request.user.signature|safe }}</p>"
+            "default": "<p>Dear {{ production_assignment.editor.full_name }},</p><p>Production for article {{ article.safe_title }} has been completed.</p><p>Regards</p><p>{{ request.user.signature|safe }}</p>"
         },
         "editable_by": [
             "editor",
@@ -1187,7 +1187,7 @@
             "type": "rich-text"
         },
         "value": {
-            "default": "<p>This is a notification to inform you that Production is complete for article \"{{ article.title}}\".</p><p>Regards,</p><p>{{ request.user.signature|safe }}</p>"
+            "default": "<p>This is a notification to inform you that Production is complete for article \"{{ article.safe_title}}\".</p><p>Regards,</p><p>{{ request.user.signature|safe }}</p>"
         },
         "editable_by": [
             "editor",
@@ -1225,7 +1225,7 @@
             "type": "rich-text"
         },
         "value": {
-            "default": "<p>Dear {{ proofing_assignment.proofing_manager.full_name }},</p><p>You have been assigned as the Proofing Manager: {{ proofing_article_url }} for {{ article.title }}.</p><p>Regards,</p><p>{{ request.user.signature|safe }}</p><p><br/></p>"
+            "default": "<p>Dear {{ proofing_assignment.proofing_manager.full_name }},</p><p>You have been assigned as the Proofing Manager: {{ proofing_article_url }} for {{ article.safe_title }}.</p><p>Regards,</p><p>{{ request.user.signature|safe }}</p><p><br/></p>"
         },
         "editable_by": [
             "editor",
@@ -1244,7 +1244,7 @@
             "type": "rich-text"
         },
         "value": {
-            "default": "<p>Dear {{ proofing_task.round.assignment.proofing_manager.full_name }},<br/><br/>I have completed proofreading: {{ proofing_article_url }} for \"{{ proofing_task.round.assignment.article.title }}\".<br/></p><p><br/>Regards,</p><p>{{ request.user.signature|safe }}</p><p><br/></p>"
+            "default": "<p>Dear {{ proofing_task.round.assignment.proofing_manager.full_name }},<br/><br/>I have completed proofreading: {{ proofing_article_url }} for \"{{ proofing_task.round.assignment.article.safe_title }}\".<br/></p><p><br/>Regards,</p><p>{{ request.user.signature|safe }}</p><p><br/></p>"
         },
         "editable_by": [
             "editor",
@@ -1263,7 +1263,7 @@
             "type": "rich-text"
         },
         "value": {
-            "default": "<p>Dear {{ proofing_task.proofreader.full_name }},</p><p>You have been assigned a proofreading task: {{ proofing_requests_url }} for \"{{ article.title }}\". We would be most grateful for your assistance in proofreading this article.</p><p>Regards,</p><p>{{ request.user.signature|safe }}</p><p><br/></p>"
+            "default": "<p>Dear {{ proofing_task.proofreader.full_name }},</p><p>You have been assigned a proofreading task: {{ proofing_requests_url }} for \"{{ article.safe_title }}\". We would be most grateful for your assistance in proofreading this article.</p><p>Regards,</p><p>{{ request.user.signature|safe }}</p><p><br/></p>"
         },
         "editable_by": [
             "editor",
@@ -1282,7 +1282,7 @@
             "type": "rich-text"
         },
         "value": {
-            "default": "<p>Dear {{ typesetter_proofing_task.typesetter.full_name }},</p><p>Changes have been requested for article \"{{ article.title }}\".</p><p>You can access this request from the requests page: {{ proofing_requests_url }} /p><p>Regards,<br/></p><p>{{ request.user.signature|safe }}</p><p><br/></p>"
+            "default": "<p>Dear {{ typesetter_proofing_task.typesetter.full_name }},</p><p>Changes have been requested for article \"{{ article.safe_title }}\".</p><p>You can access this request from the requests page: {{ proofing_requests_url }} /p><p>Regards,<br/></p><p>{{ request.user.signature|safe }}</p><p><br/></p>"
         },
         "editable_by": [
             "editor",
@@ -1301,7 +1301,7 @@
             "type": "rich-text"
         },
         "value": {
-            "default": "<p>Dear {{ user.full_name }}</p><p>Thank you for your efforts during the production of \"{{ article.title }}\".</p><p>Regards,</p><p>{{ request.user.signature|safe }}</p><p><br></p>"
+            "default": "<p>Dear {{ user.full_name }}</p><p>Thank you for your efforts during the production of \"{{ article.safe_title }}\".</p><p>Regards,</p><p>{{ request.user.signature|safe }}</p><p><br></p>"
         },
         "editable_by": [
             "editor",
@@ -1320,7 +1320,7 @@
             "type": "rich-text"
         },
         "value": {
-            "default": "<p>Dear {{ proofing_assignment.editor.full_name }},</p><p>Proofing for \"{{ article.title }}\" is now complete.</p><p>Regards,</p><p>{{ request.user.signature|safe }}</p><p><br/></p>"
+            "default": "<p>Dear {{ proofing_assignment.editor.full_name }},</p><p>Proofing for \"{{ article.safe_title }}\" is now complete.</p><p>Regards,</p><p>{{ request.user.signature|safe }}</p><p><br/></p>"
         },
         "editable_by": [
             "editor",
@@ -1339,7 +1339,7 @@
             "type": "rich-text"
         },
         "value": {
-            "default": "<p>Dear {{ proofing_task.proofreader.full_name }},<br><br>The proofreading task for \"{{ proofing_task.round.assignment.article.title }}\" that was due on {{ proofing_task.due }} has been cancelled.</p><p><br>{% if user_content_message %}{{ user_content_message|safe }}{% endif %}</p><p>Regards,</p><p>{{ request.user.signature|safe }}</p>"
+            "default": "<p>Dear {{ proofing_task.proofreader.full_name }},<br><br>The proofreading task for \"{{ proofing_task.round.assignment.article.safe_title }}\" that was due on {{ proofing_task.due }} has been cancelled.</p><p><br>{% if user_content_message %}{{ user_content_message|safe }}{% endif %}</p><p>Regards,</p><p>{{ request.user.signature|safe }}</p>"
         },
         "editable_by": [
             "editor",
@@ -1377,7 +1377,7 @@
             "type": "rich-text"
         },
         "value": {
-            "default": "<p>Dear {{ article.correspondence_author.full_name }}<br><br>We are pleased to say that your article, \"{{ article.title }}\", is set for publication on {{ article.date_published|date:'Y-m-d' }} at {{ article.date_published|date:'H:i' }}.</p><p>You may want to consider one or more of the following in order to promote your research:</p><ul><li>Email a link to your paper to colleagues</li><li>Write a blog post about your paper</li><li>Upload it to your institutional repository or a subject repository.</li><li>Add to Wikipedia <a href=\"https://en.wikipedia.org/wiki/Wikipedia:Research_help/Scholars_and_experts\">where appropriate</a></li></ul><p>Regards,<br></p><p>{{ request.user.signature|safe }}</p>"
+            "default": "<p>Dear {{ article.correspondence_author.full_name }}<br><br>We are pleased to say that your article, \"{{ article.safe_title }}\", is set for publication on {{ article.date_published|date:'Y-m-d' }} at {{ article.date_published|date:'H:i' }}.</p><p>You may want to consider one or more of the following in order to promote your research:</p><ul><li>Email a link to your paper to colleagues</li><li>Write a blog post about your paper</li><li>Upload it to your institutional repository or a subject repository.</li><li>Add to Wikipedia <a href=\"https://en.wikipedia.org/wiki/Wikipedia:Research_help/Scholars_and_experts\">where appropriate</a></li></ul><p>Regards,<br></p><p>{{ request.user.signature|safe }}</p>"
         },
         "editable_by": [
             "editor",
@@ -1719,7 +1719,7 @@
             "type": "rich-text"
         },
         "value": {
-            "default": "A section editor has made a draft decision: {{ review_in_review_url }} regarding an article in your section: {{ article.title }}.<br/><br/>The draft decision is [[DECISION TEXT ]].<br/><br/>Regards,<br/><br/>{{ request.user.signature|safe }} "
+            "default": "A section editor has made a draft decision: {{ review_in_review_url }} regarding an article in your section: {{ article.safe_title }}.<br/><br/>The draft decision is [[DECISION TEXT ]].<br/><br/>Regards,<br/><br/>{{ request.user.signature|safe }} "
         },
         "editable_by": [
             "editor",
@@ -1738,7 +1738,7 @@
             "type": "rich-text"
         },
         "value": {
-            "default": "<p>{{ draft.section_editor.full_name }} has drafted a decision for {{ article.title }}.</p><p>The section editor provided the following message:</p><p>{{ draft.message_to_editor|safe }}</p><p>You can view the draft decision on the\u00a0journal site: {{ review_edit_draft_decision_url }} <br/></p>"
+            "default": "<p>{{ draft.section_editor.full_name }} has drafted a decision for {{ article.safe_title }}.</p><p>The section editor provided the following message:</p><p>{{ draft.message_to_editor|safe }}</p><p>You can view the draft decision on the\u00a0journal site: {{ review_edit_draft_decision_url }} <br/></p>"
         },
         "editable_by": [
             "editor",
@@ -1757,7 +1757,7 @@
             "type": "rich-text"
         },
         "value": {
-            "default": "A new article, {{ article.title }}, has been submitted.<br/><br/>You can assign an editor Here: {{ review_unassigned_article_url }} <br/><br/>Regards, <br/>"
+            "default": "A new article, {{ article.safe_title }}, has been submitted.<br/><br/>You can assign an editor Here: {{ review_unassigned_article_url }} <br/><br/>Regards, <br/>"
         },
         "editable_by": [
             "editor",
@@ -1795,7 +1795,7 @@
             "type": "rich-text"
         },
         "value": {
-            "default": "<p>Dear {{ editor.full_name }},</p><p>An article that you served as section editor for, {{ article.title }}, has been set for publication.<br><br>The article will be published on {{ article.date_published }}<br><br>Regards,"
+            "default": "<p>Dear {{ editor.full_name }},</p><p>An article that you served as section editor for, {{ article.safe_title }}, has been set for publication.<br><br>The article will be published on {{ article.date_published }}<br><br>Regards,"
         },
         "editable_by": [
             "editor",
@@ -1814,7 +1814,7 @@
             "type": "rich-text"
         },
         "value": {
-            "default": "<p>Dear {{reviewer.full_name}}</p><p>An article that you served as peer reviewer for, \"{{ article.title }}\", has been set for publication.<br><br>The article will be published on {{ article.date_published }}.<br><br>Regards,"
+            "default": "<p>Dear {{reviewer.full_name}}</p><p>An article that you served as peer reviewer for, \"{{ article.safe_title }}\", has been set for publication.<br><br>The article will be published on {{ article.date_published }}.<br><br>Regards,"
         },
         "editable_by": [
             "editor",
@@ -1871,7 +1871,7 @@
             "type": "rich-text"
         },
         "value": {
-            "default": "<p>Unassigned Articles:</p><ul>{% for article in unassigned_articles %}<li>{{ article.title }}</li>{% endfor %}</ul><p>Overdue Reviews</p><ul>{% for review in overdue_reviews %}<li>{{ review.reviewer.full_name }} for article {{ review.article.title }}.</li>{% endfor %}</ul><p>Overdue Revisions</p><ul>{% for revision in overdue_revisions %}<li>{{ revision.article.correspondence_author.full_name }} for article {{ review.article.title }}.</li>{% endfor %}</ul><p>Overdue Proofing</p><ul>{% for proofing in overdue_proofing %}<li>{{ proofing.proofreader.full_name }} for article {{ proofing.round.assignment.article.title }}</li>{% endfor %}</ul><p>Awaiting Publication</p><ul>{% for article in awaiting_publication %}<li>{{ article.title }}</li>{% endfor %}</ul>"
+            "default": "<p>Unassigned Articles:</p><ul>{% for article in unassigned_articles %}<li>{{ article.safe_title }}</li>{% endfor %}</ul><p>Overdue Reviews</p><ul>{% for review in overdue_reviews %}<li>{{ review.reviewer.full_name }} for article {{ review.article.safe_title }}.</li>{% endfor %}</ul><p>Overdue Revisions</p><ul>{% for revision in overdue_revisions %}<li>{{ revision.article.correspondence_author.full_name }} for article {{ review.article.safe_title }}.</li>{% endfor %}</ul><p>Overdue Proofing</p><ul>{% for proofing in overdue_proofing %}<li>{{ proofing.proofreader.full_name }} for article {{ proofing.round.assignment.article.safe_title }}</li>{% endfor %}</ul><p>Awaiting Publication</p><ul>{% for article in awaiting_publication %}<li>{{ article.safe_title }}</li>{% endfor %}</ul>"
         },
         "editable_by": [
             "editor",
@@ -1890,7 +1890,7 @@
             "type": "rich-text"
         },
         "value": {
-            "default": "<p>Review Requests</p><ul>{% for review in pending_requests %}<li>{{ review.article.title }} due on {{ review.date_due }}</li>{% endfor %}</ul><p>Overdue Requests</p><ul>{% for review in overdue_requests %}<li>{{ review.article.title }} due on {{ review.date_due }}</li>{% endfor %}</ul>"
+            "default": "<p>Review Requests</p><ul>{% for review in pending_requests %}<li>{{ review.article.safe_title }} due on {{ review.date_due }}</li>{% endfor %}</ul><p>Overdue Requests</p><ul>{% for review in overdue_requests %}<li>{{ review.article.safe_title }} due on {{ review.date_due }}</li>{% endfor %}</ul>"
         },
         "editable_by": [
             "editor",
@@ -1909,7 +1909,7 @@
             "type": "rich-text"
         },
         "value": {
-            "default": "<p>Revision Requests</p><ul>{% for revision in pending_requests %}<li>{{ revision.article.title }} due on {{ revision.date_due }}</li>{% endfor %}</ul><p>Overdue Requests</p><ul>{% for revision in overdue_requests %}<li>{{ revision.article.title }} due on {{ revision.date_due }}</li>{% endfor %}</ul>"
+            "default": "<p>Revision Requests</p><ul>{% for revision in pending_requests %}<li>{{ revision.article.safe_title }} due on {{ revision.date_due }}</li>{% endfor %}</ul><p>Overdue Requests</p><ul>{% for revision in overdue_requests %}<li>{{ revision.article.safe_title }} due on {{ revision.date_due }}</li>{% endfor %}</ul>"
         },
         "editable_by": [
             "editor",
@@ -2099,7 +2099,7 @@
             "type": "rich-text"
         },
         "value": {
-            "default": "<p>Dear {{ user.full_name }}<br/><br/>This is an automatic notification from {{ request.journal.name }} that you have been assigned to the production of article {{ article.title }}. You can view further information on this on the journal site: {{ url }} </p><p>Regards,</p>"
+            "default": "<p>Dear {{ user.full_name }}<br/><br/>This is an automatic notification from {{ request.journal.name }} that you have been assigned to the production of article {{ article.safe_title }}. You can view further information on this on the journal site: {{ url }} </p><p>Regards,</p>"
         },
         "editable_by": [
             "editor",
@@ -2137,7 +2137,7 @@
             "type": "rich-text"
         },
         "value": {
-            "default": "<p>Dear {{ notification.user.full_name }},<br/><br/>This email is to notify you that {{ article.correspondence_author.full_name }} has submitted article \"{{ article.title }}\" to  {{ article.journal.name }}.</p><p>You can review the metadata in the journal site: {{ review_unassigned_url }} </p><p>Regards,</p>"
+            "default": "<p>Dear {{ notification.user.full_name }},<br/><br/>This email is to notify you that {{ article.correspondence_author.full_name }} has submitted article \"{{ article.safe_title }}\" to  {{ article.journal.name }}.</p><p>You can review the metadata in the journal site: {{ review_unassigned_url }} </p><p>Regards,</p>"
         },
         "editable_by": [
             "editor",
@@ -2156,7 +2156,7 @@
             "type": "rich-text"
         },
         "value": {
-            "default": "<p>Dear {{ notification.user.full_name }},<br><br>This email is to notify you that article \"{{ article.title }}\" with corresponding author&nbsp;{{ article.correspondence_author.full_name }} in {{ article.journal.name }} has been accepted for publication.</p>"
+            "default": "<p>Dear {{ notification.user.full_name }},<br><br>This email is to notify you that article \"{{ article.safe_title }}\" with corresponding author&nbsp;{{ article.correspondence_author.full_name }} in {{ article.journal.name }} has been accepted for publication.</p>"
         },
         "editable_by": [
             "editor",
@@ -2422,7 +2422,7 @@
             "type": "rich-text"
         },
         "value": {
-            "default": "<p>Dear {{ copyedit_assignment.copyeditor.full_name }},</p><p>Your copyediting assignment for article \"{{ copyedit_assignment.article.title }}\" has been updated. The due date is set to: {{ copyedit_assignment.due }}.</p><p>Regards, {{ request.user.signature|safe }}</p>"
+            "default": "<p>Dear {{ copyedit_assignment.copyeditor.full_name }},</p><p>Your copyediting assignment for article \"{{ copyedit_assignment.article.safe_title }}\" has been updated. The due date is set to: {{ copyedit_assignment.due }}.</p><p>Regards, {{ request.user.signature|safe }}</p>"
         },
         "editable_by": [
             "editor",
@@ -2441,7 +2441,7 @@
             "type": "rich-text"
         },
         "value": {
-            "default": "<p>Dear {{ copyedit_assignment.copyeditor.full_name }},</p><p>Your copyediting assignment for article \"{{ copyedit_assignment.article.title }}\" has been deleted. We no longer require you to undertake this task.</p><p>Regards, {{ request.user.signature|safe }}</p>"
+            "default": "<p>Dear {{ copyedit_assignment.copyeditor.full_name }},</p><p>Your copyediting assignment for article \"{{ copyedit_assignment.article.safe_title }}\" has been deleted. We no longer require you to undertake this task.</p><p>Regards, {{ request.user.signature|safe }}</p>"
         },
         "editable_by": [
             "editor",
@@ -2460,7 +2460,7 @@
             "type": "rich-text"
         },
         "value": {
-            "default": "<p>Dear {{ typeset_task.typesetter.full_name }},</p><p>Your typesetting assignment for article \"{{ typeset_task.assignment.article.title }}\" has been deleted. We no longer require you to undertake this task.</p><p>Regards, {{ request.user.signature|safe }}</p>"
+            "default": "<p>Dear {{ typeset_task.typesetter.full_name }},</p><p>Your typesetting assignment for article \"{{ typeset_task.assignment.article.safe_title }}\" has been deleted. We no longer require you to undertake this task.</p><p>Regards, {{ request.user.signature|safe }}</p>"
         },
         "editable_by": [
             "editor",
@@ -2479,7 +2479,7 @@
             "type": "rich-text"
         },
         "value": {
-            "default": "<p>Dear {{ proofing_task.proofreader.full_name }},</p><p>Your proofing assignment for article \"{{ proofing_task.assignment.article.title }}\" has been updated. Its due it is now {{ proofing_task.due }}. If you cannot completed the task in this time, please get in touch by replying to this email.</p><p>Regards, {{ request.user.signature|safe }}</p>"
+            "default": "<p>Dear {{ proofing_task.proofreader.full_name }},</p><p>Your proofing assignment for article \"{{ proofing_task.assignment.article.safe_title }}\" has been updated. Its due it is now {{ proofing_task.due }}. If you cannot completed the task in this time, please get in touch by replying to this email.</p><p>Regards, {{ request.user.signature|safe }}</p>"
         },
         "editable_by": [
             "editor",
@@ -3695,7 +3695,7 @@
             "type": "rich-text"
         },
         "value": {
-            "default": "<p>Dear {{ correction.typesetter.full_name }},</p><p>The correction task you were assigned for {{ article.title }} has been cancelled.</p><p>Regards,</p> {{ request.user.signature|safe }}"
+            "default": "<p>Dear {{ correction.typesetter.full_name }},</p><p>The correction task you were assigned for {{ article.safe_title }} has been cancelled.</p><p>Regards,</p> {{ request.user.signature|safe }}"
         },
         "editable_by": [
             "editor",
@@ -4379,7 +4379,7 @@
             "type": "rich-text"
         },
         "value": {
-            "default": "<p>Dear {{ revision.article.correspondence_author.full_name }},</p><p>Thank you for submitting your revisions for \"{{ revision.article.title }}\". We will be in touch with further information about your submission soon.</p><p>Best wishes,</p><p>{{ revision.editor.full_name }}</p>"
+            "default": "<p>Dear {{ revision.article.correspondence_author.full_name }},</p><p>Thank you for submitting your revisions for \"{{ revision.article.safe_title }}\". We will be in touch with further information about your submission soon.</p><p>Best wishes,</p><p>{{ revision.editor.full_name }}</p>"
         },
         "editable_by": [
             "editor",
@@ -4645,7 +4645,7 @@
             "type": "rich-text"
         },
         "value": {
-            "default": "<p>Dear {{ author_review.assignment.article.correspondence_author.full_name }},</p><p>The copyediting review request for \"{{ author_review.assignment.article.title|safe }}\" that we sent you has been deleted.</p><p>Regards,</p>{{ request.user.signature|safe }}"
+            "default": "<p>Dear {{ author_review.assignment.article.correspondence_author.full_name }},</p><p>The copyediting review request for \"{{ author_review.assignment.article.safe_title|safe }}\" that we sent you has been deleted.</p><p>Regards,</p>{{ request.user.signature|safe }}"
         },
         "editable_by": [
             "editor",
@@ -4683,7 +4683,7 @@
             "type": "rich-text"
         },
         "value": {
-            "default": "<p>You are receiving this email because you are registered for publication notifications for {{ journal.name }}.</p><p>The following articles have been published today: </p><ul>{% for article in articles %}<li><a href=\"{{ article.url }}\">{{ article.title }}</a></li>{% endfor %}</ul>"
+            "default": "<p>You are receiving this email because you are registered for publication notifications for {{ journal.name }}.</p><p>The following articles have been published today: </p><ul>{% for article in articles %}<li><a href=\"{{ article.url }}\">{{ article.safe_title }}</a></li>{% endfor %}</ul>"
         },
         "editable_by": [
             "editor",

--- a/src/utils/install/journal_defaults.json
+++ b/src/utils/install/journal_defaults.json
@@ -4645,7 +4645,7 @@
             "type": "rich-text"
         },
         "value": {
-            "default": "<p>Dear {{ author_review.assignment.article.correspondence_author.full_name }},</p><p>The copyediting review request for \"{{ author_review.assignment.article.safe_title|safe }}\" that we sent you has been deleted.</p><p>Regards,</p>{{ request.user.signature|safe }}"
+            "default": "<p>Dear {{ author_review.assignment.article.correspondence_author.full_name }},</p><p>The copyediting review request for \"{{ author_review.assignment.article.safe_title }}\" that we sent you has been deleted.</p><p>Regards,</p>{{ request.user.signature|safe }}"
         },
         "editable_by": [
             "editor",


### PR DESCRIPTION
closes #971 
Adds a new property to preprints/articles (`safe_title`).

Replaced all explicit `title|safe`
replaced all missing safe titles with `.safe_title`