### PR TITLE
3857 breadcrumb remove currentpage href

### DIFF
--- a/src/templates/admin/cms/index.html
+++ b/src/templates/admin/cms/index.html
@@ -6,7 +6,7 @@
 {% block breadcrumbs %}
     {{ block.super }}
     <li><a href="{% url 'core_manager_index' %}">Manager</a></li>
-    <li>Content Manager</a></li>
+    <li>Content Manager</li>
 {% endblock %}
 
 {% block body %}

--- a/src/templates/admin/cms/index.html
+++ b/src/templates/admin/cms/index.html
@@ -6,7 +6,7 @@
 {% block breadcrumbs %}
     {{ block.super }}
     <li><a href="{% url 'core_manager_index' %}">Manager</a></li>
-    <li><a href="{% url 'cms_index' %}">Content Manager</a></li>
+    <li>Content Manager</a></li>
 {% endblock %}
 
 {% block body %}

--- a/src/templates/admin/cms/submission_item_list.html
+++ b/src/templates/admin/cms/submission_item_list.html
@@ -13,7 +13,7 @@
 {% block breadcrumbs %}
     {{ block.super }}
     <li><a href="{% url 'core_manager_index' %}">Manager</a></li>
-    <li>Submisions Page Items</li>
+    <li>Submissions Page Items</li>
 {% endblock %}
 
 {% block body %}

--- a/src/templates/admin/cms/submission_item_list.html
+++ b/src/templates/admin/cms/submission_item_list.html
@@ -13,7 +13,7 @@
 {% block breadcrumbs %}
     {{ block.super }}
     <li><a href="{% url 'core_manager_index' %}">Manager</a></li>
-    <li><a href="{% url 'cms_submission_items' %}">Submisions Page Items</a></li>
+    <li>Submisions Page Items</li>
 {% endblock %}
 
 {% block body %}

--- a/src/templates/admin/copyediting/add_copyeditor_assignment.html
+++ b/src/templates/admin/copyediting/add_copyeditor_assignment.html
@@ -8,7 +8,7 @@
 
 {% block breadcrumbs %}
     {{ block.super }}
-    {% include "elements/breadcrumbs/copyediting_base.html" %}
+    {% include "elements/breadcrumbs/copyediting_base.html" with subpage="yes" %}
     <li>Add Copyedit Assignment</li>
 {% endblock breadcrumbs %}
 

--- a/src/templates/admin/copyediting/copyedit_requests.html
+++ b/src/templates/admin/copyediting/copyedit_requests.html
@@ -5,8 +5,9 @@
 {% block title-section %}Copyedit Requests{% endblock %}
 
 {% block breadcrumbs %}
-{{ block.super }}
-{% include "elements/breadcrumbs/copyediting_base.html" %}
+    {{ block.super }}
+    {% include "elements/breadcrumbs/copyediting_base.html" with subpage="yes" %}
+    <li>Copyedit Requests</li>
 {% endblock breadcrumbs %}
 
 {% block body %}

--- a/src/templates/admin/copyediting/delete_author_review.html
+++ b/src/templates/admin/copyediting/delete_author_review.html
@@ -9,8 +9,8 @@
 
 {% block breadcrumbs %}
     {{ block.super }}
-    {% include "elements/breadcrumbs/copyediting_base.html" %}
-    <li><a href="{% url 'editor_review' article.pk copyedit.pk %}">Review Copyediting</a></li>
+    {% include "elements/breadcrumbs/copyediting_base.html" with subpage="yes" %}
+    <li>Review Copyediting</li>
 {% endblock breadcrumbs %}
 
 {% block body %}

--- a/src/templates/admin/copyediting/edit_assignment.html
+++ b/src/templates/admin/copyediting/edit_assignment.html
@@ -7,7 +7,7 @@
 
 {% block breadcrumbs %}
     {{ block.super }}
-    {% include "elements/breadcrumbs/copyediting_base.html" %}
+    {% include "elements/breadcrumbs/copyediting_base.html" with subpage="yes" %}
     <li>Edit Assignment</li>
 {% endblock breadcrumbs %}
 

--- a/src/templates/admin/copyediting/editor_review.html
+++ b/src/templates/admin/copyediting/editor_review.html
@@ -8,7 +8,7 @@
 
 {% block breadcrumbs %}
     {{ block.super }}
-    {% include "elements/breadcrumbs/copyediting_base.html" %}
+    {% include "elements/breadcrumbs/copyediting_base.html" with subpage="yes" %}
     <li>Review Copyediting</li>
 {% endblock breadcrumbs %}
 

--- a/src/templates/admin/copyediting/request_author_copyedit.html
+++ b/src/templates/admin/copyediting/request_author_copyedit.html
@@ -9,8 +9,8 @@
 
 {% block breadcrumbs %}
     {{ block.super }}
-    {% include "elements/breadcrumbs/copyediting_base.html" %}
-    <li><a href="{% url 'editor_review' article.pk copyedit.pk %}">Review Copyediting</a></li>
+    {% include "elements/breadcrumbs/copyediting_base.html" with subpage="yes" %}
+    <li>Review Copyediting</li>
 {% endblock breadcrumbs %}
 
 {% block body %}

--- a/src/templates/admin/copyediting/upload_file.html
+++ b/src/templates/admin/copyediting/upload_file.html
@@ -8,7 +8,7 @@
 
 {% block breadcrumbs %}
     {{ block.super }}
-    {% include "elements/breadcrumbs/copyeditor_base.html" %}
+    {% include "elements/breadcrumbs/copyeditor_base.html" with subpage="yes" %}
     <li>Upload File</li>
 {% endblock breadcrumbs %}
 

--- a/src/templates/admin/core/manager/contacts/index.html
+++ b/src/templates/admin/core/manager/contacts/index.html
@@ -8,7 +8,7 @@
 {% block breadcrumbs %}
     {{ block.super }}
     <li><a href="{% url 'core_manager_index' %}">Manager</a></li>
-    <li><a href="{% url 'core_journal_contacts' %}">Contact Manager</a></li>
+    <li>Contact Manager</li>
 {% endblock %}
 
 {% block body %}

--- a/src/templates/admin/core/manager/editorial/index.html
+++ b/src/templates/admin/core/manager/editorial/index.html
@@ -9,7 +9,7 @@
 {% block breadcrumbs %}
     {{ block.super }}
     <li><a href="{% url 'core_manager_index' %}">Manager</a></li>
-    <li><a href="{% url 'core_editorial_team' %}">Editorial Group Manager</a></li>
+    <li>Editorial Group Manager</li>
 {% endblock %}
 
 {% block body %}

