### PR TITLE
#3716 next_workflow_element will no longer error out when an article is published.

### DIFF
--- a/src/submission/models.py
+++ b/src/submission/models.py
@@ -1677,7 +1677,7 @@ class Article(AbstractLastModifiedModel):
             journal_elements = list(self.journal.workflow().elements.all())
             i = journal_elements.index(current_workflow_element)
             return journal_elements[i+1]
-        except IndexError:
+        except (IndexError, ValueError):
             return 'No next workflow stage found'
 
     @cache(600)


### PR DESCRIPTION
Closes #3716 