### PR TITLE
#3348 comments to the editor field has been moved to the end of the submission flow

### DIFF
--- a/src/submission/forms.py
+++ b/src/submission/forms.py
@@ -27,7 +27,7 @@ class ArticleStart(forms.ModelForm):
 
     class Meta:
         model = models.Article
-        fields = ('publication_fees', 'submission_requirements', 'copyright_notice', 'comments_editor',
+        fields = ('publication_fees', 'submission_requirements', 'copyright_notice',
                   'competing_interests')
 
     def __init__(self, *args, **kwargs):
@@ -35,7 +35,6 @@ class ArticleStart(forms.ModelForm):
         super(ArticleStart, self).__init__(*args, **kwargs)
 
         self.fields['competing_interests'].label = ''
-        self.fields['comments_editor'].label = ''
 
         if not journal.submissionconfiguration.publication_fees:
             self.fields.pop('publication_fees')
@@ -60,9 +59,6 @@ class ArticleStart(forms.ModelForm):
 
         if not journal.submissionconfiguration.competing_interests:
             self.fields.pop('competing_interests')
-
-        if not journal.submissionconfiguration.comments_to_the_editor:
-            self.fields.pop('comments_editor')
 
 
 class ArticleInfo(KeywordModelForm, JanewayTranslationModelForm):
@@ -286,6 +282,15 @@ class AuthorForm(forms.ModelForm):
         return orcid_string
 
 
+class SubmissionCommentsForm(forms.ModelForm):
+    class Meta:
+        model = models.Article
+        fields = ('comments_editor',)
+        labels = {
+            'comments_editor': '',
+        }
+
+
 class FileDetails(forms.ModelForm):
 
     class Meta:
@@ -475,6 +480,7 @@ class FunderForm(forms.ModelForm):
             self.article.funders.add(funder)
             self.article.save()
         return funder
+
 
 def utility_clean_orcid(orcid):
     """

--- a/src/templates/admin/submission/start.html
+++ b/src/templates/admin/submission/start.html
@@ -69,17 +69,6 @@
                         {{ form.competing_interests|foundation }}
                     </div>
                 {% endif %}
-
-                {% if request.journal.submissionconfiguration.comments_to_the_editor %}
-                    <div class="title-area">
-                        <h2>{% trans "Comments to the Editor" %}</h2>
-                    </div>
-                    <div class="content submission-content">
-                        {{ form.comments_editor|foundation }}
-                    </div>
-                {% endif %}
-
-
                 <button class="success button pull-right" type="submit" name="start_submission"><i class="fa fa-check">&nbsp;</i>{% trans "Start Submission" %}
                 </button>
                 <br/>

--- a/src/templates/admin/submission/submit_review.html
+++ b/src/templates/admin/submission/submit_review.html
@@ -1,8 +1,5 @@
 {% extends "admin/core/base.html" %}
-{% load static %}
-{% load i18n %}
-{% load hooks %}
-{% load text %}
+{% load static i18n hooks text foundation %}
 
 {% block css %}
     <link href="{% static "admin/css/timeline.css" %}" rel="stylesheet"/>{% endblock %}
@@ -21,7 +18,7 @@
             <div class="row expanded">
                 <div class="large-12 columns">
 
-                    <p>{% blocktrans %}Please review your submission use the details below. If you need to make changes use the links above to move back along the submission steps. You must click the Complete Submission button at the foot of this page to complete the submission process, you will then receive a receipt email. {% endblocktrans %}</p>
+                    <p>{% blocktrans %}Please review your submission use the details below. If you need to make changes use the links above to move back along the submission steps. You must click the <strong>Complete Submission</strong> button at the foot of this page to complete the submission process, you will then receive a receipt email. {% endblocktrans %}</p>
 
                     {% if request.journal.submissionconfiguration.publication_fees or request.journal.submissionconfiguration.submission_check or request.journal.submissionconfiguration.copyright_notice %}
                         <div class="title-area">
@@ -43,12 +40,6 @@
 
                     {% endif %}
 
-                    {% if article.comments_editor %}
-                        <div class="title-area"><h2>{% trans "Comments to Editor" %}</h2></div>
-                        <div class="content">
-                            <p>{{ article.comments_editor|linebreaksbr }}</p>
-                        </div>
-                    {% endif %}
                     <div class="title-area"><h2>{% trans "Article Info" %}</h2></div>
                     <table class="scroll small">
                         <tr>
@@ -149,6 +140,16 @@
                     </table>
 
                     {% hook 'submission_review' %}
+
+                    {% if request.journal.submissionconfiguration.comments_to_the_editor %}
+                        <div class="title-area">
+                            <h2>{% trans "Comments to the Editor" %}</h2>
+                        </div>
+                        <div class="content submission-content">
+                            <p>Before submitting you have the option to add additional comments for the editor using the field below. Only the editor will see anything you add here.</p>
+                            {{ form.comments_editor|foundation }}
+                        </div>
+                    {% endif %}
 
                     <div class="large-12 columns">
                         <button class="success button pull-right" type="submit" name="next_step"><i class="fa fa-check">&nbsp;</i>{% trans "Complete" %} {% trans "Submission" %}


### PR DESCRIPTION
- Moved the comments field to the end of the review page to allow authors to reflect on the submission process before they add anything.
- Closes #3348