--- a/src/templates/admin/core/manager/email/email_templates.html
+++ b/src/templates/admin/core/manager/email/email_templates.html
@@ -4,7 +4,7 @@
 {% block breadcrumbs %}
     {{ block.super }}
     <li><a href="{% url 'core_manager_index' %}">Manager</a></li>
-    <li><a href="{% url 'core_email_templates' %}">Email Templates</a></li>
+    <li>Email Templates</li>
 {% endblock %}
 
 {% block title-section %}Email Templates{% endblock %}

--- a/src/templates/admin/core/manager/images/articles.html
+++ b/src/templates/admin/core/manager/images/articles.html
@@ -8,7 +8,7 @@
 {% block breadcrumbs %}
     {{ block.super }}
     <li><a href="{% url 'core_manager_index' %}">Manager</a></li>
-    <li><a href="{% url 'core_article_images' %}">Article Images Manager</a></li>
+    <li>Article Images Manager</li>
 {% endblock %}
 
 {% block body %}

--- a/src/templates/admin/core/manager/news/index.html
+++ b/src/templates/admin/core/manager/news/index.html
@@ -8,7 +8,7 @@
 {% block breadcrumbs %}
     {{ block.super }}
     <li><a href="{% url 'core_manager_index' %}">Manager</a></li>
-    <li><a href="{% url 'core_manager_news' %}">News Manager</a></li>
+    <li>News Manager</li>
 {% endblock %}
 
 {% block body %}

--- a/src/templates/admin/core/manager/plugins.html
+++ b/src/templates/admin/core/manager/plugins.html
@@ -7,7 +7,7 @@
 {% block breadcrumbs %}
     {{ block.super }}
     <li><a href="{% url 'core_manager_index' %}">Manager</a></li>
-    <li><a href="{% url 'core_plugin_list' %}">Plugins</a></li>
+    <li>Plugins</li>
 {% endblock %}
 
 

--- a/src/templates/admin/core/manager/roles/role.html
+++ b/src/templates/admin/core/manager/roles/role.html
@@ -10,7 +10,7 @@
     {{ block.super }}
     <li><a href="{% url 'core_manager_index' %}">Manager</a></li>
     <li><a href="{% url 'core_manager_roles' %}">Roles</a></li>
-    <li><a href="{% url 'core_manager_role' role.slug %}">{{ role.name }}</a></li>
+    <li>{{ role.name }}</li>
 {% endblock %}
 
 {% block body %}

--- a/src/templates/admin/core/manager/roles/roles.html
+++ b/src/templates/admin/core/manager/roles/roles.html
@@ -9,7 +9,7 @@
 {% block breadcrumbs %}
     {{ block.super }}
     <li><a href="{% url 'core_manager_index' %}">Manager</a></li>
-    <li><a href="{% url 'core_manager_roles' %}">Roles</a></li>
+    <li>Roles</li>
 {% endblock %}
 
 

--- a/src/templates/admin/core/manager/sections/section_articles.html
+++ b/src/templates/admin/core/manager/sections/section_articles.html
@@ -10,7 +10,7 @@
     {{ block.super }}
     <li><a href="{% url 'core_manager_index' %}">{% trans 'Manager' %}</a></li>
     <li><a href="{% url 'core_manager_sections' %}">{% trans 'Sections' %}</a></li>
-    <li><a href="{% url 'core_manager_section' section.pk %}">{{ section.name }} {% trans 'Articles' %}</a></li>
+    <li>{{ section.name }} {% trans 'Articles' %}</li>
 {% endblock %}
 
 {% block body %}

--- a/src/templates/admin/core/manager/sections/section_list.html
+++ b/src/templates/admin/core/manager/sections/section_list.html
@@ -12,7 +12,7 @@
 {% block breadcrumbs %}
     {{ block.super }}
     <li><a href="{% url 'core_manager_index' %}">Manager</a></li>
-    <li><a href="{% url 'core_manager_sections' %}">Sections</a></li>
+    <li>Sections</li>
 {% endblock %}
 
 {% block body %}

--- a/src/templates/admin/core/manager/settings/edit_setting.html
+++ b/src/templates/admin/core/manager/settings/edit_setting.html
@@ -8,12 +8,11 @@
 
 {% block breadcrumbs %}
     {{ block.super }}
+    <li><a href="{% url 'core_manager_index' %}">Manager</a></li>
     {% if request.GET.email_template %}
-        <li><a href="{% url 'core_manager_index' %}">Manager</a></li>
         <li><a href="{% url 'core_email_templates' %}">Email Templates</a></li>
     {% else %}
         {% if request.journal %}
-            <li><a href="{% url 'core_manager_index' %}">Manager</a></li>
             <li><a href="{% url 'core_settings_index' %}">Settings</a></li>
         {% else %}
             <li><a href="{% url 'core_default_settings_index' %}">Settings</a></li>

--- a/src/templates/admin/core/manager/settings/edit_setting.html
+++ b/src/templates/admin/core/manager/settings/edit_setting.html
@@ -11,21 +11,15 @@
     {% if request.GET.email_template %}
         <li><a href="{% url 'core_manager_index' %}">Manager</a></li>
         <li><a href="{% url 'core_email_templates' %}">Email Templates</a></li>
-        <li><a href="{% url 'core_manager_index' %}">Manager</a></li>
     {% else %}
         {% if request.journal %}
             <li><a href="{% url 'core_manager_index' %}">Manager</a></li>
             <li><a href="{% url 'core_settings_index' %}">Settings</a></li>
-            <li>
-                <a href="{% url 'core_edit_setting' setting.group.name setting.name %}">Edit {{ setting.pretty_name }}</a>
-            </li>
         {% else %}
             <li><a href="{% url 'core_default_settings_index' %}">Settings</a></li>
-            <li>
-                <a href="{% url 'core_edit_default_setting' setting.group.name setting.name %}">Edit {{ setting.pretty_name }}</a>
-            </li>
         {% endif %}
     {% endif %}
+    <li>Edit {{ setting.pretty_name }}</li>
 {% endblock %}
 
 {% block body %}

--- a/src/templates/admin/core/manager/settings/group.html
+++ b/src/templates/admin/core/manager/settings/group.html
@@ -8,7 +8,7 @@
 {% block breadcrumbs %}
     {{ block.super }}
     <li><a href="{% url 'core_manager_index' %}">Manager</a></li>
-    <li><a href="{% url 'core_edit_settings_group' group %}">{{ group|capfirst }} Settings</a></li>
+    <li>{{ group|capfirst }} Settings</li>
 {% endblock %}
 
 {% block body %}

--- a/src/templates/admin/core/manager/settings/index.html
+++ b/src/templates/admin/core/manager/settings/index.html
@@ -8,7 +8,7 @@
 {% block breadcrumbs %}
     {{ block.super }}
     <li><a href="{% url 'core_manager_index' %}">Manager</a></li>
