### PR TITLE
Updates how_to_cite generation.

### DIFF
--- a/src/submission/models.py
+++ b/src/submission/models.py
@@ -846,7 +846,14 @@ class Article(AbstractLastModifiedModel):
 
         template = "common/elements/how_to_cite.html"
         authors = self.frozenauthor_set.all()
-        author_str = " & ".join(a.citation_name() for a in authors)
+        author_str = ''
+        for author in authors:
+            if author == authors.first():
+                author_str = author.citation_name()
+            elif not author == authors.last():
+                author_str = author_str + f", {author.citation_name()}"
+            else:
+                author_str = author_str + f" & {author.citation_name()}"
         if author_str:
             author_str += ","
         year_str = ""

--- a/src/templates/admin/review/home.html
+++ b/src/templates/admin/review/home.html
@@ -109,7 +109,7 @@
                                                         {% endif %}
                                                         </a>
                                                     </td>
-                                                <tr>
+                                                </tr>
                                             {% endfor %}
                                         </table>
                                     {% else %}


### PR DESCRIPTION
This is far from out perfect solution (using citeproc for example), but a general complaint we've had during the aperio migration is that authors names should be joined by a comman except for the last author which should be an ampersand.