### PR TITLE
Fix some sass deprecation warnings raised by sass 0.22

### DIFF
--- a/src/themes/OLH/assets/motion-ui/src/util/_args.scss
+++ b/src/themes/OLH/assets/motion-ui/src/util/_args.scss
@@ -5,7 +5,7 @@
     $arg: nth($args, 1);
 
     @if type-of($arg) == 'string' {
-      @return call($arg);
+      @return call(get-function($arg));
     } @else if type-of($arg) == 'map' {
       @return $arg;
     }

--- a/src/themes/OLH/assets/motion-ui/src/util/_keyframe.scss
+++ b/src/themes/OLH/assets/motion-ui/src/util/_keyframe.scss
@@ -88,7 +88,7 @@ $-mui-custom: 0;
   // Iterate through each map passed in
   @each $map in $maps {
     @if type-of($map) == 'string' {
-      $map: call($map);
+      $map: call(get-function($map));
     }
 
     $map: -mui-keyframe-split($map);

--- a/src/themes/OLH/assets/scss/_settings.scss
+++ b/src/themes/OLH/assets/scss/_settings.scss
@@ -84,6 +84,7 @@ $breakpoints: (
   xxlarge: 1440px,
 );
 $breakpoint-classes: (small medium large);
+$-zf-size: null;
 
 // 3. The Grid
 // -----------


### PR DESCRIPTION
I see some deprecation warnings similar to the ones below when I `pyton -m manage build_assets` with `libsass==0.22.0`.

 **Warning** since the requirements in the this branch point to libsass==0.11.1 this PR is just intended as reference for the future. Also, even tough these changes fix the warnings and I can't detect any error, I've never used sass, so please be careful... :slightly_smiling_face: 

> DEPRECATION WARNING on line 228 of .../src/themes/OLH/assets/foundation-sites/scss/util/_mixins.scss:
> !global assignments won't be able to declare new variables in future versions.
> Consider adding `$-zf-size: null` at the top level.

> DEPRECATION WARNING: Passing a string to call() is deprecated and will be illegal
> in Sass 4.0. Use call(get-function("shake")) instead.