-    <li>Settings</a></li>
+    <li>Settings</li>
 {% endblock %}
 
 {% block body %}

--- a/src/templates/admin/core/manager/settings/index.html
+++ b/src/templates/admin/core/manager/settings/index.html
@@ -8,7 +8,7 @@
 {% block breadcrumbs %}
     {{ block.super }}
     <li><a href="{% url 'core_manager_index' %}">Manager</a></li>
-    <li><a href="{% url 'core_settings_index' %}">Settings</a></li>
+    <li>Settings</a></li>
 {% endblock %}
 
 {% block body %}

--- a/src/templates/admin/core/manager/users/edit.html
+++ b/src/templates/admin/core/manager/users/edit.html
@@ -12,7 +12,7 @@
     {{ block.super }}
     <li><a href="{% url 'core_manager_index' %}">Manager</a></li>
     <li><a href="{% url 'core_manager_users' %}">Users</a></li>
-    <li>{% if active == 'add' %}Add New User{% else %}Edit User{% endif %}</li>
+    <li>{% if active == 'add' %}Add User{% else %}Edit {{user.first_name}} {{user.last_name}} {% endif %}</li>
 {% endblock %}
 
 {% block title-section %}Users{% endblock %}

--- a/src/templates/admin/core/manager/users/edit.html
+++ b/src/templates/admin/core/manager/users/edit.html
@@ -12,7 +12,7 @@
     {{ block.super }}
     <li><a href="{% url 'core_manager_index' %}">Manager</a></li>
     <li><a href="{% url 'core_manager_users' %}">Users</a></li>
-    <li>{% if active == 'add' %}Add User{% else %}Edit {{user.first_name}} {{user.last_name}} {% endif %}</li>
+    <li>{% if active == 'add' %}Add User{% else %}Edit {{user_to_edit.full_name}} {% endif %}</li>
 {% endblock %}
 
 {% block title-section %}Users{% endblock %}
@@ -23,7 +23,7 @@
 
     <div class="box">
         <div class="title-area">
-            <h2>{% if active == 'add' %}Add User{% else %}Edit {{ registration_form.email.value }}{% endif %}</h2>
+            <h2>{% if active == 'add' %}Add User{% else %}Edit {{user_to_edit.full_name}} ({{ registration_form.email.value }}) {% endif %}</h2>
         </div>
 
         <div class="content">

--- a/src/templates/admin/core/manager/users/enrol_users.html
+++ b/src/templates/admin/core/manager/users/enrol_users.html
@@ -4,7 +4,7 @@
 {% block breadcrumbs %}
     {{ block.super }}
     <li><a href="{% url 'core_manager_index' %}">Manager</a></li>
-    <li><a href="{% url 'core_manager_users' %}">Enrol Users</a></li>
+    <li>Enrol Users</li>
 {% endblock %}
 
 {% block title %}Enrol Users{% endblock %}

--- a/src/templates/admin/core/manager/users/history.html
+++ b/src/templates/admin/core/manager/users/history.html
@@ -6,7 +6,7 @@
     {{ block.super }}
     <li><a href="{% url 'core_manager_index' %}">Manager</a></li>
     <li><a href="{% url 'core_manager_users' %}">Users</a></li>
-    <li>History</li>
+    <li>History of {{user.first_name}} {{user.last_name}} </li>
 {% endblock %}
 
 {% block title-section %}User History{% endblock %}

--- a/src/templates/admin/core/manager/users/inactive.html
+++ b/src/templates/admin/core/manager/users/inactive.html
@@ -4,7 +4,7 @@
 {% block breadcrumbs %}
     {{ block.super }}
     <li><a href="{% url 'core_manager_index' %}">Manager</a></li>
-    <li><a href="{% url 'core_manager_inactive_users' %}">Inactive Users</a></li>
+    <li>Inactive Users</li>
 {% endblock %}
 
 {% block title-section %}Users{% endblock %}

--- a/src/templates/admin/core/manager/users/index.html
+++ b/src/templates/admin/core/manager/users/index.html
@@ -4,7 +4,7 @@
 {% block breadcrumbs %}
     {{ block.super }}
     <li><a href="{% url 'core_manager_index' %}">Manager</a></li>
-    <li><a href="{% url 'core_manager_users' %}">Users</a></li>
+    <li>Users</li>
 {% endblock %}
 
 {% block title %}Enrolled Users{% endblock %}

--- a/src/templates/admin/core/manager/users/logged_in_users.html
+++ b/src/templates/admin/core/manager/users/logged_in_users.html
@@ -4,7 +4,7 @@
 {% block breadcrumbs %}
     {{ block.super }}
     <li><a href="{% url 'core_manager_index' %}">Manager</a></li>
-    <li><a href="{% url 'core_manager_inactive_users' %}">Authenticated Users</a></li>
+    <li>Authenticated Users</li>
 {% endblock %}
 
 {% block title-section %}Users{% endblock %}

--- a/src/templates/admin/cron/create_template.html
+++ b/src/templates/admin/cron/create_template.html
@@ -9,7 +9,7 @@
     {{ block.super }}
     <li><a href="{% url 'core_manager_index' %}">Manager</a></li>
     <li><a href="{% url 'cron_home' %}">Cron</a></li>
-    <li><a href="{% url 'cron_create_template' reminder.pk template_name %}">Create Reminder Template</a></li>
+    <li>Create Reminder Template</li>
 {% endblock %}
 
 {% block body %}

--- a/src/templates/admin/cron/manage_reminder.html
+++ b/src/templates/admin/cron/manage_reminder.html
@@ -10,8 +10,8 @@
     <li><a href="{% url 'core_manager_index' %}">Manager</a></li>
     <li><a href="{% url 'cron_home' %}">Cron</a></li>
     <li><a href="{% url 'cron_reminders' %}">Reminders</a></li>
-    <li><a href="{% url 'cron_reminders' %}" class="active">{% if not reminder %}Add New Reminder{% else %}Edit
-        Reminder{% endif %}</a></li>
+    <li>{% if not reminder %}Add New Reminder{% else %}Edit
+        Reminder{% endif %}</li>
 {% endblock %}
 
 {% block body %}

--- a/src/templates/admin/cron/readers.html
+++ b/src/templates/admin/cron/readers.html
@@ -9,7 +9,7 @@
     {{ block.super }}
     <li><a href="{% url 'core_manager_index' %}">Manager</a></li>
     <li><a href="{% url 'cron_home' %}">Cron</a></li>
-    <li><a href="{% url 'cron_readers' %}">Publication Notifications</a></li>
+    <li>Publication Notifications</li>
 {% endblock %}
 
 {% block body %}

