### PR TITLE
#3906 un-nest labels and inputs in themes

### DIFF
--- a/src/themes/OLH/templates/elements/journal/article_filter_form.html
+++ b/src/themes/OLH/templates/elements/journal/article_filter_form.html
@@ -23,7 +23,6 @@
         </label>
     </div>
     <div class="section">
-        Hi there
         <label>{% trans "Filter" %}</label>
         {% for section in sections %}
             <input id="section-{{ section.id }}"

--- a/src/themes/OLH/templates/elements/journal/article_filter_form.html
+++ b/src/themes/OLH/templates/elements/journal/article_filter_form.html
@@ -23,13 +23,15 @@
         </label>
     </div>
     <div class="section">
+        Hi there
         <label>{% trans "Filter" %}</label>
         {% for section in sections %}
-            <label for="section-{{ section.id }}"><input id="section-{{ section.id }}"
-                                                         value="{{ section.id }}" type="checkbox"
-                                                         name="filter[]"
-                                                         {% if section.id in filters %}checked="checked"{% endif %}>{{ section.name }}
-            </label>
+            <input id="section-{{ section.id }}"
+                value="{{ section.id }}" 
+                type="checkbox"
+                name="filter[]"
+                {% if section.id in filters %} checked="checked" {% endif %}>
+            <label for="section-{{ section.id }}">{{ section.name }}</label>
         {% endfor %}
         <button type="submit" class="button">{% trans "Filter" %}</button>
         {% if active_filters %}

--- a/src/themes/clean/templates/journal/articles.html
+++ b/src/themes/clean/templates/journal/articles.html
@@ -70,11 +70,12 @@
                             <fieldset>
                                 <legend>Section Filters</legend>
                             {% for section in sections %}
-                                <label for="section-{{ section.id }}"><input id="section-{{ section.id }}"
-                                                                             value="{{ section.id }}" type="checkbox"
-                                                                             name="filter[]"
-                                                                             {% if section.id in filters %}checked="checked"{% endif %}>&nbsp{{ section.name }}
-                                </label><br/>
+                                <input id="section-{{ section.id }}"
+                                    value="{{ section.id }}" type="checkbox"
+                                    name="filter[]"
+                                    {% if section.id in filters %}checked="checked"{% endif %}>
+                                <label for="section-{{ section.id }}">&nbsp{{ section.name }}</label>
+                                <br/>
                             {% endfor %}
                             </fieldset>
                             <br/>


### PR DESCRIPTION
all file search for labels which nested their input and only two were found, both in theme templates marked as depreciated in 1.5.1.

Labels elsewhere looked un-nested, and hence avoiding this issue.

Closes #3906 