### PR TITLE
ReviewAssignment.date_due is a DateField

### DIFF
--- a/src/review/forms.py
+++ b/src/review/forms.py
@@ -87,7 +87,7 @@ class ReviewAssignmentForm(forms.ModelForm, core_forms.ConfirmableIfErrorsForm):
             self.fields['visibility'].initial = default_visibility.value
 
         if default_due:
-            due_date = timezone.now() + timedelta(days=int(default_due))
+            due_date = timezone.now().date() + timedelta(days=int(default_due))
             self.fields['date_due'].initial = due_date
 
         if default_form and not self.instance.form:


### PR DESCRIPTION
[`ReviewAssignment.date_due`](https://github.com/mcagl/janeway/blob/master/src/review/models.py#L202) is a `DateField`, but during form initialization it is treated as `datetime`.

Django during `save()` will get the date part of the `datetime` and discard the time part, but getting the `date` since the beginning when instantiating the form will clear the situation.

Sometimes in the tests (depending on the fact that `ReviewAssignment` is loaded from the database or not) it is necessary to call `.date()` on the value of `date_due` or not.

I don't have investigated if there are other points in the code where this field is treated as `datetime`, but I welcome comments and observations on my PR.

Thank you!