--- a/src/templates/admin/cron/reminders.html
+++ b/src/templates/admin/cron/reminders.html
@@ -9,7 +9,7 @@
     {{ block.super }}
     <li><a href="{% url 'core_manager_index' %}">Manager</a></li>
     <li><a href="{% url 'cron_home' %}">Cron</a></li>
-    <li><a href="{% url 'cron_reminders' %}">Reminders</a></li>
+    <li>Reminders</li>
 {% endblock %}
 
 {% block body %}

--- a/src/templates/admin/elements/breadcrumbs/copyediting_base.html
+++ b/src/templates/admin/elements/breadcrumbs/copyediting_base.html
@@ -1,3 +1,12 @@
-<li><a href="{% url 'copyediting' %}">Articles in Copyediting</a></li>
-{% if article %}<li><a href="{% url 'article_copyediting' article.pk %}">{{ article.safe_title }}</a></li>{% endif %}
-{% if assignment %} <li><a href="{% url 'review_view_review' assignment.article.id assignment.id %}">Copyeditor Assignment</a></li>{% endif %}
+{% if subpage %}
+    <li><a href="{% url 'copyediting' %}">Articles in Copyediting</a></li>
+    {% if article %}<li><a href="{% url 'article_copyediting' article.pk %}">{{ article.safe_title }}</a></li>
+    {% elif assignment %} <li><a href="{% url 'review_view_review' assignment.article.id assignment.id %}">Copyeditor Assignment</a></li>
+    {% endif %}
+{% elif article or assignment %}
+    <li><a href="{% url 'copyediting' %}">Articles in Copyediting</a></li>
+    {% if article %}<li>{{ article.safe_title }}</li>{% endif %}
+    {% if assignment %} <li>{{ assignment.safe_title }}</li>{% endif %}
+{% else %}
+    <li>Articles in Copyediting</li>
+{% endif %}

--- a/src/templates/admin/elements/breadcrumbs/copyeditor_base.html
+++ b/src/templates/admin/elements/breadcrumbs/copyeditor_base.html
@@ -1,2 +1,7 @@
-<li><a href="{% url 'copyedit_requests' %}">Copyediting Requests</a></li>
-{% if copyedit %}<li><a href="{% url 'do_copyedit' copyedit.pk %}">Copyedit for {{ copyedit.article.safe_title }}</a></li>{% endif %}
+{% if subpage %}
+    <li><a href="{% url 'copyedit_requests' %}">Copyediting Requests</a></li>
+    {% if copyedit %}<li><a href="{% url 'do_copyedit' copyedit.pk %}">Copyedit for {{ copyedit.article.safe_title }}</a></li>{% endif %}
+{% else %}
+    <li><a href="{% url 'copyedit_requests' %}">Copyediting Requests</a></li>   
+    {% if copyedit %}<li>Copyedit for {{ copyedit.article.safe_title }}</li>{% endif %}
+{% endif %}

--- a/src/templates/admin/elements/breadcrumbs/issue_management.html
+++ b/src/templates/admin/elements/breadcrumbs/issue_management.html
@@ -1,2 +1,9 @@
-<li><a href="{% url 'manage_issues' %}">Issue Management</a></li>
-{% if issue %}<li><a href="{% url 'manage_issues_id' issue.id %}">{{ issue.display_title }}</a></li>{% endif %}
+{% if subpage %}
+    <li><a href="{% url 'manage_issues' %}">Issue Management</a></li>
+    {% if issue %}<li><a href="{% url 'manage_issues_id' issue.id %}">{{ issue.display_title }}</a></li>{% endif %}
+{% elif issue %}
+    <li><a href="{% url 'manage_issues' %}">Issue Management</a></li>
+    {% if issue %}<li>{{ issue.display_title }}</li>{% endif %}
+{% else %}
+    <li>Issue Management</li>
+{% endif %}

--- a/src/templates/admin/elements/breadcrumbs/proofing_manager_base.html
+++ b/src/templates/admin/elements/breadcrumbs/proofing_manager_base.html
@@ -1,2 +1,9 @@
-<li><a href="{% url 'proofing_list' %}">Articles in Proofing</a></li>
-{% if article %}<li><a href="{% url 'proofing_article' article.pk %}">{{ article.safe_title }}</a></li>{% endif %}
+{% if subpage %}
+    <li><a href="{% url 'proofing_list' %}">Articles in Proofing</a></li>
+     {% if article %}<li><a href="{% url 'proofing_article' article.pk %}"> {{ article.safe_title }}</a></li>{% endif %}
+{% elif article %}
+    <li><a href="{% url 'proofing_list' %}">Articles in Proofing</a></li>
+    {% if article %}<li> {{ article.safe_title }}</li>{% endif %}
+{% else %}
+    <li>Articles in Proofing</li>
+{% endif %}

--- a/src/templates/admin/elements/breadcrumbs/proofreader_base.html
+++ b/src/templates/admin/elements/breadcrumbs/proofreader_base.html
@@ -1,2 +1,9 @@
-<li><a href="{% url 'proofing_requests' %}">Proofing Requests</a></li>
-{% if article %}<li><a href="{% url 'proofing_article' article.pk %}">{{ article.safe_title }}</a></li>{% endif %}
+{% if subpage %}
+    <li><a href="{% url 'proofing_requests' %}">Proofing Requests</a></li>  
+    {% if article %}<li><a href="{% url 'proofing_article' article.pk %}">{{ article.safe_title }}</a></li>{% endif %}
+{% elif article %}
+    <li><a href="{% url 'proofing_requests' %}">Proofing Requests</a></li>
+    {% if article %}<li>{{ article.safe_title }}</li>{% endif %}
+{% else %}
+    <li>Proofing Requests</li>
+{% endif %}

--- a/src/templates/admin/elements/breadcrumbs/review_base.html
+++ b/src/templates/admin/elements/breadcrumbs/review_base.html
@@ -1,3 +1,14 @@
-<li><a href="{% url 'review_home' %}">Articles in Review</a></li>
-{% if article %}<li><a href="{% url 'review_in_review' article.pk %}">{{ article.safe_title }}</a></li>{% endif %}
-{% if review or assignment %} <li><a href="{% if review %}{% url 'review_view_review' review.article.id review.id %}{% elif assignment %}{% url 'review_view_review' assignment.article.id assignment.id %}{% endif %}">Review</a></li>{% endif %}
+{% if subpage %}
+    <li><a href="{% url 'review_home' %}">Articles in Review</a></li>
+    {% if article %}<li><a href="{% url 'review_in_review' article.pk %}">{{ article.safe_title }}</a></li>{% endif %}
+    {% if review or assignment %} <li><a href="{% if review %}{% url 'review_view_review' review.article.id review.id %}{% elif assignment %}{% url 'review_view_review' assignment.article.id assignment.id %}{% endif %}">Review</a></li>{% endif %}
+{% elif review or assignment %}
+    <li><a href="{% url 'review_home' %}">Articles in Review</a></li>
+    {% if article %}<li><a href="{% url 'review_in_review' article.pk %}">{{ article.safe_title }}</a></li>{% endif %}
+    {% if review or assignment %} <li>Review</li>{% endif %}
+{% elif article %}
+    <li><a href="{% url 'review_home' %}">Articles in Review</a></li>
+    <li>{{ article.safe_title }}</li>
+{% else %}
+    <li>Articles in Review</li>
+{% endif %}

