### PR TITLE
Remove "Incomplete submissions" from repository manager

### DIFF
--- a/src/templates/admin/repository/manager.html
+++ b/src/templates/admin/repository/manager.html
@@ -67,10 +67,6 @@
                         <a href="{% url 'repository_rejected_submissions' %}" class="box-link"></a>
                     </div>
                     <div class="summary">
-                        <span class="title">{{ incomplete_preprints|length }} Incomplete Submissions</span>
-                        <a href="" class="box-link"></a>
-                    </div>
-                    <div class="summary">
                         <span class="title">{{ version_queue|length }} Versions Awaiting Moderation</span>
                         <a href="{% url 'version_queue' %}" class="box-link"></a>
                     </div>


### PR DESCRIPTION
https://github.com/BirkbeckCTP/janeway/issues/3509 

Removing the "Incomplete submissions" option from the Repository Manager preprints stats box. The link isn't functional, and the information is irrelevant (no one needs to know the count of draft preprints authors haven't yet submitted).