### PR TITLE
#3652 when an editor views the submission form they will now see information about which sections are not open for public submission.

### DIFF
--- a/src/submission/fields.py
+++ b/src/submission/fields.py
@@ -1,6 +1,0 @@
-from django import forms
-
-
-class EditorSectionChoiceField(forms.ModelChoiceField):
-    def label_from_instance(self, obj):
-        return obj.editor_display_name()

--- a/src/submission/fields.py
+++ b/src/submission/fields.py
@@ -1,0 +1,6 @@
+from django import forms
+
+
+class EditorSectionChoiceField(forms.ModelChoiceField):
+    def label_from_instance(self, obj):
+        return obj.editor_display_name()

--- a/src/submission/forms.py
+++ b/src/submission/forms.py
@@ -8,7 +8,7 @@ import re
 from django import forms
 from django.utils.translation import gettext, gettext_lazy as _
 
-from submission import models, fields
+from submission import models
 from core import models as core_models
 from identifiers import models as ident_models
 from review.logic import render_choices
@@ -228,11 +228,13 @@ class ArticleInfoSubmit(ArticleInfo):
 class EditorArticleInfoSubmit(ArticleInfo):
     # Used when an editor is making a submission.
     FILTER_PUBLIC_FIELDS = False
-    section = fields.EditorSectionChoiceField(
-        queryset=models.Section.objects.none(),
-        help_text='As an editor you will see all sections even if they are '
-                  'closed for public submission.',
-    )
+
+    def __init__(self, *args, **kwargs):
+        super(EditorArticleInfoSubmit, self).__init__(*args, **kwargs)
+        self.fields['section'].label_from_instance = lambda obj: obj.display_name_public_submission
+        self.fields['section'].help_text = "As an editor you will see all " \
+                                           "sections even if they are  " \
+                                           "closed for public submission"
 
 
 class AuthorForm(forms.ModelForm):

--- a/src/submission/forms.py
+++ b/src/submission/forms.py
@@ -8,7 +8,7 @@ import re
 from django import forms
 from django.utils.translation import gettext, gettext_lazy as _
 
-from submission import models
+from submission import models, fields
 from core import models as core_models
 from identifiers import models as ident_models
 from review.logic import render_choices
@@ -228,6 +228,11 @@ class ArticleInfoSubmit(ArticleInfo):
 class EditorArticleInfoSubmit(ArticleInfo):
     # Used when an editor is making a submission.
     FILTER_PUBLIC_FIELDS = False
+    section = fields.EditorSectionChoiceField(
+        queryset=models.Section.objects.none(),
+        help_text='As an editor you will see all sections even if they are '
+                  'closed for public submission.',
+    )
 
 
 class AuthorForm(forms.ModelForm):

--- a/src/submission/models.py
+++ b/src/submission/models.py
@@ -2063,7 +2063,7 @@ class Section(AbstractLastModifiedModel):
             return self.name
         return f"Unnamed Section {self.pk}"
 
-    def editor_display_name(self):
+    def display_name_public_submission(self):
         """
         Returns a display name that informs the user if the section is
         close for submission.

--- a/src/submission/models.py
+++ b/src/submission/models.py
@@ -2063,6 +2063,19 @@ class Section(AbstractLastModifiedModel):
             return self.name
         return f"Unnamed Section {self.pk}"
 
+    def editor_display_name(self):
+        """
+        Returns a display name that informs the user if the section is
+        close for submission.
+        """
+        name = f"Unnamed Section {self.pk}"
+        if self.name:
+            name = self.name
+        if not self.public_submissions:
+            name = f"{name} (Public Submission Closed)"
+
+        return name
+
     def published_articles(self):
         return Article.objects.filter(section=self, stage=STAGE_PUBLISHED)
 

--- a/src/submission/tests.py
+++ b/src/submission/tests.py
@@ -698,7 +698,7 @@ class SubmissionTests(TestCase):
         )
         self.assertContains(
             response,
-            self.section_2.editor_display_name(),
+            self.section_2.display_name_public_submission(),
         )
 
     def test_author_doesnt_see_non_public_section(self):
@@ -725,7 +725,7 @@ class SubmissionTests(TestCase):
         )
         self.assertNotContains(
             response,
-            self.section_2.editor_display_name(),
+            self.section_2.display_name_public_submission(),
         )
 
 

--- a/src/submission/tests.py
+++ b/src/submission/tests.py
@@ -90,6 +90,20 @@ class SubmissionTests(TestCase):
 
         return author_1, author_2
 
+    def create_sections(self):
+        self.section_1 = models.Section.objects.create(
+            name='Test Public Section',
+            journal=self.journal_one,
+        )
+        self.section_2 = models.Section.objects.create(
+            name='Test Private Section',
+            public_submissions=False,
+            journal=self.journal_one
+        )
+        self.section_3 = models.Section.objects.create(
+            journal=self.journal_one,
+        )
+
     def setUp(self):
         """
         Setup the test environment.
