### PR TITLE
3630 the Live Article link in LDM will now link to the remote url when is_remote and remote_url are set

### DIFF
--- a/src/templates/admin/elements/article_jump.html
+++ b/src/templates/admin/elements/article_jump.html
@@ -24,7 +24,7 @@
         <li><a href="{% url 'manage_archive_article' article.pk %}">Archive Page</a></li>
         <li><a href="{% url 'manage_article_workflow' article.pk %}" target="_blank">Manage Workflow Stage</a></li>
         {% if article.is_published %}
-            <li><a href="{{ article.url }}">Live Article</a></li>
+            <li><a href="{% if article.is_remote and article.remote_url %}{{ article.remote_url }}{% else %}{{ article.url }}{% endif %}" target="_blank">Live Article</a></li>
         {% endif %}
         {% if request.user.is_superuser %}
             <li><a target="_blank" href="/admin/submission/article/{{ article.pk }}/">Admin <i

--- a/src/templates/admin/journal/manage/archive_article.html
+++ b/src/templates/admin/journal/manage/archive_article.html
@@ -25,7 +25,7 @@
                 {% if not article.stage == 'Rejected' %}
                     <a class="button" href="{% url 'publish_article' article.pk %}">{% trans 'Edit Publication Info' %}</a>
                 {% endif %}
-                {% if article.is_remote %}<a class="button" href="{{ article.remote_url }}">{% trans 'Remote Article View' %}<i class="fa fa-external-link"></i></a>{% endif %}
+                {% if article.is_remote %}<a class="button" href="{{ article.remote_url }}">{% trans 'Remote Article View' %} <i class="fa fa-external-link"></i></a>{% endif %}
                 {% hook 'request_edit' %}
             </div>
             <div class="content">


### PR DESCRIPTION
I think we need to consider whether article's `url` method should return the `remote_url` when it and `is_remote` are set, but it might have a large impact that needs to be considered.

Closes #3630 