### PR TITLE
Adds a new setting to conceal the editor details when an author is viewing their article's metadata.

### DIFF
--- a/src/core/logic.py
+++ b/src/core/logic.py
@@ -317,6 +317,13 @@ def get_settings_to_edit(display_group, journal, user):
                     'general',
                     'data_figure_file_submission_instructions', journal
                 ),
+            },
+            {
+                'name': 'hide_editors_from_authors',
+                'object': setting_handler.get_setting(
+                    'general',
+                    'hide_editors_from_authors', journal
+                ),
             }
         ]
         setting_group = 'general'

--- a/src/templates/admin/elements/forms/group_submission.html
+++ b/src/templates/admin/elements/forms/group_submission.html
@@ -22,7 +22,7 @@
 </div>
 
 {% include "admin/elements/forms/table_multi_select_user.html" with field=edit_form.editors_for_notification queryset=request.journal.editors %}
-
+{% include "admin/elements/forms/field.html" with field=edit_form.hide_editors_from_authors %}
 <div class="title-area">
     <h2>System Settings</h2>
 </div>

--- a/src/templates/admin/elements/metadata.html
+++ b/src/templates/admin/elements/metadata.html
@@ -185,6 +185,8 @@
     </table>
 {% endif %}
 
+
+{% if user_is_editor or not journal_settings.general.hide_editors_from_authors %}
 <div class="title-area">
     <h2>Editors</h2>
 </div>
@@ -206,6 +208,7 @@
         </tr>
     {% endfor %}
 </table>
+{% endif %}
 
 <div class="title-area">
     <h2>Projected Issue</h2>

--- a/src/templates/admin/elements/metadata.html
+++ b/src/templates/admin/elements/metadata.html
@@ -191,7 +191,7 @@
     <h2>Editors</h2>
 </div>
 {% if user_is_editor and journal_settings.general.hide_editors_from_authors %}
-    <p>The <a href="{% url 'core_edit_setting' 'general' 'hide_editors_from_authors' %}">hide editors from authors</a> setting is enabled. Whilst editors can see this section, authors cannot.</p>
+    <p>The setting to <a href="{% url 'core_edit_setting' 'general' 'hide_editors_from_authors' %}">hide editor details from authors</a> is turned on. Editors can view this section, but authors cannot.</p>
 {% endif %}
 <table id="unassigned" class="scroll small">
     <tr style="text-align: left">

--- a/src/templates/admin/elements/metadata.html
+++ b/src/templates/admin/elements/metadata.html
@@ -190,6 +190,9 @@
 <div class="title-area">
     <h2>Editors</h2>
 </div>
+{% if user_is_editor and journal_settings.general.hide_editors_from_authors %}
+    <p>The <a href="{% url 'core_edit_setting' 'general' 'hide_editors_from_authors' %}">hide editors from authors</a> setting is enabled. Whilst editors can see this section, authors cannot.</p>
+{% endif %}
 <table id="unassigned" class="scroll small">
     <tr style="text-align: left">
         <th>Name</th>

--- a/src/utils/install/journal_defaults.json
+++ b/src/utils/install/journal_defaults.json
@@ -5045,5 +5045,24 @@
         "editable_by": [
             "journal-manager"
         ]
+    },
+    {
+        "group": {
+            "name": "general"
+        },
+        "setting": {
+            "description": "Removes the editor section from the author's article status page. This does not stop editors from identifying themselves when, for example, rejecting an article if using an account with their name associated.",
+            "is_translatable": false,
+            "name": "hide_editors_from_authors",
+            "pretty_name": "Hide Assigned Editor Details",
+            "type": "boolean"
+        },
+        "value": {
+            "default": ""
+        },
+        "editable_by": [
+            "editor",
+            "journal-manager"
+        ]
     }
 ]


### PR DESCRIPTION
I believe this solution covers most of the request in #3738, as Phillipa is talking about the editors section of the article metadata page. However, in discussion with @mauromsl we noted that an editor may still reveal themselves when rejecting a paper as their email address will be used in the reply-to section.

There is some discussion to be had about how we approach this, do we want to enable the anonymous rejection of papers easily? The public display of an editorial board means that either way this is only partially anonymous as an author will be aware of who the editors are generally.

Personally I think this solution is enough, as editor should be accountable for article decisions, if editors _do_ want to circumvent the reply-to setup they could make use of a generic account to desk reject papers. Open to thoughts on this one. I've assigned everyone as a review so we can chip in our two cents.

Potentially closes #3738 

For clarification this page is accessed by authors from the Dashboard (Dashboard > Active Articles > View Status) screenshots with and without edutor details below.

Without editor details:
<img width="869" alt="Screenshot 2024-03-12 at 17 17 05" src="https://github.com/BirkbeckCTP/janeway/assets/8321378/ba79f249-8465-4eb6-af22-a090fdfc0407">

With editor details:
<img width="877" alt="Screenshot 2024-03-12 at 17 16 51" src="https://github.com/BirkbeckCTP/janeway/assets/8321378/f068b85a-b71f-4c4a-b148-bb1e3688a8b1">