--- a/src/templates/admin/journal/manage/add_guest_editor.html
+++ b/src/templates/admin/journal/manage/add_guest_editor.html
@@ -9,7 +9,7 @@
 
 {% block breadcrumbs %}
     {{ block.super }}
-    {% include "elements/breadcrumbs/issue_management.html" %}
+    {% include "elements/breadcrumbs/issue_management.html" with subpage="yes" %}
     <li>Add Guest Editor</li>
 {% endblock breadcrumbs %}
 

--- a/src/templates/admin/journal/manage/archive_article.html
+++ b/src/templates/admin/journal/manage/archive_article.html
@@ -14,6 +14,7 @@
 {% block breadcrumbs %}
     {{ block.super }}
     <li><a href="{% url 'manage_archive' %}">Article Archive</a></li>
+    <li>{{ article.safe_title }}</li>
 {% endblock breadcrumbs %}
 
 {% block body %}

--- a/src/templates/admin/journal/manage/issue_add_article.html
+++ b/src/templates/admin/journal/manage/issue_add_article.html
@@ -9,7 +9,7 @@
 {% block breadcrumbs %}
     {{ block.super }}
     {% include "elements/breadcrumbs/issue_management.html" with subpage="yes"%}
-    <li> Add Article </li>
+    <li>Add Article</li>
 {% endblock breadcrumbs %}
 
 

--- a/src/templates/admin/journal/manage/issue_add_article.html
+++ b/src/templates/admin/journal/manage/issue_add_article.html
@@ -8,7 +8,8 @@
 
 {% block breadcrumbs %}
     {{ block.super }}
-    {% include "elements/breadcrumbs/issue_management.html" %}
+    {% include "elements/breadcrumbs/issue_management.html" with subpage="yes"%}
+    <li> Add Article </li>
 {% endblock breadcrumbs %}
 
 

--- a/src/templates/admin/journal/manage/issue_display.html
+++ b/src/templates/admin/journal/manage/issue_display.html
@@ -5,7 +5,7 @@
 
 {% block breadcrumbs %}
     {{ block.super }}
-    {% include "elements/breadcrumbs/issue_management.html" %}
+    {% include "elements/breadcrumbs/issue_management.html" with subpage="yes" %}
     <li>Issue Title Display Settings</li>
 {% endblock breadcrumbs %}
 

--- a/src/templates/admin/journal/manage/issues.html
+++ b/src/templates/admin/journal/manage/issues.html
@@ -6,8 +6,8 @@
 
 {% block title %}Issue Management{% endblock title %}
 
-{% block breadcrumbs %}
-{{ block.super }}
+{% block breadcrumbs %} 
+    {{ block.super }}
     {% include "elements/breadcrumbs/issue_management.html" %}
 {% endblock breadcrumbs %}
 

--- a/src/templates/admin/proofing/acknowledge.html
+++ b/src/templates/admin/proofing/acknowledge.html
@@ -6,9 +6,9 @@
 {% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.safe_title }}{% endblock %}
 
 {% block breadcrumbs %}
-{{ block.super }}
-{% include "elements/breadcrumbs/proofing_manager_base.html" %}
-<li>Acknowledge Task</li>
+{{ block.super }}  
+    {% include "elements/breadcrumbs/proofing_manager_base.html" with subpage="yes" %}
+    <li>Acknowledge Task</li>
 {% endblock breadcrumbs %}
 
 {% block body %}

--- a/src/templates/admin/proofing/complete_proofing.html
+++ b/src/templates/admin/proofing/complete_proofing.html
@@ -9,7 +9,8 @@
 
 {% block breadcrumbs %}
     {{ block.super }}
-    {% include "elements/breadcrumbs/proofing_manager_base.html" %}
+    {% include "elements/breadcrumbs/proofing_manager_base.html" with subpage="yes"  %}
+    <li>Complete Proofing</li>
 {% endblock breadcrumbs %}
 
 {% block body %}

--- a/src/templates/admin/proofing/correction_requests.html
+++ b/src/templates/admin/proofing/correction_requests.html
@@ -8,7 +8,7 @@
 
 {% block breadcrumbs %}
     {{ block.super }}
-    {% include "elements/breadcrumbs/proofreader_base.html" %}
+    {% include "elements/breadcrumbs/proofreader_base.html" with subpage="yes" %}
     <li>Correction Requests</li>
 {% endblock breadcrumbs %}
 

--- a/src/templates/admin/proofing/delete_proofing_round.html
+++ b/src/templates/admin/proofing/delete_proofing_round.html
@@ -9,7 +9,7 @@
 
 {% block breadcrumbs %}
     {{ block.super }}
-    {% include "elements/breadcrumbs/proofing_manager_base.html" %}
+    {% include "elements/breadcrumbs/proofing_manager_base.html" with subpage="yes" %}
     <li>Deleting Proofing Round #{{ round.number }}</li>
 {% endblock breadcrumbs %}
 

--- a/src/templates/admin/proofing/edit_proofing_assignment.html
+++ b/src/templates/admin/proofing/edit_proofing_assignment.html
@@ -9,7 +9,7 @@
 
 {% block breadcrumbs %}
     {{ block.super }}
-    {% include "elements/breadcrumbs/proofing_manager_base.html" %}
+    {% include "elements/breadcrumbs/proofing_manager_base.html" with subpage="yes" %}
     <li>#{{ proofing_task.pk }} - {{ proofing_task.proofreader.full_name }}</li>
 {% endblock breadcrumbs %}
 

--- a/src/templates/admin/proofing/notify_proofreader.html
+++ b/src/templates/admin/proofing/notify_proofreader.html
@@ -8,7 +8,7 @@
 
 {% block breadcrumbs %}
 {{ block.super }}
-{% include "elements/breadcrumbs/proofing_manager_base.html" %}
+{% include "elements/breadcrumbs/proofing_manager_base.html" with subpage="yes" %}
 <li>Notify Proofreader</li>
 {% endblock breadcrumbs %}
 

