### PR TITLE
#3802 rework the clean theme's editorial page layout.

### DIFF
--- a/src/static/clean/css/clean.css
+++ b/src/static/clean/css/clean.css
@@ -218,6 +218,10 @@ main a:hover {
     margin-bottom: 15px !important;
 }
 
+.full-width-card {
+    min-width: 100%;
+}
+
 .card img {
     max-height: 250px;
     object-fit: cover;
@@ -253,6 +257,7 @@ main a:hover {
 .card-block {
     padding: 20px;
 }
+
 #carousel-buttons {
     margin-left: 100px;
     position: absolute;
@@ -331,6 +336,7 @@ footer svg {
 .article-img {
     filter: brightness(50%);
 }
+
 .journal-name {
     font-size: 2.5rem;
     margin-bottom: .5rem;
@@ -348,6 +354,102 @@ footer svg {
     display: inline-block;
 }
 
+
+.table-foot .table-footnotes li.fn {
+    list-style-type: none;
+}
+
 .article-table {
   display: block;
-  overflow-x: scroll;}
+  overflow-x: scroll;
+}
+
+.table-caption {
+    margin-bottom: 8px;
+}
+
+.math-formulae {
+    overflow-x: auto;
+    padding-bottom: 1rem;
+}
+
+.journal-card-title {
+    margin-bottom: 0;
+    font-size: 13px;
+}
+
+.row-smaller-gutters {
+    margin-left: -9px;
+    margin-right: -9px;
+}
+.row-smaller-gutters > div[class^="col"] {
+    padding-left: 9px;
+    padding-right: 9px;
+}
+header svg {
+    max-height: 120px;
+    max-width: 100%;
+}
+.journal-div {
+    padding-bottom:15px;
+}
+.journal-name {
+    font-size: 1.4rem;
+}
+.journal-button-block {
+    margin-top: 4px;
+    margin-bottom: 4px;
+}
+
+.responsive-img {
+    max-width: 100%;
+}
+
+.article-table {
+  width: 100%;
+  margin-bottom: 1rem;
+  color: #212529;
+}
+
+.article-table th,
+.article-table td {
+  padding: 0.75rem;
+  vertical-align: top;
+  border-top: 1px solid #dee2e6;
+}
+
+.article-table thead th {
+  vertical-align: bottom;
+  border-bottom: 2px solid #dee2e6;
+}
+
+.article-table tbody + tbody {
+  border-top: 2px solid #dee2e6;
+}
+
+.article-table-sm th,
+.article-table-sm td {
+  padding: 0.3rem;
+}
+
+
+.homepage-element-search-bar input[type="text"] {
+    font-size: 1.5rem;
+}
+
+.homepage-element-search-bar .input-group-text {
+    font-size: 1.5rem;
+}
+
+#main_article {
+    margin-top: 30px;
+}
+
+.page-link,
+.page-link:hover {
+  color: #4F637D;
+}
+
+.page-item.active .page-link {
+  background-color: #4F637D;
+}

--- a/src/themes/clean/assets/css/clean.css
+++ b/src/themes/clean/assets/css/clean.css
@@ -218,6 +218,10 @@ main a:hover {
     margin-bottom: 15px !important;
 }
 
+.full-width-card {
+    min-width: 100%;
+}
+
 .card img {
     max-height: 250px;
     object-fit: cover;

--- a/src/themes/clean/templates/journal/editorial_team.html
+++ b/src/themes/clean/templates/journal/editorial_team.html
@@ -4,44 +4,51 @@
 {% block title %}{% trans 'Editorial Team' %}{% endblock title %}
 
 {% block body %}
-    <div class="row mb-2">
+    <div class="row">
         <div class="col-md-12">
             <h1>{% trans 'Editorial Team' %}</h1>
         </div>
+    </div>
 
-        {% for group in editorial_groups %}
+    {% for group in editorial_groups %}
+        <div class="row">
             <div class="col-md-12">
                 <h2>{{ group.name }}</h2>
                 {% if group.description %}
                     <p>{{ group.description|safe }}</p>
                 {% endif %}
             </div>
-            <div class="card-deck">
-                {% for member in group.members %}
-                    <div class="card row-eq-height">
-                    {% if journal_settings.styling.enable_editorial_images %}
-                        <img class="card-img-top card-img" src="
-                                {% if member.user.profile_image %}{{ member.user.profile_image.url }}{% else %}{% static "common/img/icons/users.png" %}{% endif %}"
-                             alt="{{ member.user.full_name }}'s profile image.">
-                    {% endif %}
-                    <div class="card-body">
-                        <h3 class="card-title editor-name">{{ member.user.full_name }}</h3>
-                        <p class="card-text">
-                            <small>{{ member.user.affiliation }}</small>
-                        </p>
-                        {% if user.enable_public_profile %}
-                            <p class="card-text">
-                                <small class="text-muted"><a href="{% url 'core_public_profile' member.user.uuid %}">View
-                                    Profile</a>
-                                </small>
-                            </p>
-                        {% endif %}
-                        {% include "elements/journal/editorial_social_content.html" with user=member.user %}
-                    </div>
+        </div>
 
+        <div class="row">
+            {% for member in group.members %}
+                <div class="col-md-4 row-eq-height">
+                    <div class="card full-width-card">
+                        {% if journal_settings.styling.enable_editorial_images %}
+                            <img class="card-img-top card-img" src="
+
+                                    {% if member.user.profile_image %}{{ member.user.profile_image.url }}{% else %}{% static "common/img/icons/users.png" %}{% endif %}"
+                                 alt="{{ member.user.full_name }}'s profile image.">
+                        {% endif %}
+                        <div class="card-body">
+                            <h3 class="card-title editor-name">{{ member.user.full_name }}</h3>
+                            <p class="card-text">
+                                <small>{{ member.user.affiliation }}</small>
+                            </p>
+                            {% if user.enable_public_profile %}
+                                <p class="card-text">
+                                    <small class="text-muted"><a
+                                            href="{% url 'core_public_profile' member.user.uuid %}">View
+                                        Profile</a>
+                                    </small>
+                                </p>
+                            {% endif %}
+                            {% include "elements/journal/editorial_social_content.html" with user=member.user %}
+                        </div>
                     </div>
-                {% endfor %}
-            </div>
-        {% endfor %}
+                </div>
+            {% endfor %}
+        </div>
+    {% endfor %}
     </div>
 {% endblock %}


### PR DESCRIPTION
Bootstrap's built-in card deck is fairly unpredicatable and only works for one row so I've removed it in favour of just making use for the grid and a class to force cards to be full-size, which gives better results.

<img width="393" alt="Screenshot 2023-12-04 at 10 35 40" src="https://github.com/BirkbeckCTP/janeway/assets/8321378/cc3be2d9-b480-417b-9822-6145ce6bb70f">

<img width="1128" alt="Screenshot 2023-12-04 at 10 35 32" src="https://github.com/BirkbeckCTP/janeway/assets/8321378/9ae56f49-8cf8-415a-aced-051dafb25227">

Closes #3802 

NB. This has been deployed to Amherst here: https://openpublishing.library.umass.edu/cpo/editorialteam/
