### PR TITLE
Fixes an issue where multiple jump links appear in an article's workflow nav when it has been moved through the workflow in a non linear fashion

### DIFF
--- a/src/submission/models.py
+++ b/src/submission/models.py
@@ -1680,14 +1680,8 @@ class Article(AbstractLastModifiedModel):
         return core_models.WorkflowLog.objects.filter(article=self)
 
     def distinct_workflow_elements(self):
-        workflow_element_ids = core_models.WorkflowLog.objects.filter(
-            article=self,
-        ).values_list(
-            'element'
-        ).distinct()
-
         return core_models.WorkflowElement.objects.filter(
-            pk__in=[element_id[0] for element_id in workflow_element_ids]
+            pk__in=self.workflowlog_set.values_list("element").distinct()
         )
 
     @property

--- a/src/submission/models.py
+++ b/src/submission/models.py
@@ -1679,6 +1679,17 @@ class Article(AbstractLastModifiedModel):
     def workflow_stages(self):
         return core_models.WorkflowLog.objects.filter(article=self)
 
+    def distinct_workflow_elements(self):
+        workflow_element_ids = core_models.WorkflowLog.objects.filter(
+            article=self,
+        ).values_list(
+            'element'
+        ).distinct()
+
+        return core_models.WorkflowElement.objects.filter(
+            pk__in=[element_id[0] for element_id in workflow_element_ids]
+        )
+
     @property
     def current_workflow_element(self):
         try:

--- a/src/templates/admin/elements/article_jump.html
+++ b/src/templates/admin/elements/article_jump.html
@@ -6,10 +6,9 @@
 {% if editor or section_editor %}
     <div class="small expanded button-group">
         <a class="button" href="{% url 'review_unassigned_article' article.pk %}">Editor Assignment</a>
-        {% for stage in article.workflow_stages %}
-
-            <a class="button{% if stage.element.element_name == 'review' and article.stage == 'Unassigned' %} disabled{% endif %}"
-               href="{% url stage.element.jump_url article.pk %}">{{ stage.element.element_name|capfirst }}</a>
+        {% for element in article.distinct_workflow_elements %}
+            <a class="button{% if element.element_name == 'review' and article.stage == 'Unassigned' %} disabled{% endif %}"
+               href="{% url element.jump_url article.pk %}">{{ element.element_name|capfirst }}</a>
         {% endfor %}
         <button class="button" type="button" data-toggle="more-dropdown">Logs, Documents and More</button>
 


### PR DESCRIPTION
As `workflow_stages` is used elsewhere I've opted to add a new method that explicitly returns distinct `WorkflowElements`. This will also reduce the number of queries run as the template will no longer be fetching related items.

Closes #3593 