### PR TITLE
Fixed an issue where bounced email notifications failed with an error due to not being linked to a journal or repository

### DIFF
--- a/src/utils/logic.py
+++ b/src/utils/logic.py
@@ -95,25 +95,28 @@ def send_bounce_notification_to_event_actor(event):
             request.site_type = target.repository
             request.repository = target.repository
 
-    # Setup log dict
-    log_dict = {
-        'level': 'Info',
-        'action_text': 'Email Delivery Failed ',
-        'types': 'Email Delivery',
-        'target': target,
-    }
-
-    notify_helpers.send_email_with_body_from_setting_template(
-        request=request,
-        template='bounced_email_notification',
-        subject='subject_bounced_email_notification',
-        to=to,
-        context={
+    # currently this feature is set up for article and preprint emails.
+    # if no site type is set, we shouldn't try to send a bounce email.
+    if request.site_type:
+        # Setup log dict
+        log_dict = {
+            'level': 'Info',
+            'action_text': 'Email Delivery Failed ',
+            'types': 'Email Delivery',
             'target': target,
-            'event': event,
-        },
-        log_dict=log_dict,
-    )
+        }
+
+        notify_helpers.send_email_with_body_from_setting_template(
+            request=request,
+            template='bounced_email_notification',
+            subject='subject_bounced_email_notification',
+            to=to,
+            context={
+                'target': target,
+                'event': event,
+            },
+            log_dict=log_dict,
+        )
 
 
 def build_url_for_request(request=None, path="", query=None, fragment=""):


### PR DESCRIPTION
This feature is only supposed to fire when the target is an Article or Preprint, this PR makes sure that it only fires when one of those sets the request.site_type.

Closes #3992 