### PR TITLE
Call get_setting with setting.name

### DIFF
--- a/src/utils/setting_handler.py
+++ b/src/utils/setting_handler.py
@@ -91,6 +91,13 @@ def get_setting(
     :default: If True, returns the default SettingValue when no journal specific
         value is present
     """
+    if not isinstance(setting_name, str):
+        import inspect
+        callee = inspect.stack()[1]
+        logger.warning(
+            f"utils.get_setting called by {callee.function}::{callee.lineno}"
+            f" with setting_name {str(setting_name)}",
+        )
     try:
         setting = core_models.Setting.objects.get(
             name=setting_name,
@@ -120,7 +127,7 @@ def get_setting(
                     journal = None
                     return get_setting(
                         setting_group_name,
-                        setting,
+                        setting.name,
                         journal,
                         create,
                     )
@@ -230,7 +237,7 @@ def get_email_subject_setting(
 ):
     try:
         setting = core_models.Setting.objects.get(name=setting_name)
-        return get_setting(setting_group, setting, journal, create=False, default=True).value
+        return get_setting(setting_group, setting.name, journal, create=False, default=True).value
     except (core_models.Setting.DoesNotExist, AttributeError):
         return setting_name
 


### PR DESCRIPTION
Sometimes the function `utils.settings_handler.get_setting()` is called with a wrong argument.

The function expects a string as second argument (`setting_name`), but here and there it is called with a `core.Setting` object instead. I think that everything works fine anyway because `str(Setting)` is `Setting.name`, but I thought I should mention :slightly_smiling_face: 

Here I fix a couple of calls, and I add (temporary) code to report if someone is calling with non-str argument.