### PR TITLE
prevents None from appearing in Add Review Assignment

### DIFF
--- a/src/review/logic.py
+++ b/src/review/logic.py
@@ -39,7 +39,7 @@ def get_reviewers(article, candidate_queryset, exclude_pks):
         'reviewer',
         queryset=models.ReviewAssignment.objects.filter(
             article__journal=article.journal
-        ).order_by("-date_complete")
+        ).exclude(date_complete__isnull=True).order_by("-date_complete")
     )
     active_reviews_count = models.ReviewAssignment.objects.filter(
         is_complete=False,


### PR DESCRIPTION
If a reviewer has been assigned a new review, has accepted it but has not completed it that value is left empty but the None still shows up as the "Last Review Completed" for their last review on the Add Review Assignment page.

![image](https://github.com/BirkbeckCTP/janeway/assets/1020384/196557a7-d051-49d7-9dee-1ffbaf497d62)

Some of the None values are there because an article was rejected/archived but that particular person did not leave their review. It also shows None when that person has an active review. But "Last Review Completed" implies that it should show the last review regardless of their current status.
This fix excludes reviews that have null values and shows the actual last date of a completed review. 

![image](https://github.com/BirkbeckCTP/janeway/assets/1020384/68174dcb-29a7-4d1d-8d55-6aa04d3017ed)


I don't know if it would be better code-wise to explicitly state that you want to hide articles that are in `STAGE_REJECTED` in addition to hiding NULL values or if there is another method of marking them as complete when an article is rejected. 

