### PR TITLE
Correct display of author last names on Clean theme

### DIFF
--- a/src/themes/clean/templates/journal/article.html
+++ b/src/themes/clean/templates/journal/article.html
@@ -3,7 +3,7 @@
 {% load hooks %}
 {% load i18n %}
 
-{% block title %}{{ article.authors.all.0.last_name | striptags }} | {{ article.title | striptags }} |
+{% block title %}{{ article.frozen_authors.all.0.last_name | striptags }} | {{ article.title | striptags }} |
     {{ journal_settings.general.journal_name | striptags }} {% endblock %}
 
 {% block head %}


### PR DESCRIPTION
Spotted this on AUP who are using clean as their base theme. This now matches OLH and Material.

The clean theme will now correctly display the first frozen author's name in the article page's title.

Closes #4030 