### PR TITLE
Fix "make install" error on pristine clone

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,6 +112,7 @@ db-load-backup: #Loads a previosuly captured backup in the db directory (e.g.: m
 	@sudo mv /tmp/$(DB_VOLUME) db/
 uninstall:	## Removes all janeway related docker containers, docker images and database volumes
 	@bash -c "rm -rf db/*"
+	@bash -c "git checkout db"
 	@bash -c "docker rm -f `docker ps --filter 'name=janeway*' -aq` >/dev/null 2>&1 | true"
 	@bash -c "docker rmi `docker images -q janeway*` >/dev/null 2>&1 | true"
 	@echo " Janeway has been uninstalled"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
       - "POSTGRES_PASSWORD=${DB_PASSWORD}"
       - "POSTGRES_USER=${DB_USER}"
       - "POSTGRES_DB=${DB_NAME}"
+      - PGDATA=/var/lib/postgresql/data/pgdata
     depends_on:
       - janeway-pgadmin
 


### PR DESCRIPTION
This is my first PR, so I apologize if I'm doing something wrong here.

- The change to docker-compose.yml gives postgres a different data directory from the mount path, which is non-empty (.gitignore). This is what is suggested in https://serverfault.com/questions/1018377/postgres-mount-volume-error-in-k8s. Closes #2775.
- The change to Makefile makes sure that after deleting `db/*` the contents of this directory is reinitialized from the git index; otherwise you are left with a changeset that you don't want to commit. This is not really related to the previous point, but I thought it was too small to make a separate issue and PR. If you prefer I can remove this commit of course.