### PR TITLE
Added support for clearing fromatting from pasted inputs onto the user page data

### DIFF
--- a/src/templates/common/elements/edit_profile_js_block.html
+++ b/src/templates/common/elements/edit_profile_js_block.html
@@ -10,4 +10,9 @@
             {allowSpaces: true});
     });
 </script>
-{% include "elements/jqte.html" %}
+{% if settings.DEBUG %}
+<script src="{% static "common/js/tinymce/tinymce.js" %}"></script>
+{% else %}
+<script src="{% static "common/js/tinymce/tinymce.min.js" %}"></script>
+{% endif %}
+<script src="{% static "django_tinymce/init_tinymce.js" %}"></script>

--- a/src/themes/clean/templates/core/accounts/edit_profile.html
+++ b/src/themes/clean/templates/core/accounts/edit_profile.html
@@ -13,14 +13,5 @@
 {% endblock body %}
 
 {% block js %}
-<link rel="stylesheet" href="https://code.jquery.com/ui/1.11.0/themes/smoothness/jquery-ui.css">
-<script type="text/javascript" src="{% static "common/js/jq-ui.min.js" %}"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/tag-it/2.0/js/tag-it.js"></script>
-
-<script type="text/javascript">
-    $(document).ready(function () {
-        $("#id_interests").tagit(
-            {allowSpaces: true});
-    });
-</script>
+    {% include "common/elements/edit_profile_js_block.html" %}
 {% endblock %}


### PR DESCRIPTION
following #3983 , This PR adds support for the same feature on all three themes edit profile page.

Note: Clean theme was not making use of `edit_profile_js_block.html` and was instead using the same code in the `edit_profile.html` template, so this PR brings that theme inline with the others