--- a/src/templates/admin/proofing/notify_typesetter_changes.html
+++ b/src/templates/admin/proofing/notify_typesetter_changes.html
@@ -6,10 +6,10 @@
 {% block admin-header %}Notify Typesetter{% endblock %}
 {% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.safe_title }}{% endblock %}
 
-{% block breadcrumbs %}
-{{ block.super }}
-{% include "elements/breadcrumbs/proofing_manager_base.html" %}
-<li>Notify Typesetter</li>
+{% block breadcrumbs %} 
+    {{ block.super }}
+    {% include "elements/breadcrumbs/proofing_manager_base.html" with subpage="yes" %}
+    <li>Notify Typesetter</li>
 {% endblock breadcrumbs %}
 
 {% block body %}

--- a/src/templates/admin/proofing/request_typesetting_changes.html
+++ b/src/templates/admin/proofing/request_typesetting_changes.html
@@ -12,7 +12,7 @@
 
 {% block breadcrumbs %}
     {{ block.super }}
-    {% include "elements/breadcrumbs/proofing_manager_base.html" %}
+    {% include "elements/breadcrumbs/proofing_manager_base.html" with subpage="yes" %}
     <li>Request Corrections</li>
 {% endblock breadcrumbs %}
 

--- a/src/templates/admin/proofing/typesetting/typesetting_corrections.html
+++ b/src/templates/admin/proofing/typesetting/typesetting_corrections.html
@@ -10,7 +10,8 @@
 
 {% block breadcrumbs %}
     {{ block.super }}
-    {% include "elements/breadcrumbs/proofreader_base.html" %}
+    {% include "elements/breadcrumbs/proofreader_base.html" with subpage="yes" %}
+    <li>Proofing Corrections</li>
 {% endblock breadcrumbs %}
 
 {% block body %}

--- a/src/templates/admin/review/add_files.html
+++ b/src/templates/admin/review/add_files.html
@@ -7,7 +7,7 @@
 
 {% block breadcrumbs %}
     {{ block.super }}
-    {% include "elements/breadcrumbs/review_base.html" %}
+    {% include "elements/breadcrumbs/review_base.html" with subpage="yes" %}
     <li>Add Files</li>
 {% endblock breadcrumbs %}
 

--- a/src/templates/admin/review/add_review_assignment.html
+++ b/src/templates/admin/review/add_review_assignment.html
@@ -6,7 +6,7 @@
 
 {% block breadcrumbs %}
     {{ block.super }}
-    {% include "elements/breadcrumbs/review_base.html" %}
+    {% include "elements/breadcrumbs/review_base.html" with subpage="yes" %}
     <li>Add Review Assignment</li>
 {% endblock breadcrumbs %}
 

--- a/src/templates/admin/review/decision.html
+++ b/src/templates/admin/review/decision.html
@@ -7,7 +7,7 @@
 
 {% block breadcrumbs %}
     {{ block.super }}
-    {% include "elements/breadcrumbs/review_base.html" %}
+    {% include "elements/breadcrumbs/review_base.html" with subpage="yes" %}
     <li>{{ decision|capfirst }} Article</li>
 {% endblock breadcrumbs %}
 

--- a/src/templates/admin/review/decision_helper.html
+++ b/src/templates/admin/review/decision_helper.html
@@ -9,7 +9,7 @@
 
 {% block breadcrumbs %}
     {{ block.super }}
-    {% include "elements/breadcrumbs/review_base.html" %}
+    {% include "elements/breadcrumbs/review_base.html" with subpage="yes" %}
     <li>#{{ article.pk }} Decision Helper</li>
 {% endblock breadcrumbs %}
 

--- a/src/templates/admin/review/delete_review.html
+++ b/src/templates/admin/review/delete_review.html
@@ -6,7 +6,7 @@
 
 {% block breadcrumbs %}
 {{ block.super }}
-{% include "elements/breadcrumbs/review_base.html" %}
+{% include "elements/breadcrumbs/review_base.html" with subpage="yes" %}
 <li>Delete Review</li>
 {% endblock breadcrumbs %}
 

--- a/src/templates/admin/review/delete_review_round.html
+++ b/src/templates/admin/review/delete_review_round.html
@@ -5,7 +5,7 @@
 
 {% block breadcrumbs %}
     {{ block.super }}
-    {% include "elements/breadcrumbs/review_base.html" %}
+    {% include "elements/breadcrumbs/review_base.html" with subpage="yes" %}
     <li>Delete Review Round</li>
 {% endblock breadcrumbs %}
 

--- a/src/templates/admin/review/draft_decision.html
+++ b/src/templates/admin/review/draft_decision.html
@@ -9,7 +9,7 @@
 
 {% block breadcrumbs %}
     {{ block.super }}
-    {% include "elements/breadcrumbs/review_base.html" %}
+    {% include "elements/breadcrumbs/review_base.html" with subpage="yes" %}
     <li><a href="{% url 'decision_helper' article.pk %}">Decision Helper</a></li>
     <li class="active">Draft a Decision</li>
 {% endblock breadcrumbs %}

--- a/src/templates/admin/review/edit_review.html
+++ b/src/templates/admin/review/edit_review.html
@@ -7,7 +7,7 @@
 
 {% block breadcrumbs %}
     {{ block.super }}
-    {% include "elements/breadcrumbs/review_base.html" %}
+    {% include "elements/breadcrumbs/review_base.html" with subpage="yes" %}
     <li>Edit Review</li>
 {% endblock breadcrumbs %}
 

--- a/src/templates/admin/review/edit_review_answer.html
+++ b/src/templates/admin/review/edit_review_answer.html
@@ -6,7 +6,7 @@
 
 {% block breadcrumbs %}
     {{ block.super }}
-    {% include "elements/breadcrumbs/review_base.html" %}
+    {% include "elements/breadcrumbs/review_base.html" with subpage="yes" %}
     <li>Edit Review Answer</li>
 {% endblock breadcrumbs %}
 

--- a/src/templates/admin/review/notify_reviewer.html
+++ b/src/templates/admin/review/notify_reviewer.html
@@ -13,7 +13,7 @@
 
 {% block breadcrumbs %}
     {{ block.super }}
-    {% include "elements/breadcrumbs/review_base.html" %}
+    {% include "elements/breadcrumbs/review_base.html" with subpage="yes" %}
     <li>Send Review Notification</li>
 {% endblock breadcrumbs %}
 

--- a/src/templates/admin/review/rate_reviewer.html
+++ b/src/templates/admin/review/rate_reviewer.html
@@ -6,7 +6,7 @@
 
 {% block breadcrumbs %}
     {{ block.super }}
