### PR TITLE
#3728 when editing a frozen author record the Add Author button now works as expected.

### DIFF
--- a/src/submission/views.py
+++ b/src/submission/views.py
@@ -613,7 +613,7 @@ def edit_metadata(request, article_id):
             pop_disabled_fields=False,
             editor_view=True,
         )
-        frozen_author, modal = None, None
+
         return_param = request.GET.get('return')
         reverse_url = create_language_override_redirect(
             request,
@@ -622,11 +622,12 @@ def edit_metadata(request, article_id):
             query_strings={'return': return_param}
         )
 
+        frozen_author, modal, author_form = None, None, forms.EditFrozenAuthor()
         if request.GET.get('author'):
             frozen_author, modal = logic.get_author(request, article)
             author_form = forms.EditFrozenAuthor(instance=frozen_author)
-        else:
-            author_form = forms.EditFrozenAuthor()
+        elif request.GET.get('modal') == 'author':
+            modal = 'author'
 
         if request.POST:
             if 'add_funder' in request.POST:

--- a/src/templates/admin/elements/submission/edit_author.html
+++ b/src/templates/admin/elements/submission/edit_author.html
@@ -3,11 +3,14 @@
      data-animation-out="slide-out-down">
     <div class="card">
         <div class="card-divider">
-            <h4><i class="fa fa-user">&nbsp;</i>Edit {{ frozen_author.full_name }}</h4>
+            <h4><i class="fa fa-user">&nbsp;</i>{% if frozen_author %}Edit {{ frozen_author.full_name }}{% else %}Add New Frozen Author{% endif %}</h4>
         </div>
         <div class="card-section">
-            <p>You are editing the frozen metadata record for this author, not their live user
-                profile.{% if frozen_author.author %} This frozen metadata record is linked to account ID <a target="_blank" href="{% url 'core_user_edit' frozen_author.author.pk %}">{{ frozen_author.author.pk }} - {{ frozen_author.author.full_name }}</a>. If you wish to change the ORCID or email address associated with this record we recommend doing so at the account level using the link.{% endif %}</p>
+            {% if frozen_author %}<p>You are editing the frozen metadata record for this author, not their live user
+                profile.{% if frozen_author.author %} This frozen metadata record is linked to account ID
+                <a target="_blank" href="{% url 'core_user_edit' frozen_author.author.pk %}">{{ frozen_author.author.pk }} -
+                    {{ frozen_author.author.full_name }}</a>. If you wish to change the ORCID or email address associated
+                with this record we recommend doing so at the account level using the link.{% endif %}</p>{% endif %}
             {% include "elements/forms/errors.html" with form=author_form %}
             <form method="POST">
                 {% if frozen_author.author and not frozen_author.author == article.correspondence_author %}

--- a/src/templates/admin/submission/edit/metadata.html
+++ b/src/templates/admin/submission/edit/metadata.html
@@ -120,7 +120,12 @@
         </div>
         <div class="title-area">
             <h2>Authors</h2>
-            <a href="#" class="button" data-open="author">Add Author</a>
+            {% if frozen_author %}
+                <a href="{% url 'edit_metadata' article.pk %}?modal=author&return={{ return }}" class="button">Add Author</a>
+            {% else %}
+                <a href="#" class="button" data-open="author">Add Author</a>
+            {% endif %}
+
         </div>
         <div class="content">
             <form method="POST">


### PR DESCRIPTION
- `review.views.edit_metadata` now checks for a query string parameter `modal` so that we can link directly to this page and open an empty author modal
- This fixes an issue where after clicking the Edit button on an author and clicking Add New would cause the form to show the author instance
- Closes #3724 