### PR TITLE
Fixes a bug where the footer in material theme would not be fixed at the bottom of the page

### DIFF
--- a/src/themes/material/assets/mat.css
+++ b/src/themes/material/assets/mat.css
@@ -687,3 +687,13 @@ strong {
 #homepage-element-search-bar .input-field #search_term {
   font-size: 1.5rem;
 }
+
+body {
+    display: flex;
+    min-height: 100vh;
+    flex-direction: column;
+}
+
+main {
+    flex: 1 0 auto;
+}

--- a/src/themes/material/templates/core/base.html
+++ b/src/themes/material/templates/core/base.html
@@ -44,6 +44,7 @@
 </head>
 <body>
 
+<header>
 {% block navbar %}
     {% if request.journal %}
         {% include "core/nav.html" %}
@@ -53,12 +54,14 @@
         {% include "press/nav.html" %}
     {% endif %}
 {% endblock navbar %}
-
-<div class="container">
-    <div class="section">
-        {% block body %}{% endblock %}
+</header>
+<main>
+    <div class="container">
+        <div class="section">
+            {% block body %}{% endblock %}
+        </div>
     </div>
-</div>
+</main>
 <footer class="page-footer">
     <div class="footer-copyright">
         <div class="container">


### PR DESCRIPTION
before:

![image](https://github.com/BirkbeckCTP/janeway/assets/10760678/37a7027e-0e51-4513-8cbe-1b087c26dbb4)

After:

![image](https://github.com/BirkbeckCTP/janeway/assets/10760678/96813380-f3b0-40ab-a25e-0fef8d282d29)



Closes #3584