-    {% include "elements/breadcrumbs/review_base.html" %}
+    {% include "elements/breadcrumbs/review_base.html" with subpage="yes" %}
     <li>Rate Reviewer</li>
 {% endblock breadcrumbs %}
 

--- a/src/templates/admin/review/reset.html
+++ b/src/templates/admin/review/reset.html
@@ -7,7 +7,7 @@
 
 {% block breadcrumbs %}
 {{ block.super }}
-{% include "elements/breadcrumbs/review_base.html" %}
+{% include "elements/breadcrumbs/review_base.html" with subpage="yes" %}
 <li>Reset Review</li>
 {% endblock breadcrumbs %}
 

--- a/src/templates/admin/review/review_warning.html
+++ b/src/templates/admin/review/review_warning.html
@@ -6,7 +6,7 @@
 
 {% block breadcrumbs %}
     {{ block.super }}
-    {% include "elements/breadcrumbs/review_base.html" %}
+    {% include "elements/breadcrumbs/review_base.html" with subpage="yes" %}
     <li>Review Warning</li>
 {% endblock breadcrumbs %}
 

--- a/src/templates/admin/review/revision/do_revision.html
+++ b/src/templates/admin/review/revision/do_revision.html
@@ -8,7 +8,7 @@
 
 {% block breadcrumbs %}
     {{ block.super }}
-    {% include "elements/breadcrumbs/review_base.html" %}
+    {% include "elements/breadcrumbs/review_base.html" with subpage="yes" %}
     <li>Revisions for {{ revision_request.article.safe_title }}</li>
 {% endblock breadcrumbs %}
 

--- a/src/templates/admin/review/revision/edit_revision_request.html
+++ b/src/templates/admin/review/revision/edit_revision_request.html
@@ -7,7 +7,7 @@
 
 {% block breadcrumbs %}
     {{ block.super }}
-    {% include "elements/breadcrumbs/review_base.html" %}
+    {% include "elements/breadcrumbs/review_base.html" with subpage="yes" %}
     <li>Edit Revision</li>
 {% endblock breadcrumbs %}
 

--- a/src/templates/admin/review/revision/replace_file.html
+++ b/src/templates/admin/review/revision/replace_file.html
@@ -7,7 +7,7 @@
 
 {% block breadcrumbs %}
     {{ block.super }}
-    {% include "elements/breadcrumbs/review_base.html" %}
+    {% include "elements/breadcrumbs/review_base.html" with subpage="yes" %}
     <li><a href="{% url 'do_revisions' revision_request.article.pk revision_request.pk %}">Revisions
         for {{ revision_request.article.safe_title }}</a></li>
     <li>Replace File</li>

--- a/src/templates/admin/review/revision/request_revisions.html
+++ b/src/templates/admin/review/revision/request_revisions.html
@@ -7,7 +7,7 @@
 
 {% block breadcrumbs %}
     {{ block.super }}
-    {% include "elements/breadcrumbs/review_base.html" %}
+    {% include "elements/breadcrumbs/review_base.html" with subpage="yes" %}
     <li>Request Revisions</li>
 {% endblock breadcrumbs %}
 

--- a/src/templates/admin/review/revision/request_revisions_notification.html
+++ b/src/templates/admin/review/revision/request_revisions_notification.html
@@ -8,8 +8,8 @@
 
 {% block breadcrumbs %}
 {{ block.super }}
-{% include "elements/breadcrumbs/review_base.html" %}
-<li>Request Revisions</li>
+    {% include "elements/breadcrumbs/review_base.html" with subpage="yes" %}
+    <li>Request Revisions</li>
 {% endblock breadcrumbs %}
 
 {% block body %}

--- a/src/templates/admin/review/revision/upload_file.html
+++ b/src/templates/admin/review/revision/upload_file.html
@@ -7,7 +7,7 @@
 
 {% block breadcrumbs %}
 {{ block.super }}
-{% include "elements/breadcrumbs/review_base.html" %}
+{% include "elements/breadcrumbs/review_base.html" with subpage="yes" %}
 <li><a href="{% url 'do_revisions' revision_request.article.pk revision_request.pk %}">Revisions for {{ revision_request.article.safe_title }}</a></li>
 <li>Replace File</li>
 {% endblock breadcrumbs %}

--- a/src/templates/admin/review/revision/view_revision.html
+++ b/src/templates/admin/review/revision/view_revision.html
@@ -7,9 +7,9 @@
 {% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.safe_title }}{% endblock %}
 
 {% block breadcrumbs %}
-{{ block.super }}
-{% include "elements/breadcrumbs/review_base.html" %}
-<li>Revision Request</li>
+    {{ block.super }}
+    {% include "elements/breadcrumbs/review_base.html" with subpage="yes" %}
+    <li>Revision Request</li>
 {% endblock breadcrumbs %}
 
 {% block body %}

--- a/src/templates/admin/review/send_review_reminder.html
+++ b/src/templates/admin/review/send_review_reminder.html
@@ -7,7 +7,7 @@
 
 {% block breadcrumbs %}
     {{ block.super }}
-    {% include "elements/breadcrumbs/review_base.html" %}
+    {% include "elements/breadcrumbs/review_base.html" with subpage="yes" %}
     <li>Review Reminders</li>
 {% endblock breadcrumbs %}
 

--- a/src/templates/admin/review/share/editor.html
+++ b/src/templates/admin/review/share/editor.html
@@ -9,7 +9,7 @@
 
 {% block breadcrumbs %}
     {{ block.super }}
-    {% include "elements/breadcrumbs/review_base.html" %}
+    {% include "elements/breadcrumbs/review_base.html" with subpage="yes" %}
     <li><a href="{% url 'decision_helper' article.pk %}">Decision Helper</a>
     </li>
     <li>Share Peer Reviews</li>

--- a/src/templates/admin/review/unassign_editor.html
+++ b/src/templates/admin/review/unassign_editor.html
@@ -7,7 +7,7 @@
 
 {% block breadcrumbs %}
     {{ block.super }}
-    {% include "elements/breadcrumbs/review_base.html" %}
+    {% include "elements/breadcrumbs/review_base.html" with subpage="yes" %}
     <li>Unassign Editor</li>
 {% endblock breadcrumbs %}
 

--- a/src/templates/admin/review/upload_reviewers_from_csv.html
+++ b/src/templates/admin/review/upload_reviewers_from_csv.html
@@ -9,7 +9,7 @@
 
 {% block breadcrumbs %}
     {{ block.super }}
-    {% include "elements/breadcrumbs/review_base.html" %}
+    {% include "elements/breadcrumbs/review_base.html" with subpage="yes" %}
     <li>Bulk Assign Reviewers</li>
 {% endblock breadcrumbs %}
 

