### PR TITLE
Make journal sorting more reliable

### DIFF
--- a/src/press/models.py
+++ b/src/press/models.py
@@ -349,7 +349,8 @@ class Press(AbstractSiteModel):
         Journal = apps.get_model('journal.Journal')
         return Journal.objects.filter(
             hide_from_press=False,
-        )
+            is_conference=False,
+        ).order_by('sequence')
 
     @property
     def published_articles(self):

--- a/src/press/views.py
+++ b/src/press/views.py
@@ -123,12 +123,9 @@ def journals(request):
 
     template = "press/press_journals.html"
 
-    journal_objects = journal_models.Journal.objects.filter(
-            hide_from_press=False,
-            is_conference=False,
-    ).order_by('sequence')
-
-    context = {'journals': journal_objects}
+    context = {
+        'journals': request.press.public_journals,
+    }
 
     return render(request, template, context)
 


### PR DESCRIPTION
Completes #3707.

The new `public_journals` method did not take `sequence` into account. This PR updates the method and uses it for the `journals` view, avoiding repetition of logic.