### PR TITLE
Disable is_secure URL builder checks when DEBUG is on

### DIFF
--- a/src/core/model_utils.py
+++ b/src/core/model_utils.py
@@ -98,9 +98,14 @@ class AbstractSiteModel(models.Model):
     def site_url(self, path=None):
         return logic.build_url(
             netloc=self.domain,
-            scheme=self.SCHEMES[self.is_secure],
+            scheme=self._get_scheme(),
             path=path or "",
         )
+    def _get_scheme(self):
+        scheme = self.SCHEMES[self.is_secure]
+        if settings.DEBUG is True:
+            scheme = self.SCHEMES[False]
+        return scheme
 
 
 class PGCaseInsensitivedMixin():

--- a/src/journal/models.py
+++ b/src/journal/models.py
@@ -335,7 +335,7 @@ class Journal(AbstractSiteModel):
                 path = path[len(site_path):]
             return logic.build_url(
                     netloc=self.domain,
-                    scheme=self.SCHEMES[self.is_secure],
+                    scheme=self._get_scheme(),
                     port=None,
                     path=path,
             )

--- a/src/press/models.py
+++ b/src/press/models.py
@@ -190,7 +190,7 @@ class Press(AbstractSiteModel):
 
         return logic.build_url(
             netloc=self.domain,
-            scheme=self.SCHEMES[self.is_secure],
+            scheme=self._get_scheme(),
             port=port,
             path=_path,
         )

--- a/src/repository/models.py
+++ b/src/repository/models.py
@@ -242,7 +242,7 @@ class Repository(model_utils.AbstractSiteModel):
         if self.domain and not settings.URL_CONFIG == 'path':
             return logic.build_url(
                     netloc=self.domain,
-                    scheme=self.SCHEMES[self.is_secure],
+                    scheme=self._get_scheme(),
                     port=None,
                     path=path,
             )


### PR DESCRIPTION
What it says on the tin, it avoids having the development environment render links with the https scheme, which cannot be loaded by django's development server