@@ -98,6 +112,7 @@ class SubmissionTests(TestCase):
         self.journal_one = self.create_journal()
         self.editor = helpers.create_editor(self.journal_one)
         self.press = helpers.create_press()
+        self.create_sections()
 
     def test_article_image_galley(self):
         article = models.Article.objects.create(
@@ -505,7 +520,9 @@ class SubmissionTests(TestCase):
         self.assertEqual(expected_article_issue_title, article.issue_title)
 
     def test_url_based_orcid_cleaned(self):
-        clean_orcid = forms.utility_clean_orcid('https://orcid.org/0000-0003-2126-266X')
+        clean_orcid = forms.utility_clean_orcid(
+            'https://orcid.org/0000-0003-2126-266X'
+        )
         self.assertEqual(
             clean_orcid,
             '0000-0003-2126-266X',
@@ -655,6 +672,54 @@ class SubmissionTests(TestCase):
             page_numbers='custom'
         )
         self.assertEqual(article.page_range, 'custom')
+
+    def test_editor_sees_non_public_sections(self):
+        article = models.Article.objects.create(
+            journal=self.journal_one,
+            title='Test article: Testing non public sections',
+            current_step=2,
+        )
+        self.client.force_login(
+            self.editor,
+        )
+        response = self.client.get(
+            reverse(
+                'submit_info',
+                kwargs={'article_id': article.pk},
+            )
+        )
+        self.assertEqual(
+            response.status_code, 200
+        )
+        self.assertContains(
+            response,
+            self.section_2.editor_display_name(),
+        )
+
+    def test_author_doesnt_see_non_public_section(self):
+        author = helpers.create_author(self.journal_one)
+        article = models.Article.objects.create(
+            journal=self.journal_one,
+            title='Test article: Testing public sections',
+            current_step=2,
+            owner=author
+        )
+        self.client.force_login(
+            author,
+        )
+        response = self.client.get(
+            reverse(
+                'submit_info',
+                kwargs={'article_id': article.pk},
+            )
+        )
+        self.assertEqual(
+            response.status_code, 200
+        )
+        self.assertNotContains(
+            response,
+            self.section_2.editor_display_name(),
+        )
 
 
 class ArticleSearchTests(TransactionTestCase):

--- a/src/submission/tests.py
+++ b/src/submission/tests.py
@@ -682,11 +682,13 @@ class SubmissionTests(TestCase):
         self.client.force_login(
             self.editor,
         )
+        clear_script_prefix()
         response = self.client.get(
             reverse(
                 'submit_info',
                 kwargs={'article_id': article.pk},
-            )
+            ),
+            SERVER_NAME="testserver",
         )
         self.assertEqual(
             response.status_code, 200
@@ -707,11 +709,13 @@ class SubmissionTests(TestCase):
         self.client.force_login(
             author,
         )
+        clear_script_prefix()
         response = self.client.get(
             reverse(
                 'submit_info',
                 kwargs={'article_id': article.pk},
-            )
+            ),
+            SERVER_NAME="testserver",
         )
         self.assertEqual(
             response.status_code, 200

--- a/src/submission/tests.py
+++ b/src/submission/tests.py
@@ -458,6 +458,7 @@ class SubmissionTests(TestCase):
     @override_settings(URL_CONFIG='domain')
     def test_submit_info_view_form_selection_author(self):
         author_1, author_2 = self.create_authors()
+        clear_cache()
         article = models.Article.objects.create(
             journal=self.journal_one,
             title="Test article: a test of author sections",
@@ -674,10 +675,12 @@ class SubmissionTests(TestCase):
         self.assertEqual(article.page_range, 'custom')
 
     def test_editor_sees_non_public_sections(self):
+        clear_cache()
         article = models.Article.objects.create(
             journal=self.journal_one,
             title='Test article: Testing non public sections',
             current_step=2,
+            owner=self.editor,
         )
         self.client.force_login(
             self.editor,


### PR DESCRIPTION
- Adds a new method to section that returns a display name for editors that includes information on public submission status
- Adds a new field that displays the above method as the <option> label
- Adds help text explaining that editors will see all sections but that authors will not
- Adds two tests to check that what editors and authors see
- Closes #3652 

Editor view:
![image](https://github.com/BirkbeckCTP/janeway/assets/8321378/fa1a0dff-cce7-41d6-8bdf-4314482ad3a6)
![image](https://github.com/BirkbeckCTP/janeway/assets/8321378/38ead46a-2da5-4542-97a8-7e50574abfa3)
