### PR TITLE
#3657 removed the repository metrics summary from the dashbaord page, now available in the reporting plugin

### DIFF
--- a/src/repository/logic.py
+++ b/src/repository/logic.py
@@ -1,6 +1,6 @@
 from dateutil.relativedelta import relativedelta
 from user_agents import parse as parse_ua_string
-from datetime import timedelta
+from datetime import datetime, timedelta
 from collections import Counter
 
 from django.utils import timezone
@@ -13,16 +13,16 @@ from django.db.models import (
     OuterRef,
     Subquery,
     Value,
+    Count,
 )
 from django.db.models.functions import Concat
-from django.forms import formset_factory
 
 from production.logic import save_galley
 from core import models as core_models, files
 from utils import render_template, shared
 from utils.function_cache import cache
 from events import logic as event_logic
-from repository import models, forms
+from repository import models
 from metrics.logic import get_iso_country_code, iso_to_country_object
 
 
@@ -33,50 +33,6 @@ def get_month_day_range(date):
     last_day = date + relativedelta(day=1, months=+1, days=-1)
     first_day = date + relativedelta(day=1)
     return first_day, last_day
-
-
-def metrics_summary(published_preprints):
-    """
-    Fetches view counts for a month and year.
-    :param published_preprints: preprint queryset
-    :return: dictionary with access results
-    """
-    first_this_month, last_this_month = get_month_day_range(timezone.now())
-    last_month_date = timezone.now() - relativedelta(months=1)
-    first_last_month, last_last_month = get_month_day_range(last_month_date)
-
-    total_accesses_this_month = models.PreprintAccess.objects.filter(
-        accessed__gte=first_this_month,
-        accessed__lte=last_this_month,
-        preprint__in=published_preprints,
-    )
-
-    total_accesses_last_month = models.PreprintAccess.objects.filter(
-        accessed__gte=first_last_month,
-        accessed__lte=last_last_month,
-        preprint__in=published_preprints,
-    )
-
-    views_this_month = total_accesses_this_month.filter(
-        file__isnull=True,
-    ).count()
-    views_last_month = total_accesses_last_month.filter(
-        file__isnull=True,
-    ).count()
-    downloads_this_month = total_accesses_this_month.filter(
-        file__isnull=False,
-    ).count()
-    downloads_last_month = total_accesses_last_month.filter(
-        file__isnull=False,
-    ).count()
-
-
-    return {
-        'views_this_month': views_this_month,
-        'views_last_month': views_last_month,
-        'downloads_this_month': downloads_this_month,
-        'downloads_last_month': downloads_last_month,
-    }
 
 
 def handle_file_upload(request, preprint):

--- a/src/repository/views.py
+++ b/src/repository/views.py
@@ -4,6 +4,8 @@ __license__ = "AGPL v3"
 __maintainer__ = "Birkbeck Centre for Technology and Publishing"
 
 import operator
+from dateutil.relativedelta import relativedelta
+from datetime import datetime
 
 from django.shortcuts import render, redirect, get_object_or_404
 from django.utils import timezone
@@ -827,8 +829,7 @@ def preprints_manager(request):
         date_declined__isnull=False,
         repository=request.repository,
     )
-    metrics_summary = repository_logic.metrics_summary(published_preprints)
-    versisons = models.VersionQueue.objects.filter(
+    versions = models.VersionQueue.objects.filter(
         date_decision__isnull=True,
         preprint__repository=request.repository,
     )
@@ -843,8 +844,7 @@ def preprints_manager(request):
         'published_preprints': published_preprints,
         'incomplete_preprints': incomplete_preprints,
         'rejected_preprints': rejected_preprints,
-        'version_queue': versisons,
-        'metrics_summary': metrics_summary,
+        'version_queue': versions,
         'subjects': subjects,
     }
 

--- a/src/templates/admin/repository/manager.html
+++ b/src/templates/admin/repository/manager.html
@@ -116,68 +116,11 @@
                 </div>
             </div>
         </div>
-
-    <div class="large-12 columns">
-            <div class="box">
-                <div class="title-area">
-                    <h2>Metrics Summary</h2>
-                </div>
-                <div class="content">
-                    <canvas id="metrics_chart" width="400" height="400"></canvas>
-                </div>
-            </div>
-        </div>
-
-
     </div>
 
 {% endblock %}
 
-{% cache 600 metrics request.repository.id %}
-
 {% block js %}
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.7.0/Chart.min.js"></script>
-    <script>
-        var ctx = document.getElementById("metrics_chart");
-        var myChart = new Chart(ctx, {
-            type: 'bar',
-            data: {
-                labels: ["Views this Month", "Downloads this Month", "Views Last Month", "Downloads Last Month"],
-                datasets: [{
-                    label: 'Preprint Accesses',
-                    data: [{{ metrics_summary.views_this_month }}, {{ metrics_summary.downloads_this_month }}, {{ metrics_summary.views_last_month }}, {{ metrics_summary.downloads_last_monnth }}],
-                    backgroundColor: [
-                        'rgba(255, 99, 132, 0.2)',
-                        'rgba(75, 192, 192, 0.2)',
-                        'rgba(255, 99, 132, 0.2)',
-                        'rgba(75, 192, 192, 0.2)',
-                        'rgba(153, 102, 255, 0.2)',
-                        'rgba(255, 159, 64, 0.2)'
-                    ],
-                    borderColor: [
-                        'rgba(255,99,132,1)',
-                        'rgba(75, 192, 192, 1)',
-                        'rgba(255,99,132,1)',
-                        'rgba(75, 192, 192, 1)',
-                        'rgba(153, 102, 255, 1)',
-                        'rgba(255, 159, 64, 1)'
-                    ],
-                    borderWidth: 1
-                }]
-            },
-            options: {
-                maintainAspectRatio: false,
-                scales: {
-                    yAxes: [{
-                        ticks: {
-                            beginAtZero: true
-                        }
-                    }]
-                }
-            }
-        });
-    </script>
     {% include "elements/datatables.html" with target="#unpub" page_length=10 sort=1 order='desc' %}
     {% include "elements/datatables.html" with target="#pubd" page_length=10 sort=2 order='desc' %}
 {% endblock %}
-{% endcache %}


### PR DESCRIPTION
This PR closes #3657 

- This PR removes the summary from the dashboard page.
- A report has been added in its place: ttps://github.com/BirkbeckCTP/reporting/pull/37/