### PR TITLE
Use press-level contact template at press level #3709

### DIFF
--- a/src/journal/views.py
+++ b/src/journal/views.py
@@ -1874,8 +1874,10 @@ def contact(request):
 
     if request.journal and request.journal.disable_front_end:
         template = 'admin/journal/contact.html'
-    else:
+    elif request.journal:
         template = 'journal/contact.html'
+    else:
+        template = 'press/journal/contact.html'
     context = {
         'contact_form': contact_form,
         'contacts': contacts,


### PR DESCRIPTION
Important: Please don't merge this in v1.5.1! It could introduce further bugs in the press-level templates that we haven't caught because Janeway was using the journal-level templates. Let's introduce it in v1.5.2 or later.

Closes #3709.