### PR TITLE
Stops multiple galley image files with the same name from being loaded in the edit galley interface.

### DIFF
--- a/src/journal/views.py
+++ b/src/journal/views.py
@@ -932,7 +932,7 @@ def identifier_figure(request, identifier_type, identifier, file_name):
     if not galley:
         raise Http404
 
-    # Use a filter with .first() here to avoid an error when two images with
+    # Use a filter with .latest() here to avoid an error when two images with
     # the same name are present.
     figure = galley.images.filter(
         original_filename=file_name

--- a/src/journal/views.py
+++ b/src/journal/views.py
@@ -932,7 +932,16 @@ def identifier_figure(request, identifier_type, identifier, file_name):
     if not galley:
         raise Http404
 
-    figure = get_object_or_404(galley.images, original_filename=file_name)
+    # Use a filter with .first() here to avoid an error when two images with
+    # the same name are present.
+    figure = galley.images.filter(
+        original_filename=file_name
+    ).latest(
+        'last_modified',
+    )
+
+    if not figure:
+        raise Http404
 
     return files.serve_file(request, figure, figure_article)
 

--- a/src/journal/views.py
+++ b/src/journal/views.py
@@ -932,13 +932,13 @@ def identifier_figure(request, identifier_type, identifier, file_name):
     if not galley:
         raise Http404
 
-    # Use a filter with .latest() here to avoid an error when two images with
+    # Use a filter with .first() here to avoid an error when two images with
     # the same name are present.
     figure = galley.images.filter(
         original_filename=file_name
-    ).latest(
-        'last_modified',
-    )
+    ).order_by(
+        '-last_modified',
+    ).first()
 
     if not figure:
         raise Http404
@@ -955,9 +955,25 @@ def article_figure(request, article_id, galley_id, file_name):
     :param file_name: an File object name
     :return: a streaming file response or a 404 if not found
     """
-    figure_article = get_object_or_404(submission_models.Article, pk=article_id)
-    galley = get_object_or_404(core_models.Galley, pk=galley_id, article=figure_article)
-    figure = get_object_or_404(galley.images, original_filename=file_name)
+    figure_article = get_object_or_404(
+        submission_models.Article,
+        pk=article_id,
+    )
+    galley = get_object_or_404(
+        core_models.Galley,
+        pk=galley_id,
+        article=figure_article,
+    )
+    # Use a filter with .first() here to avoid an error when two images with
+    # the same name are present.
+    figure = galley.images.filter(
+        original_filename=file_name
+    ).order_by(
+        '-last_modified',
+    ).first()
+
+    if not figure:
+        raise Http404
 
     return files.serve_file(request, figure, figure_article)
 

--- a/src/production/logic.py
+++ b/src/production/logic.py
@@ -203,8 +203,8 @@ def save_galley_image(
             messages.add_message(
                 request,
                 messages.WARNING,
-                'The file you uploaded does not match the mime of the '
-                'file expected.',
+                f'The file you uploaded does not have the expected '
+                f'type: { expected_mime }.'
             )
 
     new_file = files.save_file_to_article(uploaded_file, galley.article, request.user)

--- a/src/production/logic.py
+++ b/src/production/logic.py
@@ -179,7 +179,7 @@ def save_galley_image(
         uploaded_file,
         label="Galley Image",
         fixed=False,
-        check_for_existing_images=False
+        check_for_existing_images=False,
 ):
     filename = uploaded_file.name
     # Check if an image with this name already exists for this galley.

--- a/src/production/views.py
+++ b/src/production/views.py
@@ -917,6 +917,7 @@ def edit_galley(request, galley_id, typeset_id=None, article_id=None):
                     uploaded_file,
                     label,
                     fixed=True,
+                    check_for_existing_images=True,
                 )
 
         if 'image-upload' in request.POST:
@@ -927,6 +928,7 @@ def edit_galley(request, galley_id, typeset_id=None, article_id=None):
                     uploaded_file,
                     label,
                     fixed=False,
+                    check_for_existing_images=True,
                 )
 
         elif 'css-upload' in request.POST:


### PR DESCRIPTION
This closes #3979 

The implementation includes two prongs:

`save_galley_image` now takes `check_for_existing_images` which defaults to `False`. When set to `True` the function will check if the image exists and if its found return `None`. Existing calls are protected.

In addition, I've updated the Typesetting Plugin view to use the new kwarg: https://github.com/BirkbeckCTP/typesetting/pull/204