### PR TITLE
#3486 DOI batch deposit timestamps are now generated in the view using datetime rather than the now templatetag which uses timezone.

### DIFF
--- a/src/identifiers/logic.py
+++ b/src/identifiers/logic.py
@@ -230,7 +230,7 @@ def create_crossref_doi_batch_context(journal, identifiers):
 
     template_context = {
         'batch_id': uuid4(),
-        'now': timezone.now(),
+        'now': datetime.datetime.now(),
         'timestamp': int(round((datetime.datetime.now() - datetime.datetime(1970, 1, 1)).total_seconds())),
         'timestamp_suffix': timestamp_suffix,
         'depositor_name': setting_handler.get_setting('Identifiers', 'crossref_name',

--- a/src/metrics/admin.py
+++ b/src/metrics/admin.py
@@ -34,7 +34,7 @@ class ArticleAccessAdmin(admin_utils.ArticleFKModelAdmin):
     list_filter = ('article__journal', 'accessed', 'type', 'galley_type',)
     search_fields = ('article__title', 'article__pk', 'identifier',
                      'article__journal__code',
-                     'type', 'galley_type', 'accessed', 'country__code',
+                     'type', 'galley_type', 'accessed', 'country',
                      'country__name')
     raw_id_fields = ('article',)
     date_hierarchy = ('accessed')

--- a/src/production/views.py
+++ b/src/production/views.py
@@ -1121,25 +1121,47 @@ def supp_file_doi(request, article_id, supp_file_id):
         'crossref_date_suffix',
     )
 
-    test_mode = setting_handler.get_setting('Identifiers', 'crossref_test', article.journal).processed_value
+    test_mode = setting_handler.get_setting(
+        'Identifiers',
+        'crossref_test',
+        article.journal
+    ).processed_value
 
     if not article.get_doi():
-        messages.add_message(request, messages.INFO, 'Parent article must have a DOI before you can assign a'
-                                                     'supplementary file a DOI.')
+        messages.add_message(
+            request,
+            messages.INFO,
+            'Parent article must have a DOI before you can assign a '
+            'supplementary file a DOI.')
 
-    xml_context = {'supp_file': supplementary_file,
-                   'article': article,
-                   'batch_id': uuid.uuid4(),
-                   'timestamp_suffix': timestamp_suffix,
-                   'depositor_name': setting_handler.get_setting('Identifiers', 'crossref_name',
-                                                                 article.journal).processed_value,
-                   'depositor_email': setting_handler.get_setting('Identifiers', 'crossref_email',
-                                                                  article.journal).processed_value,
-                   'registrant': setting_handler.get_setting('Identifiers', 'crossref_registrant',
-                                                             article.journal).processed_value,
-                   'parent_doi': article.get_doi()
-                   }
-    xml_content = render_to_string('common/identifiers/crossref_component.xml', xml_context, request)
+    xml_context = {
+        'supp_file': supplementary_file,
+        'article': article,
+        'batch_id': uuid.uuid4(),
+        'timestamp_suffix': timestamp_suffix,
+        'depositor_name': setting_handler.get_setting(
+            'Identifiers',
+            'crossref_name',
+            article.journal
+        ).processed_value,
+        'depositor_email': setting_handler.get_setting(
+            'Identifiers',
+            'crossref_email',
+            article.journal
+        ).processed_value,
+        'registrant': setting_handler.get_setting(
+            'Identifiers',
+            'crossref_registrant',
+            article.journal
+        ).processed_value,
+        'parent_doi': article.get_doi(),
+        'now': datetime.datetime.now(),
+    }
+    xml_content = render_to_string(
+        'common/identifiers/crossref_component.xml',
+        xml_context,
+        request
+    )
 
     if request.POST:
         from identifiers import logic

--- a/src/templates/common/identifiers/crossref_component.xml
+++ b/src/templates/common/identifiers/crossref_component.xml
@@ -3,7 +3,7 @@
            xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schema/deposit/crossref4.3.7.xsd">
     <head>
         <doi_batch_id>{{ batch_id }}</doi_batch_id>
-        <timestamp>{% now "YmdHis" %}{{ timestamp_suffix }}</timestamp>
+        <timestamp>{{ now|date:"YmdHis" }}{{ timestamp_suffix }}</timestamp>
         <depositor>
             <depositor_name>{{ depositor_name }}</depositor_name>
             <email_address>{{ depositor_email }}</email_address>

--- a/src/templates/common/identifiers/crossref_doi_batch.xml
+++ b/src/templates/common/identifiers/crossref_doi_batch.xml
@@ -9,7 +9,7 @@
 >
     <head>
         <doi_batch_id>{{ batch_id }}</doi_batch_id>
-        <timestamp>{% now "YmdHis" %}{{ timestamp_suffix }}</timestamp>
+        <timestamp>{{ now|date:"YmdHis" }}{{ timestamp_suffix }}</timestamp>
         <depositor>
             <depositor_name>{{ depositor_name }}</depositor_name>
             <email_address>{{ depositor_email }}</email_address>


### PR DESCRIPTION
```
<timestamp>20230918114200656</timestamp>
```

- Output remains in the same format but uses server time rather than the user's timezone. Example output from the view above.
- Note this particular example has a timestamp suffix '656' tagged onto it.
- Closes #3486 