### PR TITLE
#3382 author dashboard update to link to article history

### DIFF
--- a/src/templates/admin/elements/core/author_dashboard.html
+++ b/src/templates/admin/elements/core/author_dashboard.html
@@ -99,7 +99,8 @@
                             <td>{{ article.get_stage_display }}</td>
                             <td>{{ article.date_published }}</td>
                             <td>
-                                <!--same link as "View Status" above for unpublished articles so history, peer reviews etc can be viewed -->
+                                {% comment "same link as "View Status" above for unpublished articles so history, peer reviews etc can be viewed" %}
+                                {% endcomment %}
                                 <a class="small button" href="{% url 'core_dashboard_article' article.pk %}">History</a> 
                                 {% for revision in article.active_revision_requests %}
                                     {% if not revision.date_completed %}
@@ -108,7 +109,8 @@
                                     {% endif %}
                                 {% endfor %}
                                             
-                                <!--links to published article-->
+                                {% comment "links to published article" %}
+                                {% endcomment %}
                                 <a class="small button" href="{{ article.url }}">Live</a>
                             </td>
                         </tr>

--- a/src/templates/admin/elements/core/author_dashboard.html
+++ b/src/templates/admin/elements/core/author_dashboard.html
@@ -89,7 +89,7 @@
                         <th>Title</th>
                         <th>Current Stage</th>
                         <th>Date Published</th>
-                        <th>View Live</th>
+                        <th>View </th>
                     </tr>
                     </thead>
                     <tbody>
@@ -99,7 +99,17 @@
                             <td>{{ article.get_stage_display }}</td>
                             <td>{{ article.date_published }}</td>
                             <td>
-                                <a class="small button" href="{{ article.url }}">View Live</a>
+                                <!--same link as "View Status" above for unpublished articles so history, peer reviews etc can be viewed -->
+                                <a class="small button" href="{% url 'core_dashboard_article' article.pk %}">History</a> 
+                                {% for revision in article.active_revision_requests %}
+                                    {% if not revision.date_completed %}
+                                        <a class="small button" href="{% url 'do_revisions' article.pk revision.pk %}">Revision
+                                            Request</a>
+                                    {% endif %}
+                                {% endfor %}
+                                            
+                                <!--links to published article-->
+                                <a class="small button" href="{{ article.url }}">Live</a>
                             </td>
                         </tr>
                     {% endfor %}

--- a/src/templates/admin/elements/core/author_dashboard.html
+++ b/src/templates/admin/elements/core/author_dashboard.html
@@ -99,8 +99,6 @@
                             <td>{{ article.get_stage_display }}</td>
                             <td>{{ article.date_published }}</td>
                             <td>
-                                {% comment "same link as "View Status" above for unpublished articles so history, peer reviews etc can be viewed" %}
-                                {% endcomment %}
                                 <a class="small button" href="{% url 'core_dashboard_article' article.pk %}">History</a> 
                                 {% for revision in article.active_revision_requests %}
                                     {% if not revision.date_completed %}
@@ -108,9 +106,6 @@
                                             Request</a>
                                     {% endif %}
                                 {% endfor %}
-                                            
-                                {% comment "links to published article" %}
-                                {% endcomment %}
                                 <a class="small button" href="{{ article.url }}">Live</a>
                             </td>
                         </tr>


### PR DESCRIPTION
After publication, both the live article and the article history (e.g. peer reviews) should be accessible from the author dashboard.

Updated the author dashboard:
- column heading 'View Live' changed to 'View
- button 'View Live' changed to 'Live'
- button 'History' added before 'Live' in 'View' Column which links to same page as 'View Status' does before publication (copy/paste of code for View Status).

closes #3382 