### PR TITLE
Fixed an issue where From address was being encoded as a tuple on some email backends

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,19 @@ ifdef VERBOSE
 	_VERBOSE=--verbose
 endif
 
+# Email
+JANEWAY_EMAIL_BACKEND=''
+JANEWAY_EMAIL_HOST=''
+JANEWAY_EMAIL_PORT=''
+JANEWAY_EMAIL_USE_TLS=0
+
+ifdef DEBUG_SMTP
+	JANEWAY_EMAIL_BACKEND=django.core.mail.backends.smtp.EmailBackend
+	JANEWAY_EMAIL_HOST=janeway-debug-smtp
+	JANEWAY_EMAIL_PORT=1025
+	JANEWAY_EMAIL_USE_TLS=
+endif
+
 export DB_VENDOR
 export DB_HOST
 export DB_PORT
@@ -53,6 +66,12 @@ export DB_USER
 export DB_PASSWORD
 export JANEWAY_PORT
 export PGADMIN_PORT
+
+export JANEWAY_EMAIL_BACKEND
+export JANEWAY_EMAIL_HOST
+export JANEWAY_EMAIL_PORT
+export JANEWAY_EMAIL_USE_TLS
+
 SUFFIX ?= $(shell date +%s)
 SUFFIX := ${SUFFIX}
 DATE := `date +"%y-%m-%d"`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,6 +59,7 @@ services:
     image: dadarek/wait-for-dependencies
     depends_on:
      - "janeway-${DB_VENDOR}"
+     - janeway-debug-smtp
     command: "janeway-${DB_VENDOR}:${DB_PORT}"
 
   janeway-web:
@@ -92,3 +93,7 @@ services:
     command: /bin/bash
     volumes:
       - ./db/janeway.sqlite:/var/lib/janeway.sqlite
+  janeway-debug-smtp:
+    # Use same python as janeway-web to reduce the number of images
+    image: python:3.8
+    entrypoint: python -u -m smtpd -c DebuggingServer -n 0.0.0.0:1025

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -83,6 +83,11 @@ services:
       - PYTHONDONTWRITEBYTECODE=yes
       - JANEWAY_SETTINGS_MODULE=core.dev_settings
       - NOSE_INCLUDE_EXE=1
+      - JANEWAY_EMAIL_BACKEND
+      - JANEWAY_EMAIL_HOST
+      - JANEWAY_EMAIL_PORT
+      - JANEWAY_EMAIL_USE_TLS
+
     depends_on:
       - "start_dependencies"
 

--- a/src/core/dev_settings.py
+++ b/src/core/dev_settings.py
@@ -1,11 +1,14 @@
 # SECURITY WARNING: keep the secret key used in production secret!
 # You should change this key before you go live!
+import os
 DEBUG = True
 SECRET_KEY = 'uxprsdhk^gzd-r=_287byolxn)$k6tsd8_cepl^s^tms2w1qrv'
 
 # This is the default redirect if no other sites are found.
 DEFAULT_HOST = 'https://www.example.org'
-EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
+EMAIL_BACKEND = os.environ.get(
+    'JANEWAY_EMAIL_BACKEND', 'django.core.mail.backends.console.EmailBackend',
+)
 
 URL_CONFIG = 'path'  # path or domain
 

--- a/src/core/janeway_global_settings.py
+++ b/src/core/janeway_global_settings.py
@@ -370,12 +370,14 @@ MESSAGE_TAGS = {
 LOGIN_REDIRECT_URL = '/'
 LOGIN_URL = '/login/'
 
-EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
-EMAIL_HOST = ''
-EMAIL_PORT = ''
-EMAIL_HOST_USER = ''
-EMAIL_HOST_PASSWORD = ''
-EMAIL_USE_TLS = True
+EMAIL_BACKEND = os.environ.get(
+    'JANEWAY_EMAIL_BACKEND', 'django.core.mail.backends.smtp.EmailBackend',
+)
+EMAIL_HOST = os.environ.get("JANEWAY_EMAIL_HOST", '')
+EMAIL_PORT = os.environ.get("JANEWAY_EMAIL_PORT", '')
+EMAIL_HOST_USER = os.environ.get("JANEWAY_EMAIL_HOST_USER", '')
+EMAIL_HOST_PASSWORD = os.environ.get("JANEWAY_EMAIL_HOST_PASSWORD", '')
+EMAIL_USE_TLS = os.environ.get("JANEWAY_EMAIL_USE_TLS", True)
 DUMMY_EMAIL_DOMAIN = "@journal.com"
 
 # Settings for use with Mailgun

--- a/src/utils/notify_plugins/notify_email.py
+++ b/src/utils/notify_plugins/notify_email.py
@@ -80,7 +80,15 @@ def send_email(subject, to, html, journal, request, bcc=None, cc=None, attachmen
     if reply_to and not isinstance(reply_to, (tuple, list)):
         reply_to = [reply_to]
 
-    msg = EmailMultiAlternatives(subject, strip_tags(html), full_from_string, to, bcc=bcc, cc=cc, reply_to=reply_to)
+    kwargs = dict(
+        bcc=bcc,
+        cc=cc,
+    )
+    if reply_to:
+        # Avoid empty mailboxes for servers not compliant with RFC 5322
+        kwargs[reply_to] = reply_to
+
+    msg = EmailMultiAlternatives(subject, strip_tags(html), full_from_string, to, **kwargs)
     msg.attach_alternative(html, "text/html")
 
     if request and request.FILES and request.FILES.getlist('attachment'):


### PR DESCRIPTION
With this PR we always sanitize the from address before handing it over to the email backend. This will be a redundant call for some backends but will stop the bad encoding on others.

It also avoids sending an empty reply_to header as some **very** old SMTP servers could have trouble with this.

As a bonus, I added an additional service to docker-compose that allows running the development server against a very simple SMTP server when using the `DEBUG_SMTP` flag (e.g: `DEBUG_SMTP=1 make run`

closes #3545 