### PR TITLE
The OLH theme article block now renders 12 columns across rather than 10 eliminating a large chunk of whitespace.

### DIFF
--- a/src/themes/OLH/templates/journal/article.html
+++ b/src/themes/OLH/templates/journal/article.html
@@ -149,7 +149,7 @@
             <div class="row">
                 <div class="large-8 columns border-right">
                     <div class="row">
-                        <div id="article" class="large-10 columns">
+                        <div id="article" class="large-12 columns">
                 {% if journal_settings.article.disable_article_large_image %}
                     <small>{{ article.section.name }}</small>
                     <h1>{{ article.title|safe }}</h1>


### PR DESCRIPTION
Before:
<img width="1195" alt="Screenshot 2023-10-03 at 15 45 27" src="https://github.com/BirkbeckCTP/janeway/assets/8321378/2aa0e814-e1a7-420b-af71-2d56fd09dd14">

After:
<img width="1196" alt="Screenshot 2023-10-03 at 15 45 09" src="https://github.com/BirkbeckCTP/janeway/assets/8321378/cb7e7f75-3cb4-4140-b2ea-838bfb1ffa5d">
