### PR TITLE
#3821 Dashboard Breadcrumb removed

### DIFF
--- a/src/templates/admin/core/dashboard.html
+++ b/src/templates/admin/core/dashboard.html
@@ -5,6 +5,9 @@
 {% block title-section %}Dashboard{% endblock %}
 {% block title-sub %}Summary{% endblock %}
 
+<!--empty breadcrumb block to override default behaviour an ensure there is no breadcrumb-->
+{% block breadcrumbs %}  
+{% endblock breadcrumbs %}
 
 {% block body %}
     <section>

--- a/src/templates/admin/core/dashboard.html
+++ b/src/templates/admin/core/dashboard.html
@@ -5,7 +5,8 @@
 {% block title-section %}Dashboard{% endblock %}
 {% block title-sub %}Summary{% endblock %}
 
-<!--empty breadcrumb block to override default behaviour an ensure there is no breadcrumb-->
+{% comment "empty breadcrumb block to override default behaviour an ensure there is no breadcrumb" %}
+{% endcomment %}
 {% block breadcrumbs %}  
 {% endblock breadcrumbs %}
 


### PR DESCRIPTION
added an empty breadcrumb block to dashboard template to override the default behaviour (for when there is no breadcrumb block) thus removing the breadcrumb.

Closes #3821