### PR TITLE
Upgrade materialize

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ crossrefapi==1.5.0
 Django==3.2.19
 django-bootstrap4==22.3
 -e git+https://github.com/BirkbeckCTP/django-foundation-form.git@284fc5f08e58d8655c7301eddb49f920fda516d2#egg=foundationform
--e git+https://github.com/BirkbeckCTP/django-materialize.git@ca97451d96cab4b2c83797f34c32dfb69af08e0a#egg=django_materialize
+-e git+https://github.com/kalwalkden/django-materializecss-form.git@7018fe0659ad12e74cfea80e281faa1390a3132f#egg=django-materializecss-form
 django-debug-toolbar==3.7.0
 django-hCaptcha==0.2.0
 django-hijack==3.2.1

--- a/src/core/janeway_global_settings.py
+++ b/src/core/janeway_global_settings.py
@@ -95,7 +95,7 @@ INSTALLED_APPS = [
     'bootstrap4',
     'rest_framework',
     'foundationform',
-    'materialize',
+    'materializecssform',
     'captcha',
     'simplemathcaptcha',
     'hijack',

--- a/src/journal/forms.py
+++ b/src/journal/forms.py
@@ -13,7 +13,7 @@ from django_summernote.widgets import SummernoteWidget
 
 from core import models as core_models
 from journal import models as journal_models, logic
-from utils.forms import CaptchaForm, LeftBooleanField
+from utils.forms import CaptchaForm
 
 SEARCH_SORT_OPTIONS = [
         # Translators: Search order options
@@ -92,14 +92,15 @@ class SearchForm(forms.Form):
         if self.data and not self.has_filter:
             for search_filter in self.SEARCH_FILTERS:
                 self.data[search_filter] = "on"
+        self.label_suffix = ''
 
     article_search = forms.CharField(label=_('Search term'), min_length=3, max_length=100, required=False)
-    title = LeftBooleanField(initial=True, label=_('Search Titles'), required=False)
-    abstract = LeftBooleanField(initial=True, label=_('Search Abstract'), required=False)
-    authors = LeftBooleanField(initial=True, label=_('Search Authors'), required=False)
-    keywords = LeftBooleanField(initial=True, label=_("Search Keywords"), required=False)
-    full_text = LeftBooleanField(initial=True, label=_("Search Full Text"), required=False)
-    orcid = LeftBooleanField(label=_("Search ORCIDs"), required=False)
+    title = forms.BooleanField(initial=True, label=_('Search Titles'), required=False)
+    abstract = forms.BooleanField(initial=True, label=_('Search Abstract'), required=False)
+    authors = forms.BooleanField(initial=True, label=_('Search Authors'), required=False)
+    keywords = forms.BooleanField(initial=True, label=_("Search Keywords"), required=False)
+    full_text = forms.BooleanField(initial=True, label=_("Search Full Text"), required=False)
+    orcid = forms.BooleanField(label=_("Search ORCIDs"), required=False)
     sort = forms.ChoiceField(label=_('Sort results by'), widget=forms.Select, choices=SEARCH_SORT_OPTIONS)
 
     def get_search_filters(self):

--- a/src/themes/OLH/templates/journal/full-text-search.html
+++ b/src/themes/OLH/templates/journal/full-text-search.html
@@ -1,6 +1,7 @@
 {% extends "core/base.html" %}
 {% load hooks %}
 {% load i18n %}
+{% load foundation %}
 
 {% hook 'filter_search' %}
 
@@ -33,7 +34,32 @@
                         <div class="form-group">
                             {% if not keyword %}
                                 {% include 'elements/forms/errors.html'  with form=form%}
-                                {{ form.as_p }}
+                                {{ form.article_search|foundation }}
+                                <div>
+                                    {{ form.title }}
+                                    {{ form.title.label_tag }}
+                                </div>
+                                <div>
+                                    {{ form.abstract }}
+                                    {{ form.abstract.label_tag }}
+                                </div>
+                                <div>
+                                    {{ form.authors }}
+                                    {{ form.authors.label_tag }}
+                                </div>
+                                <div>
+                                    {{ form.keywords }}
+                                    {{ form.keywords.label_tag }}
+                                </div>
+                                <div>
+                                    {{ form.full_text }}
+                                    {{ form.full_text.label_tag }}
+                                </div>
+                                <div>
+                                    {{ form.orcid }}
+                                    {{ form.orcid.label_tag }}
+                                </div>
+                                {{ form.sort|foundation }}
                             {% else %}
                                 You are currently browsing by keyword. <a href="{% url 'search' %}">Search for an article.</a>
                             {% endif %}

--- a/src/themes/clean/templates/journal/full-text-search.html
+++ b/src/themes/clean/templates/journal/full-text-search.html
@@ -1,6 +1,7 @@
 {% extends "core/base.html" %}
 {% load hooks %}
 {% load i18n %}
+{% load bootstrap4 %}
 
 {% hook 'filter_search' %}
 
@@ -33,7 +34,7 @@
                         <div class="form-group">
                             {% if not keyword %}
                                 {% include 'elements/forms/errors.html'  with form=form%}
-                                {{ form.as_p }}
+                                {% bootstrap_form form %}
                             {% else %}
                                 You are currently browsing by keyword. <a href="{% url 'search' %}">Search for an article.</a>
                             {% endif %}

--- a/src/themes/material/assets/mat.css
+++ b/src/themes/material/assets/mat.css
@@ -456,7 +456,10 @@ nav ul li {
     line-height: 90px;
 }
 
-nav, nav .nav-wrapper i, nav a.button-collapse, nav a.button-collapse i {
+nav,
+nav .nav-wrapper i,
+nav a.sidenav-trigger,
+nav a.sidenav-trigger i {
     line-height: 90px;
 }
 
@@ -477,7 +480,7 @@ nav, nav .nav-wrapper i, nav a.button-collapse, nav a.button-collapse i {
     color: white;
 }
 
-.button-collapse {
+.sidenav-trigger {
     color: #616161;
 }
 

--- a/src/themes/material/assets/material.js
+++ b/src/themes/material/assets/material.js
@@ -16,7 +16,6 @@ function table_downloads() {
 
 
 $( document ).ready(function(){
-    $(".button-collapse").sideNav();
     $('.modal').modal();
     figure_downloads();
     table_downloads();
@@ -24,9 +23,11 @@ $( document ).ready(function(){
 
 var $root = $('html, body');
 
-$('a[href^="#"]').click(function() {
+$('a[href^="#"]:not(a[href$="!"])').click(function() {
+  // The jquery selector needs to exclude href="#!"
+  // or the event listener will interefere with the sidenav trigger
     var href = $.attr(this, 'href');
-    if (href && href != "#!") {
+    if (href) {
 
         $root.animate({
             scrollTop: $(href).offset().top

--- a/src/themes/material/assets/material.js
+++ b/src/themes/material/assets/material.js
@@ -16,7 +16,6 @@ function table_downloads() {
 
 
 $( document ).ready(function(){
-    $('.modal').modal();
     figure_downloads();
     table_downloads();
 })

--- a/src/themes/material/assets/material.js
+++ b/src/themes/material/assets/material.js
@@ -17,7 +17,6 @@ function table_downloads() {
 
 $( document ).ready(function(){
     $(".button-collapse").sideNav();
-    $('select').material_select();
     $('.modal').modal();
     figure_downloads();
     table_downloads();

--- a/src/themes/material/templates/500.html
+++ b/src/themes/material/templates/500.html
@@ -10,7 +10,9 @@
     <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet"
           integrity="sha384-wvfXpqpZZVQGK6TAh5PVlGOfQNHSoD2xbE+QkPxCAFlNEevoEH3Sl0sibVcOQVnN" crossorigin="anonymous">
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/0.100.2/css/materialize.min.css">
+    <link
+        rel="stylesheet"
+        href="https://cdn.jsdelivr.net/npm/@materializecss/materialize@1.2.2/dist/css/materialize.min.css">
     <link rel="stylesheet" href="{% static "material/mat.css" %}">
 </head>
 <body>
@@ -29,8 +31,14 @@
 
 
 <!--  Scripts-->
-<script src="https://code.jquery.com/jquery-2.1.1.min.js"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/0.100.2/js/materialize.min.js"></script>
+<script
+    src="https://code.jquery.com/jquery-3.4.1.min.js"
+    integrity="sha256-CSXorXvZcTkaix6Yvo6HppcZGetbYMGWSFlBw8HfCJo="
+    crossorigin="anonymous">
+</script>
+<script
+    src="https://cdn.jsdelivr.net/npm/@materializecss/materialize@1.2.2/dist/js/materialize.min.js">
+</script>
 <script src="{% static 'material/material.js' %}"></script>
 </body>
 </html>

--- a/src/themes/material/templates/core/accounts/register.html
+++ b/src/themes/material/templates/core/accounts/register.html
@@ -1,5 +1,5 @@
 {% extends "core/base.html" %}
-{% load materialize %}
+{% load materializecss %}
 {% load i18n %}
 {% load static %}
 
@@ -29,7 +29,7 @@
                     <form method="POST">
                         {% include "elements/forms/errors.html" %}
                         {% csrf_token %}
-                        {% materialize_form form=form %}
+                        {{ form|materializecss }}
                         <p>{% trans "By registering an account you agree to our" %}
                           {% if journal_settings.general.privacy_policy_url %}
                             <a href="{{ journal_settings.general.privacy_policy_url }}">{% trans "Privacy Policy" %}</a>

--- a/src/themes/material/templates/core/accounts/reset_password.html
+++ b/src/themes/material/templates/core/accounts/reset_password.html
@@ -1,6 +1,6 @@
 {% extends "core/base.html" %}
 {% load i18n %}
-{% load materialize %}
+{% load materializecss %}
 
 {% block title %}{% trans "Reset Password" %}{% endblock title %}
 
@@ -23,7 +23,7 @@
                                 <p>{% blocktrans %}For more information read our
                                     <a href="#passwordmodal" class="modal-trigger">password guide</a>
                                     .{% endblocktrans %}</p>
-                                {% materialize_form form=form %}
+                                {{ form|materializecss }}
                                 <br/>
                                 <button type="submit"
                                         class="btn btn-primary btn-block">{% trans "Reset Password" %}</button>

--- a/src/themes/material/templates/core/base.html
+++ b/src/themes/material/templates/core/base.html
@@ -27,7 +27,9 @@
         <link rel="icon" href="{{ request.repository.favicon.url }}" type="image/vnd.microsoft.icon"/>
     {% endif %}
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/0.100.2/css/materialize.min.css">
+    <link
+        rel="stylesheet"
+        href="https://cdn.jsdelivr.net/npm/@materializecss/materialize@1.2.2/dist/css/materialize.min.css">
     <link rel="stylesheet" href="{% static "material/mat.css" %}">
 
     {% if request.journal %}
@@ -78,8 +80,17 @@
 
 
 <!--  Scripts-->
-<script src="https://code.jquery.com/jquery-2.1.1.min.js"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/0.100.2/js/materialize.min.js"></script>
+<script
+    src="https://code.jquery.com/jquery-3.4.1.min.js"
+    integrity="sha256-CSXorXvZcTkaix6Yvo6HppcZGetbYMGWSFlBw8HfCJo="
+    crossorigin="anonymous">
+</script>
+<script
+    src="https://cdn.jsdelivr.net/npm/@materializecss/materialize@1.2.2/dist/js/materialize.min.js">
+</script>
+<script>
+    M.AutoInit()
+</script>
 <script src="{% static 'material/material.js' %}"></script>
 <script src="{% static "admin/js/csrf.js" %}"></script>
 <script src="{% static "common/js/timezone-setter.js" %}"></script>

--- a/src/themes/material/templates/core/base.html
+++ b/src/themes/material/templates/core/base.html
@@ -89,7 +89,7 @@
     src="https://cdn.jsdelivr.net/npm/@materializecss/materialize@1.2.2/dist/js/materialize.min.js">
 </script>
 <script>
-    M.AutoInit()
+    window.M.AutoInit()
 </script>
 <script src="{% static 'material/material.js' %}"></script>
 <script src="{% static "admin/js/csrf.js" %}"></script>
@@ -98,7 +98,12 @@
 <script>
     {% if messages %}
         {% for message in messages %}
-            Materialize.toast('{{ message|linebreaksbr }}', 4000);
+            window.M.toast(
+              {
+                html: '{{ message|linebreaksbr }}',
+                displayLength: 4000,
+              }
+            )
         {% endfor %}
     {% endif %}
 </script>

--- a/src/themes/material/templates/core/nav.html
+++ b/src/themes/material/templates/core/nav.html
@@ -44,9 +44,17 @@
 
             {% for item in navigation_items %}
                 {% if item.has_sub_nav %}
-                    <li><a class="dropdown-button" href="#!"
-                           data-activates="{{ item.link_name|slugify }}">{{ item.link_name }}<i
-                            class="material-icons right">arrow_drop_down</i></a></li>
+                    <li>
+                        <a
+                            class="dropdown-trigger"
+                            href="#!"
+                            data-target="{{ item.link_name|slugify }}">
+                            {{ item.link_name }}
+                            <i class="material-icons right">
+                                arrow_drop_down
+                            </i>
+                        </a>
+                    </li>
                 {% elif not item.for_footer %}
                 <li><a href="{{ item.url }}" class="nav-link">{{ item.link_name }}</a></li>
                 {% endif %}
@@ -57,8 +65,15 @@
             {% endif %}
             {% hook 'nav_block' %}
             {% if request.user.is_authenticated %}
-                <li><a class="dropdown-button" href="#!" data-activates="account">{% trans "Account" %}<i
-                        class="material-icons right">arrow_drop_down</i></a></li>
+                <li>
+                    <a
+                        class="dropdown-trigger"
+                        href="#!"
+                        data-target="account">
+                        {% trans "Account" %}
+                        <i class="material-icons right">arrow_drop_down</i>
+                    </a>
+                </li>
             {% else %}
                 <li><a href="{% url 'core_login' %}" class="nav-link">{% trans "Login" %}</a></li>
                 <li><a href="{% url 'core_register' %}">{% trans "Register" %}</a></li>
@@ -90,23 +105,41 @@
 
             {% for item in navigation_items %}
                 {% if item.has_sub_nav %}
-                    <li><a class="dropdown-button" href="#!"
-                           data-activates="{{ item.link_name|slugify }}-mobile">{{ item.link_name }}<i
-                            class="material-icons right">arrow_drop_down</i></a></li>
+                    <li>
+                        <a
+                            class="dropdown-trigger"
+                            href="#!"
+                            data-target="{{ item.link_name|slugify }}-mobile">
+                            {{ item.link_name }}
+                            <i class="material-icons right">arrow_drop_down</i>
+                        </a>
+                    </li>
                 {% else %}
                     <li><a href="{{ item.url }}" class="nav-link">{{ item.link_name }}</a></li>
                 {% endif %}
             {% endfor %}
 
             {% if request.user.is_authenticated %}
-                <li><a class="dropdown-button" href="#!" data-activates="dropdown1">{% trans "Account" %}<i
-                        class="material-icons right">arrow_drop_down</i></a></li>
+                <li>
+                    <a
+                        class="dropdown-trigger"
+                        href="#!"
+                        data-target="dropdown1">
+                        {% trans "Account" %}
+                        <i class="material-icons right">arrow_drop_down</i>
+                    </a>
+                </li>
             {% else %}
                 <li><a href="{% url 'core_login' %}" class="nav-link">{% trans "Login" %}</a></li>
                 <li><a href="{% url 'core_register' %}">{% trans "Register" %}</a></li>
             {% endif %}
         </ul>
-        <a href="#!" data-activates="nav-mobile" class="button-collapse"><i class="material-icons">{% trans "menu" %}</i></a>
+        <a
+            href="#!"
+            data-target="nav-mobile"
+            class="button-collapse">
+            <i class="material-icons">menu</i>
+        </a>
     </div>
 </nav>
 

--- a/src/themes/material/templates/core/nav.html
+++ b/src/themes/material/templates/core/nav.html
@@ -80,7 +80,7 @@
             {% endif %}
         </ul>
 
-        <ul class="side-nav" id="nav-mobile">
+        <ul class="sidenav" id="nav-mobile">
             {% if request.journal.nav_home %}
             <li><a href="{% url 'website_index' %}">{% trans "Home" %}</a></li>
             {% endif %}
@@ -137,7 +137,7 @@
         <a
             href="#!"
             data-target="nav-mobile"
-            class="button-collapse">
+            class="sidenav-trigger">
             <i class="material-icons">menu</i>
         </a>
     </div>

--- a/src/themes/material/templates/elements/nav_element.html
+++ b/src/themes/material/templates/elements/nav_element.html
@@ -1,8 +1,15 @@
 {# Not used #}
 
 {% if item.has_sub_nav %}
-    <li><a class="dropdown-button" href="#!" data-activates="sub_nav_content">{{ item.link_name }}<i
-            class="material-icons right">arrow_drop_down</i></a></li>
+    <li>
+        <a
+            class="dropdown-trigger"
+            href="#!"
+            data-target="sub_nav_content">
+            {{ item.link_name }}
+            <i class="material-icons right">arrow_drop_down</i>
+        </a>
+    </li>
 {% elif not item.for_footer %}
     <li><a href="/{{ item.link }}">{{ item.link_name }}</a></li>
 {% endif %}

--- a/src/themes/material/templates/journal/articles.html
+++ b/src/themes/material/templates/journal/articles.html
@@ -117,7 +117,7 @@
 {% block js %}
     <script>
         $(document).ready(function () {
-            $('select').material_select();
+            $('select').formSelect();
         });
     </script>
 {% endblock %}

--- a/src/themes/material/templates/journal/articles.html
+++ b/src/themes/material/templates/journal/articles.html
@@ -113,11 +113,3 @@
         </div>
     </div>
 {% endblock %}
-
-{% block js %}
-    <script>
-        $(document).ready(function () {
-            $('select').formSelect();
-        });
-    </script>
-{% endblock %}

--- a/src/themes/material/templates/journal/contact.html
+++ b/src/themes/material/templates/journal/contact.html
@@ -1,6 +1,6 @@
 {% extends "core/base.html" %}
 {% load i18n %}
-{% load materialize %}
+{% load materializecss %}
 
 {% block title %}{% trans "Contact" %}{% endblock %}
 
@@ -40,7 +40,7 @@
                         {% include "elements/forms/errors.html" with form=contact_form %}
                         {% csrf_token %}
 
-                        {% materialize_form form=contact_form %}
+                        {{ form|materializecss }}
 
                         <button type="submit" class="btn">{% trans "Send Message" %}</button>
                     </form>

--- a/src/themes/material/templates/journal/contact.html
+++ b/src/themes/material/templates/journal/contact.html
@@ -53,7 +53,7 @@
 {% block js %}
     <script>
         $(document).ready(function () {
-            $('select').material_select();
+            $('select').formSelect();
         });
     </script>
 {% endblock %}

--- a/src/themes/material/templates/journal/contact.html
+++ b/src/themes/material/templates/journal/contact.html
@@ -40,7 +40,7 @@
                         {% include "elements/forms/errors.html" with form=contact_form %}
                         {% csrf_token %}
 
-                        {{ form|materializecss }}
+                        {{ contact_form|materializecss }}
 
                         <button type="submit" class="btn">{% trans "Send Message" %}</button>
                     </form>

--- a/src/themes/material/templates/journal/contact.html
+++ b/src/themes/material/templates/journal/contact.html
@@ -49,11 +49,3 @@
         </div>
     </div>
 {% endblock %}
-
-{% block js %}
-    <script>
-        $(document).ready(function () {
-            $('select').formSelect();
-        });
-    </script>
-{% endblock %}

--- a/src/themes/material/templates/journal/full-text-search.html
+++ b/src/themes/material/templates/journal/full-text-search.html
@@ -69,11 +69,3 @@
         </div>
     </div>
 {% endblock %}
-
-{% block js %}
-    <script>
-        $(document).ready(function () {
-            $('select').formSelect();
-        });
-    </script>
-{% endblock %}

--- a/src/themes/material/templates/journal/full-text-search.html
+++ b/src/themes/material/templates/journal/full-text-search.html
@@ -73,7 +73,7 @@
 {% block js %}
     <script>
         $(document).ready(function () {
-            $('select').material_select();
+            $('select').formSelect();
         });
     </script>
 {% endblock %}

--- a/src/themes/material/templates/journal/full-text-search.html
+++ b/src/themes/material/templates/journal/full-text-search.html
@@ -1,8 +1,7 @@
 {% extends "core/base.html" %}
 {% load hooks %}
 {% load i18n %}
-{% load materialize %}
-{% load utils_forms %}
+{% load materializecss %}
 
 {% hook 'filter_search' %}
 
@@ -31,39 +30,40 @@
 	    <div class="col m4">
             <div class="card">
                 <div class="card-content">
-                    <form method="GET">
-                        <div class="form-group">
-                            {% if not keyword %}
-                                <label for="id_article_search">{{ form.article_search.label }}</label>
-                                {{ form.article_search| addcss:''}}
-                                {{ form.title| addcss:''}}
-                                {{ form.abstract| addcss:''}}
-                                {{ form.authors| addcss:''}}
-                                {{ form.keywords| addcss:''}}
-                                {{ form.full_text| addcss:''}}
-                                {{ form.orcid| addcss:''}}
-                                <br />
-                                <label for="id_sort">{{ form.sort.label }}</label>
-                                {{ form.sort| addcss:''}}
-                            {% else %}
-                                You are currently browsing by keyword. <a href="{% url 'search' %}">Search for an article.</a>
+                    <div class="row">
+                        <form method="GET">
+                            <div class="form-group">
+                                {% if not keyword %}
+                                    {{ form|materializecss }}
+                                {% else %}
+                                    You are currently browsing by keyword.
+                                    <a href="{% url 'search' %}">Search for an article.</a>
+                                {% endif %}
+                            </div>
+                            {% if all_keywords %}
+                            <div class="form-group">
+                                <label>
+                                    {% trans "Keywords" %}
+
+                                    {% for keyword in all_keywords %}
+                                        <a href="{% url 'search' %}?keyword={{ keyword.word }}">
+                                            {{ keyword.word }}
+                                        </a>{% if not forloop.last %},
+                                        {% endif %}
+                                    {% endfor %}
+
+                                </label>
+                            </div>
                             {% endif %}
-                        </div>
-                        {% if all_keywords %}
-                        <div class="form-group">
-                            <label>{% trans "Keywords" %}
-
-                                {% for keyword in all_keywords %}
-                                    <a href="{% url 'search' %}?keyword={{ keyword.word }}">{{ keyword.word }}</a>{% if not forloop.last %}, {% endif %}
-                                {% endfor %}
-
-                            </label>
-                        </div>
-                        {% endif %}
-                        <div class="form-group">
-                            <button type="submit" class="btn btn-primary">{% trans "Filter" %}</button>
-                        </div>
-                    </form>
+                            <div class="form-group">
+                                <div class="col s12">
+                                    <button type="submit" class="btn btn-primary">
+                                        {% trans "Filter" %}
+                                    </button>
+                                </div>
+                            </div>
+                        </form>
+                    </div>
                 </div>
             </div>
         </div>

--- a/src/themes/material/templates/press/nav.html
+++ b/src/themes/material/templates/press/nav.html
@@ -18,9 +18,15 @@
             <li><a href="/">{% trans "Home" %}</a></li>
             {% for item in navigation_items %}
                 {% if item.has_sub_nav %}
-                    <li><a class="dropdown-button" href="#!"
-                           data-activates="{{ item.link_name|slugify }}">{{ item.link_name }}<i
-                            class="material-icons right">arrow_drop_down</i></a></li>
+                    <li>
+                        <a
+                            class="dropdown-trigger"
+                            href="#!"
+                            data-target="{{ item.link_name|slugify }}">
+                            {{ item.link_name }}
+                            <i class="material-icons right">arrow_drop_down</i>
+                        </a>
+                    </li>
                 {% elif not item.for_footer %}
                     <li><a href="/{{ item.link }}" class="nav-link">{{ item.link_name }}</a></li>
                 {% endif %}
@@ -31,16 +37,30 @@
             {% endif %}
 
             {% if request.press.enable_preprints %}
-                <li><a class="dropdown-button" href="#!" data-activates="preprints">{% trans "Repositories" %}<i
-                        class="material-icons right">arrow_drop_down</i></a></li>
+                <li>
+                    <a
+                        class="dropdown-trigger"
+                        href="#!"
+                        data-target="preprints">
+                        {% trans "Repositories" %}
+                        <i class="material-icons right">arrow_drop_down</i>
+                    </a>
+                </li>
             {% endif %}
 
             <li><a href="{% url 'contact' %}" class="nav-link">{% trans 'Contact' %}</a></li>
 
             {% hook 'nav_block' %}
             {% if request.user.is_authenticated %}
-                <li><a class="dropdown-button" href="#!" data-activates="account">{% trans "Account" %}<i
-                        class="material-icons right">arrow_drop_down</i></a></li>
+                <li>
+                    <a
+                        class="dropdown-trigger"
+                        href="#!"
+                        data-target="account">
+                        {% trans "Account" %}
+                        <i class="material-icons right">arrow_drop_down</i>
+                    </a>
+                </li>
             {% else %}
                 <li><a href="{% url 'core_login' %}" class="nav-link">{% trans "Login" %}</a></li>
                 <li><a href="{% url 'core_register' %}">{% trans "Register" %}</a></li>
@@ -51,9 +71,15 @@
             <li><a href="/">{% trans "Home" %}</a></li>
             {% for item in navigation_items %}
                 {% if item.has_sub_nav %}
-                    <li><a class="dropdown-button" href="#!"
-                           data-activates="{{ item.link_name|slugify }}-mobile">{{ item.link_name }}<i
-                            class="material-icons right">arrow_drop_down</i></a></li>
+                    <li>
+                        <a
+                            class="dropdown-trigger"
+                            href="#!"
+                            data-target="{{ item.link_name|slugify }}-mobile">
+                            {{ item.link_name }}
+                            <i class="material-icons right">arrow_drop_down</i>
+                        </a>
+                    </li>
                 {% elif not item.for_footer %}
                     <li><a href="/{{ item.link }}" class="nav-link">{{ item.link_name }}</a></li>
                 {% endif %}
@@ -62,19 +88,38 @@
                 <li><a href="{% url 'press_journals' %}" class="nav-link">Journals</a></li>
             {% endif %}
             {% if request.press.enable_preprints %}
-                <li><a class="dropdown-button" href="#!" data-activates="preprints-mobile">{% trans "Repositories" %}<i
-                        class="material-icons right">arrow_drop_down</i></a></li>
+                <li>
+                    <a
+                        class="dropdown-trigger"
+                        href="#!"
+                        data-target="preprints-mobile">
+                        {% trans "Repositories" %}
+                        <i class="material-icons right">arrow_drop_down</i>
+                    </a>
+                </li>
             {% endif %}
             <li><a href="{% url 'contact' %}" class="nav-link">{% trans 'Contact' %}</a></li>
             {% if request.user.is_authenticated %}
-                <li><a class="dropdown-button" href="#!" data-activates="dropdown1">{% trans "Account" %}<i
-                        class="material-icons right">arrow_drop_down</i></a></li>
+                <li>
+                    <a
+                        class="dropdown-trigger"
+                        href="#!"
+                        data-target="dropdown1">
+                        {% trans "Account" %}
+                        <i class="material-icons right">arrow_drop_down</i>
+                    </a>
+                </li>
             {% else %}
                 <li><a href="{% url 'core_login' %}" class="nav-link">{% trans "Login" %}</a></li>
                 <li><a href="{% url 'core_register' %}">{% trans "Register" %}</a></li>
             {% endif %}
         </ul>
-        <a href="#!" data-activates="nav-mobile" class="button-collapse"><i class="material-icons">{% trans "menu" %}</i></a>
+        <a
+            href="#!"
+            data-target="nav-mobile"
+            class="button-collapse">
+            <i class="material-icons">menu</i>
+        </a>
     </div>
 </nav>
 

--- a/src/themes/material/templates/press/nav.html
+++ b/src/themes/material/templates/press/nav.html
@@ -67,7 +67,7 @@
             {% endif %}
         </ul>
 
-        <ul class="side-nav" id="nav-mobile">
+        <ul class="sidenav" id="nav-mobile">
             <li><a href="/">{% trans "Home" %}</a></li>
             {% for item in navigation_items %}
                 {% if item.has_sub_nav %}
@@ -117,7 +117,7 @@
         <a
             href="#!"
             data-target="nav-mobile"
-            class="button-collapse">
+            class="sidenav-trigger">
             <i class="material-icons">menu</i>
         </a>
     </div>

--- a/src/themes/material/templates/repository/nav.html
+++ b/src/themes/material/templates/repository/nav.html
@@ -23,8 +23,15 @@
 
             {% hook 'nav_block' %}
             {% if request.user.is_authenticated %}
-                <li><a class="dropdown-button" href="#!" data-activates="account">Account<i
-                        class="material-icons right">arrow_drop_down</i></a></li>
+                <li>
+                    <a
+                        class="dropdown-trigger"
+                        href="#!"
+                        data-target="account">
+                        Account
+                        <i class="material-icons right">arrow_drop_down</i>
+                    </a>
+                </li>
             {% else %}
                 <li><a href="{% url 'core_login' %}" class="nav-link">Login</a></li>
                 <li><a href="{% url 'core_register' %}">Register</a></li>
@@ -39,14 +46,26 @@
             <li><a href="{% url 'repository_submit' %}">{% trans "Submit" %}</a></li>
 
             {% if request.user.is_authenticated %}
-                <li><a class="dropdown-button" href="#!" data-activates="dropdown1">{% trans "Account" %}<i
-                        class="material-icons right">arrow_drop_down</i></a></li>
+                <li>
+                    <a
+                        class="dropdown-trigger"
+                        href="#!"
+                        data-target="dropdown1">
+                        {% trans "Account" %}
+                        <i class="material-icons right">arrow_drop_down</i>
+                    </a>
+                </li>
             {% else %}
                 <li><a href="{% url 'core_login' %}" class="nav-link">{% trans "Login" %}</a></li>
                 <li><a href="{% url 'core_register' %}">{% trans "Register" %}</a></li>
             {% endif %}
         </ul>
-        <a href="#!" data-activates="nav-mobile" class="button-collapse"><i class="material-icons">menu</i></a>
+        <a
+            href="#!"
+            data-target="nav-mobile"
+            class="button-collapse">
+            <i class="material-icons">menu</i>
+        </a>
     </div>
 </nav>
 

--- a/src/themes/material/templates/repository/nav.html
+++ b/src/themes/material/templates/repository/nav.html
@@ -38,7 +38,7 @@
             {% endif %}
         </ul>
 
-        <ul class="side-nav" id="nav-mobile">
+        <ul class="sidenav" id="nav-mobile">
             <li><a href="{% url 'website_index' %}">{% trans "Home" %}</a></li>
             <li><a href="{% url 'repository_about' %}">{% trans "About" %}</a></li>
             <li><a href="{% url 'repository_list' %}">{{ request.repository.object_name_plural }}</a></li>
@@ -63,7 +63,7 @@
         <a
             href="#!"
             data-target="nav-mobile"
-            class="button-collapse">
+            class="sidenav-trigger">
             <i class="material-icons">menu</i>
         </a>
     </div>

--- a/src/utils/forms.py
+++ b/src/utils/forms.py
@@ -1,15 +1,11 @@
 from django.forms import (
-    BooleanField,
     CharField,
     CheckboxInput,
     ModelForm,
     DateInput,
     HiddenInput,
     Form,
-    widgets,
 )
-from django.utils.html import format_html
-from django.utils.safestring import mark_safe
 from django.utils.translation import gettext_lazy as _
 from django.conf import settings
 
@@ -113,30 +109,3 @@ class CaptchaForm(Form):
             captcha = CharField(widget=HiddenInput, required=False)
 
         self.fields["captcha"] = captcha
-
-
-class LeftCheckboxInput(CheckboxInput):
-    """ A checkbox input that renders the actual checkbox left on the text"""
-    def __init__(self, *args, **kwargs):
-        self.choice_label = kwargs.pop('choice_label', '')
-        super().__init__(*args, **kwargs)
-
-    def render(self, name, value, attrs=None, renderer=None):
-        attrs = attrs or self.attrs
-        label_attrs = ['class="checkbox-inline"']
-        if 'id' in self.attrs:
-            label_attrs.append(format_html('for="{}"', self.attrs['id']))
-        label_for = mark_safe(' '.join(label_attrs))
-        tag = super(CheckboxInput, self).render(name, value, attrs)
-        return format_html('<label {0}>{1} {2}</label>', label_for, tag, self.choice_label)
-
-
-class LeftBooleanField(BooleanField):
-    widget = LeftCheckboxInput
-    """ A BooleanField that uses the LeftCheckboxInput widget"""
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        if self.label:
-            if not self.widget.choice_label:
-                self.widget.choice_label = self.label
-            self.label = ''


### PR DESCRIPTION
Closes #3425

This morning we discussed potentially keeping this out of 1.5.1 in case there are problems with custom CSS that different journals have implemented using selectors from Materialize 0.100.2. 

Based on the [v1 upgrade guide](https://github.com/Dogfalo/materialize/blob/v1-dev/v1-upgrade-guide.md), there are only a few classes and attributes that are likely to need attention. The following were all changed one-to-one:

## Classes
`dropdown-button` was changed to `dropdown-trigger`
`button-collapse` was changed to `sidenav-trigger`
`side-nav` was changed to `sidenav`

## Data attributes
`data-activates` was changed to `data-target`

When we release this upgrade, we should encourage press managers to check their custom stylesheets for any affected selectors and to change them to the new ones.