### PR TITLE
Fixes an issue were email settings were empty on Docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,11 +47,6 @@ ifdef VERBOSE
 endif
 
 # Email
-JANEWAY_EMAIL_BACKEND=''
-JANEWAY_EMAIL_HOST=''
-JANEWAY_EMAIL_PORT=''
-JANEWAY_EMAIL_USE_TLS=0
-
 ifdef DEBUG_SMTP
 	JANEWAY_EMAIL_BACKEND=django.core.mail.backends.smtp.EmailBackend
 	JANEWAY_EMAIL_HOST=janeway-debug-smtp

--- a/src/core/dev_settings.py
+++ b/src/core/dev_settings.py
@@ -7,8 +7,8 @@ SECRET_KEY = 'uxprsdhk^gzd-r=_287byolxn)$k6tsd8_cepl^s^tms2w1qrv'
 # This is the default redirect if no other sites are found.
 DEFAULT_HOST = 'https://www.example.org'
 EMAIL_BACKEND = os.environ.get(
-    'JANEWAY_EMAIL_BACKEND', 'django.core.mail.backends.console.EmailBackend',
-)
+    'JANEWAY_EMAIL_BACKEND',
+) or 'django.core.mail.backends.console.EmailBackend'
 
 URL_CONFIG = 'path'  # path or domain
 

--- a/src/core/janeway_global_settings.py
+++ b/src/core/janeway_global_settings.py
@@ -374,8 +374,8 @@ LOGIN_REDIRECT_URL = '/'
 LOGIN_URL = '/login/'
 
 EMAIL_BACKEND = os.environ.get(
-    'JANEWAY_EMAIL_BACKEND', 'django.core.mail.backends.smtp.EmailBackend',
-)
+    'JANEWAY_EMAIL_BACKEND',
+) or 'django.core.mail.backends.smtp.EmailBackend'
 EMAIL_HOST = os.environ.get("JANEWAY_EMAIL_HOST", '')
 EMAIL_PORT = os.environ.get("JANEWAY_EMAIL_PORT", '')
 EMAIL_HOST_USER = os.environ.get("JANEWAY_EMAIL_HOST_USER", '')


### PR DESCRIPTION
When using the docker development setup, and when the `JANEWAY_EMAIL_BACKEND` is present but not set, our `dev_settings.py` file would set the EMAIL_BACKEND to ''