### PR TITLE
Altmetric badges will now display as expected on the material theme.

### DIFF
--- a/src/themes/material/templates/journal/article.html
+++ b/src/themes/material/templates/journal/article.html
@@ -543,4 +543,5 @@
     });
     </script>
     <script src="{% static "common/lightbox/js/lightbox.js" %}"></script>
+    <script type='text/javascript' src='https://d1bxh8uas1mnw7.cloudfront.net/assets/embed.js'></script>
 {% endblock %}


### PR DESCRIPTION
- Adds the required embed js that was missing from the material article template.