--- a/src/templates/admin/review/view_review.html
+++ b/src/templates/admin/review/view_review.html
@@ -10,7 +10,7 @@
 
 {% block breadcrumbs %}
     {{ block.super }}
-    {% include "elements/breadcrumbs/review_base.html" %}
+    {% include "elements/breadcrumbs/review_base.html"%}
 {% endblock breadcrumbs %}
 
 {% block body %}

--- a/src/templates/admin/review/view_review.html
+++ b/src/templates/admin/review/view_review.html
@@ -10,7 +10,7 @@
 
 {% block breadcrumbs %}
     {{ block.super }}
-    {% include "elements/breadcrumbs/review_base.html"%}
+    {% include "elements/breadcrumbs/review_base.html" %}
 {% endblock breadcrumbs %}
 
 {% block body %}

--- a/src/templates/admin/review/withdraw_review.html
+++ b/src/templates/admin/review/withdraw_review.html
@@ -7,7 +7,7 @@
 
 {% block breadcrumbs %}
     {{ block.super }}
-    {% include "elements/breadcrumbs/review_base.html" %}
+    {% include "elements/breadcrumbs/review_base.html" with subpage="yes" %}
     <li>Withdraw Review Request</li>
 {% endblock breadcrumbs %}
 

--- a/src/templates/admin/submission/manager/configurator.html
+++ b/src/templates/admin/submission/manager/configurator.html
@@ -9,7 +9,7 @@
 {% block breadcrumbs %}
     {{ block.super }}
     <li><a href="{% url 'core_manager_index' %}">Manager</a></li>
-    <li><a href="{% url 'submission_configurator' %}">Submission Configurator</a></li>
+    <li>Submission Configurator</li>
 {% endblock %}
 
 {% block body %}

--- a/src/templates/admin/submission/manager/delete_license.html
+++ b/src/templates/admin/submission/manager/delete_license.html
@@ -10,9 +10,12 @@
 {% block breadcrumbs %}
     {{ block.super }}
     <li><a href="{% url 'core_manager_index' %}">Manager</a></li>
-    <li><a href="{% url 'submission_licenses' %}">Licences</a></li>
     {% if license %}
-        <li><a href="{% url 'submission_licenses_id' license.pk %}">{{ license.name }}</a></li>{% endif %}
+        <li><a href="{% url 'submission_licenses' %}">Licences</a></li>
+        <li>Delete {{ license.name }}</li>
+    {% else %}
+        <li>Licences</li>
+    {% endif %}
 {% endblock %}
 
 {% block body %}

--- a/src/templates/admin/submission/manager/delete_license.html
+++ b/src/templates/admin/submission/manager/delete_license.html
@@ -10,9 +10,8 @@
 {% block breadcrumbs %}
     {{ block.super }}
     <li><a href="{% url 'core_manager_index' %}">Manager</a></li>
-    <li><a href="{% url 'submission_licenses' %}">Licences</a></li>
-    <li>Delete {{ license.name }}</li>
-    {% endif %}
+        <li><a href="{% url 'submission_licenses' %}">Licences</a></li>
+        <li>Delete {{ license.name }}</li>
 {% endblock %}
 
 {% block body %}

--- a/src/templates/admin/submission/manager/delete_license.html
+++ b/src/templates/admin/submission/manager/delete_license.html
@@ -10,11 +10,8 @@
 {% block breadcrumbs %}
     {{ block.super }}
     <li><a href="{% url 'core_manager_index' %}">Manager</a></li>
-    {% if license %}
-        <li><a href="{% url 'submission_licenses' %}">Licences</a></li>
-        <li>Delete {{ license.name }}</li>
-    {% else %}
-        <li>Licences</li>
+    <li><a href="{% url 'submission_licenses' %}">Licences</a></li>
+    <li>Delete {{ license.name }}</li>
     {% endif %}
 {% endblock %}
 

--- a/src/templates/admin/submission/manager/fields.html
+++ b/src/templates/admin/submission/manager/fields.html
@@ -9,8 +9,12 @@
 {% block breadcrumbs %}
     {{ block.super }}
     <li><a href="{% url 'core_manager_index' %}">Manager</a></li>
-    <li><a href="{% url 'submission_fields' %}">Submission Fields</a></li>
-    {% if field %}<li><a href="{% url 'submission_fields_id' field.pk %}">{{ field.name }}</a></li>{% endif %}
+    {% if field %}
+        <li><a href="{% url 'submission_fields' %}">Submission Fields</a></li>
+        <li>Edit {{ field.name }}</li>
+    {% else %}
+        <li>Submission Fields</li>
+    {% endif %}
 {% endblock %}
 
 {% block body %}

--- a/src/templates/admin/submission/manager/licenses.html
+++ b/src/templates/admin/submission/manager/licenses.html
@@ -9,8 +9,12 @@
 {% block breadcrumbs %}
     {{ block.super }}
     <li><a href="{% url 'core_manager_index' %}">Manager</a></li>
-    <li><a href="{% url 'submission_licenses' %}">Licences</a></li>
-    {% if license %}<li><a href="{% url 'submission_licenses_id' license.pk %}">{{ license.name }}</a></li>{% endif %}
+    {% if license %}
+        <li><a href="{% url 'submission_licenses' %}">Licences</a></li>
+        <li>Edit {{ license.name }}</li>
+    {% else %}
+        <li>Licences</li>
+    {% endif %}
 {% endblock %}
 
 {% block body %}


### PR DESCRIPTION
I have worked through the known areas of this issue one directory at a time, and each has its own commit on this branch.  Then there will be a final commit coming which tidies up any typos and trailing </a> tags that were missed.

The breadcrumbs have been implemented in three different ways - 
1. some were fully within the template itself, 
2. some used an include to a breadcrumb template within elements/breadcrumbs, 
3. and some used the include while listing the current page after it within the main template.

This fix was about making sure that final item in the list was not a link.

For 1.  there was a simple fix of removing the `<a>` tags from the final item.

For 2 and 3, Where an include was used, it needed to work for templates that only used the include, and those which had a final line in the template - i.e. sometimes return a list of links, and sometimes a list where the last item was not a link.  some of the time the problem was within the include, and then within the same section there might be some templates which used the include and then listed the current page with or without <a> tags in the main template.  Fixing this across each section required the some includes to be updated and some of the main templates, and some templates then worked without modification due to the updated includes.  Where there was a subpage listed within the main template, I have updated the includes with the suffix `with subpage="Yes"`so that the include can then display all items as links.

This is mostly done, but given how many changes were made, I will now review the changes on github so that I can check for any typos or trailing `</a>` that have not been caught already.


