### PR TITLE
2986 fixes an error that caused edit_metadata to fail when additional fields were present.

### DIFF
--- a/src/submission/forms.py
+++ b/src/submission/forms.py
@@ -196,10 +196,10 @@ class ArticleInfo(KeywordModelForm, JanewayTranslationModelForm):
                         except models.FieldAnswer.DoesNotExist:
                             pass
 
-                # if the editor is viewing the page, don't set additional
-                # fields to be required.
-                if editor_view:
-                    self.fields[element.name].required = False
+                    # if the editor is viewing the page, don't set additional
+                    # fields to be required.
+                    if editor_view:
+                        self.fields[element.name].required = False
 
 
     def save(self, commit=True, request=None):

--- a/src/submission/forms.py
+++ b/src/submission/forms.py
@@ -100,6 +100,7 @@ class ArticleInfo(KeywordModelForm, JanewayTranslationModelForm):
         submission_summary = kwargs.pop('submission_summary', None)
         journal = kwargs.pop('journal', None)
         self.pop_disabled_fields = kwargs.pop('pop_disabled_fields', True)
+        editor_view = kwargs.pop('editor_view', False)
 
         super(ArticleInfo, self).__init__(*args, **kwargs)
         if 'instance' in kwargs:
@@ -194,6 +195,12 @@ class ArticleInfo(KeywordModelForm, JanewayTranslationModelForm):
                             self.fields[element.name].initial = check_for_answer.answer
                         except models.FieldAnswer.DoesNotExist:
                             pass
+
+                # if the editor is viewing the page, don't set additional
+                # fields to be required.
+                if editor_view:
+                    self.fields[element.name].required = False
+
 
     def save(self, commit=True, request=None):
         article = super(ArticleInfo, self).save(commit=False)

--- a/src/submission/views.py
+++ b/src/submission/views.py
@@ -587,18 +587,22 @@ def edit_metadata(request, article_id):
     """
     with translation.override(request.override_language):
         article = get_object_or_404(models.Article, pk=article_id)
-        additional_fields = models.Field.objects.filter(journal=request.journal)
+        additional_fields = models.Field.objects.filter(
+            journal=request.journal,
+        )
         submission_summary = setting_handler.get_setting(
             'general',
             'submission_summary',
             request.journal,
         ).processed_value
         funder_form = forms.FunderForm()
+
         info_form = forms.ArticleInfo(
             instance=article,
             additional_fields=additional_fields,
             submission_summary=submission_summary,
             pop_disabled_fields=False,
+            editor_view=True,
         )
         frozen_author, modal = None, None
         return_param = request.GET.get('return')
@@ -633,8 +637,10 @@ def edit_metadata(request, article_id):
                 info_form = forms.ArticleInfo(
                     request.POST,
                     instance=article,
+                    additional_fields=additional_fields,
                     submission_summary=submission_summary,
                     pop_disabled_fields=False,
+                    editor_view=True,
                 )
 
                 if info_form.is_valid():


### PR DESCRIPTION
- The `edit_metadata` view now passes `additional_fields` to the form on POST
- Adds a new `editor_view` kwarg to the `ArticleInfo` form which allows editors to bypass required status on additional fields
- Closes #2986 