### PR TITLE
PreprintFile download_url should point to the public url

### DIFF
--- a/src/repository/models.py
+++ b/src/repository/models.py
@@ -817,7 +817,7 @@ class PreprintFile(models.Model):
 
     def download_url(self):
         return reverse(
-            'repository_download_file',
+            'repository_file_download',
             kwargs=self.reverse_kwargs(),
         )
 


### PR DESCRIPTION
repository_download_file is manager only view whereas repository_file_download is public view. Updating the download url so that correct item url in OAI and JATS metadata for repository items.