### PR TITLE
#2678 wrapper div of class columns added

### DIFF
--- a/src/themes/OLH/templates/journal/homepage_elements/issue_block.html
+++ b/src/themes/OLH/templates/journal/homepage_elements/issue_block.html
@@ -1,6 +1,8 @@
 <section>
     <div class="row">
-        {% include 'elements/journal/issue_top.html' %}
-        {% include 'elements/journal/issue_block.html' %}
+        <div class="columns">
+            {% include 'elements/journal/issue_top.html' %}
+            {% include 'elements/journal/issue_block.html' %}
+        </div>
     </div>
 </section>


### PR DESCRIPTION
On investigating, this bug only affected OLH theme.

The about section was unaffected due to padding provided by div class 'columns.' 

Added a wrapper div of class columns to the issue_block.html template to gain same affect for this block.

Used a wrapper within homepage element because otherwise this would have required individual changes (e.g. to add this class) to both issue_top and issue_block journal elements which may be re-used elsewhere as not specific to homepage.

Closes #2678 