### PR TITLE
Removed light and wave effects from headers in the material theme. These serve no real purpose and stop users from copying the title text easily.

### DIFF
--- a/src/themes/material/templates/elements/journal/issue_top.html
+++ b/src/themes/material/templates/elements/journal/issue_top.html
@@ -2,7 +2,7 @@
 
 {% if issue.large_image %}
     <div class="card">
-        <div class="card-image waves-effect waves-block waves-light">
+        <div class="card-image">
             <a href="{{ issue.url }}">
                 <img class="activator" src="{{ issue.hero_image_url }}" alt="{{ issue.display_title }} hero image.">
             </a>

--- a/src/themes/material/templates/journal/article.html
+++ b/src/themes/material/templates/journal/article.html
@@ -19,7 +19,7 @@
         <div class="col m12">
             <div class="card">
             {% if not journal_settings.article.disable_article_large_image %}
-                <div class="card-image article-card waves-effect waves-block waves-light">
+                <div class="card-image article-card">
                         <img class="orbit-image"
                             {% if article.large_image_file.id %}
                              src="{% url 'article_file_download' 'id' article.id article.large_image_file.id %}"

--- a/src/themes/material/templates/repository/preprint.html
+++ b/src/themes/material/templates/repository/preprint.html
@@ -15,7 +15,7 @@
     <div class="row preprint-content">
         <div class="col m12">
             <div class="card">
-                <div class="card-image preprint-card waves-effect waves-block waves-light">
+                <div class="card-image preprint-card">
                     <img class="orbit-image" alt="{{ preprint.title|striptags }}"
                          src="{% if request.repository.hero_background %}{{ request.repository.hero_background.url }}{% else %}{% static "common/img/repository_background.jpg" %}{% endif %}">
                     <span class="card-title">


### PR DESCRIPTION
Tagging @MartinPaulEve who might appreciate this. Thanks for reporting it :)