### PR TITLE
#3836 create accessiblity issue reporting template

### DIFF
--- a/.github/ISSUE_TEMPLATE/a11y_report.md
+++ b/.github/ISSUE_TEMPLATE/a11y_report.md
@@ -5,11 +5,11 @@ title: ''
 labels: a11y
 assignees: ''
 ---
-## Report Issue
-**Describe the inaccessible feature**
+## Report Accessibility Issue
+### Describe the inaccessible feature
 A clear and concise description of what cannot be accessed.
 
-**Which users are impacted?**
+### Which users are impacted?
  (delete as applicable)
  1. Everyone
  2. Readers (i.e. those accessing the published site but not logging in to Janeway)
@@ -23,21 +23,21 @@ A clear and concise description of what cannot be accessed.
     f. proofreader
     g. manager
 
-**Assistive software or customised computer setup**
+### Assistive software or customised computer setup
 Is this about an incompatibility with assistive software, hardware or accessibility settings? If so, please give details, including version numbers.
 
-**Janeway version**
+### Janeway version
 The version of Janeway under which the issue was encountered.
 If running off of master, please, indicate the current HEAD of the Janeway installation
 
-**To Reproduce**
+### To Reproduce
 Steps to reproduce:
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
 4. See error
 
-**Screenshots**
+### Screenshots
 If applicable, add screenshots to help explain your problem.
 
 ## Preferred Solution
@@ -46,12 +46,12 @@ A clear and concise description of what you would like to happen instead.
 ## Front-end Issues (only)
 If the issue is front-end specific please add the following details:
 
-**Desktop (please complete the following information):**
+### Desktop (please complete the following information):
  - OS: [e.g. iOS]
  - Browser [e.g. chrome, safari]
  - Version [e.g. 22]
 
-**Smartphone (please complete the following information):**
+### Smartphone (please complete the following information):
  - Device: [e.g. iPhone6]
  - OS: [e.g. iOS8.1]
  - Browser [e.g. stock browser, safari]

--- a/.github/ISSUE_TEMPLATE/a11y_report.md
+++ b/.github/ISSUE_TEMPLATE/a11y_report.md
@@ -1,0 +1,64 @@
+---
+name: Accessibility Report
+about: Tell us about something that is not accessible.
+title: ''
+labels: a11y
+assignees: ''
+---
+## Missing Alt-text
+Please do not currently report missing alt-text for images unless you are part of the alt-text audit.
+
+## Report Issue
+**Describe the inaccessible feature**
+A clear and concise description of what cannot be accessed.
+
+**Which users are impacted?**
+ (delete as applicable)
+ 1. Everyone
+ 2. Readers (i.e. those accessing the published site but not logging in to Janeway)
+ 3. All Janeway Users
+ 4. Only some Janeway Workflows:
+    a. author
+    b. editor
+    c. reviewer
+    d. copyeditor
+    e. typesetter
+    f. proofreader
+    g. manager
+
+**Assistive software or customised computer setup**
+Is this about an incompatibility with assistive software, hardware or accessibility settings? If so, please give details, including version numbers.
+
+**Janeway version**
+The version of Janeway under which the issue was encountered.
+If running off of master, please, indicate the current HEAD of the Janeway installation
+
+**To Reproduce**
+Steps to reproduce:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+## Preferred Solution
+A clear and concise description of what you would like to happen instead.
+
+## Front-end Issues (only)
+If the issue is front-end specific please add the following details:
+
+**Desktop (please complete the following information):**
+ - OS: [e.g. iOS]
+ - Browser [e.g. chrome, safari]
+ - Version [e.g. 22]
+
+**Smartphone (please complete the following information):**
+ - Device: [e.g. iPhone6]
+ - OS: [e.g. iOS8.1]
+ - Browser [e.g. stock browser, safari]
+ - Version [e.g. 22]
+
+## Additional context
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/a11y_report.md
+++ b/.github/ISSUE_TEMPLATE/a11y_report.md
@@ -5,9 +5,6 @@ title: ''
 labels: a11y
 assignees: ''
 ---
-## Missing Alt-text
-Please do not currently report missing alt-text for images unless you are part of the alt-text audit.
-
 ## Report Issue
 **Describe the inaccessible feature**
 A clear and concise description of what cannot be accessed.


### PR DESCRIPTION
new template for accessibility issue reporting.

using the a11y tag

based on bug report template

asks for missing alt-text not to be reported at present unless part of the alt text audit (to reduce likelihood of multiple reports - better to do this as one audit than accept these issue individually).

Closes #3836 