### PR TITLE
#2123 news item template tag filters updated for HTML

### DIFF
--- a/src/themes/OLH/templates/core/news/index.html
+++ b/src/themes/OLH/templates/core/news/index.html
@@ -22,7 +22,7 @@
                         <div class="large-7 columns">
                             <h4>{{ item.title }}</h4>
                             <h6>{{ item.byline }} {% trans "on" %} {{ item.posted|date:"Y-m-d" }}</h6>
-                            <p>{{ item.body|striptags|truncatesmart:400 }}</p>
+                            <p>{{ item.body|truncatewords_html:50|safe}}</p>
                             <a class="button" href="{% url 'core_news_item' item.pk %}">{% trans "Read More" %}</a>
                         </div>
                     </div>

--- a/src/themes/clean/templates/core/news/index.html
+++ b/src/themes/clean/templates/core/news/index.html
@@ -13,7 +13,7 @@
             <div class="col-md-12">
                 <h4>{{ item.title }}</h4>
                 <h6>{{ item.byline }} on {{ item.posted|date:"Y-m-d" }}</h6>
-                <p>{{ item.body|striptags|truncatesmart:400 }}</p>
+                <p>{{ item.body|truncatewords_html:50|safe }}</p>
                 <a href="{% url 'core_news_item' item.pk %}">{% trans 'Read More' %}</a>
                 <hr/>
             </div>

--- a/src/themes/material/templates/core/news/index.html
+++ b/src/themes/material/templates/core/news/index.html
@@ -28,7 +28,7 @@
                             <h2 class="no-top-margin">{{ item.title }}</h2>
                         {% endif %}
                         <h6><em>{{ item.byline }} {% trans "on" %} {{ item.posted|date:"Y-m-d" }}</em></h6>
-                        <p>{{ item.body|striptags|truncatesmart:400 }}</p>
+                        <p>{{ item.body|truncatewords_html:50|safe }}</p>
                     </div>
                     <div class="card-action">
                         <a href="{% url 'core_news_item' item.pk %}">{% trans "Read More" %}</a>


### PR DESCRIPTION
identified templates as core/news/index.html across themes OLH, Material and Clean.

previously used striptag and truncatesmart

updated to truncatewords_html and safe

truncatesmart was set at 400 char, have used 50 words as an equivalent.

there are other templates which also use striptag and truncatesmart, these may need to considered for a similar update.

Closes #2123

