### PR TITLE
Removed django countries from the master branch

### DIFF
--- a/src/core/janeway_global_settings.py
+++ b/src/core/janeway_global_settings.py
@@ -91,7 +91,6 @@ INSTALLED_APPS = [
 
     # 3rd Party
     'mozilla_django_oidc',
-    'django_countries',
     'django_summernote',
     'bootstrap4',
     'rest_framework',


### PR DESCRIPTION
This PR removes django countries which is causing fresh installs of Janeway on master to break.