### PR TITLE
Check field value before accessing an attribute

### DIFF
--- a/src/review/admin.py
+++ b/src/review/admin.py
@@ -47,7 +47,7 @@ class ReviewAdmin(admin_utils.ArticleFKModelAdmin):
                      'form', 'review_file')
 
     def _round(self, obj):
-        return obj.review_round.round_number if obj else ''
+        return obj.review_round.round_number if obj and obj.review_round else ''
 
     inlines = [
         admin_utils.ReviewAssignmentAnswerInline,


### PR DESCRIPTION
While `ReviewAssignment.review_round` is usually set by logic functions, in case of customization of the workflow this might be `None`, it's best to check its value before accessing an attribute of the foreignkey