### PR TITLE
#3618 the review preview form now renders correctly accounting for display settings

### DIFF
--- a/src/review/forms.py
+++ b/src/review/forms.py
@@ -177,25 +177,21 @@ class ReviewerDecisionForm(forms.ModelForm):
     def __init__(self, *args, **kwargs):
         decision_required = kwargs.pop("decision_required", False)
         open_review_initial = kwargs.pop("open_review_initial", False)
+        self.recommendation_disabled = kwargs.pop("recommendation_disabled", False)
         super().__init__(*args, **kwargs)
         self.fields['decision'].required = decision_required
         self.fields['decision'].choices = models.reviewer_decision_choices()
         self.fields['permission_to_make_public'].widget.attrs['checked'] = open_review_initial
 
         if self.instance:
-            self.disable_reviewer_decision = setting_handler.get_setting(
-                'general',
-                'disable_reviewer_recommendation',
-                self.instance.article.journal,
-            ).processed_value
-            if self.disable_reviewer_decision:
+            if self.recommendation_disabled:
                 del self.fields['decision']
 
     def save(self, commit=True):
         review_assignment = super().save(commit=False)
 
         # sets the decision to none, if decisions are disabled.
-        if self.disable_reviewer_decision:
+        if self.recommendation_disabled:
             review_assignment.decision = models.RD.DECISION_NO_RECOMMENDATION.value
 
         if commit:

--- a/src/review/views.py
+++ b/src/review/views.py
@@ -831,6 +831,11 @@ def do_review(request, assignment_id):
         'open_review_default_opt_in',
         request.journal,
     ).processed_value
+    recommendation_disabled = setting_handler.get_setting(
+        'general',
+        'disable_reviewer_recommendation',
+        request.journal,
+    ).processed_value
 
     fields_required = False
     decision_required = False if allow_save_review else True
@@ -844,6 +849,7 @@ def do_review(request, assignment_id):
         instance=assignment,
         decision_required=decision_required,
         open_review_initial=open_review_initial,
+        recommendation_disabled=recommendation_disabled,
     )
 
     if 'review_file' in request.GET:
@@ -889,6 +895,7 @@ def do_review(request, assignment_id):
             request.POST,
             instance=assignment,
             decision_required=decision_required,
+            recommendation_disabled=recommendation_disabled,
         )
 
         if form.is_valid() and decision_form.is_valid():
@@ -2499,7 +2506,14 @@ def preview_form(request, form_id):
     """Displays a preview of a review form."""
     form = get_object_or_404(models.ReviewForm, pk=form_id)
     generated_form = forms.GeneratedForm(preview=form)
-    decision_form = forms.FakeReviewerDecisionForm()
+    recommendation_disabled = setting_handler.get_setting(
+        'general',
+        'disable_reviewer_recommendation',
+        request.journal,
+    ).processed_value
+    decision_form = forms.FakeReviewerDecisionForm(
+        recommendation_disabled=recommendation_disabled,
+    )
 
     template = 'review/manager/preview_form.html'
     context = {


### PR DESCRIPTION
- This bug was introduced in 1.5.1
- PR includes a tweak to ensure that the review form preview view takes `disable_reviewer_recommendation` into account
- Closes #3618 