### PR TITLE
Fixes additional whitespace being added after italics and bold to HTML galleys 

### DIFF
--- a/src/production/logic.py
+++ b/src/production/logic.py
@@ -162,7 +162,7 @@ def remove_css_from_html(source_html):
     for tag in soup():
           del tag["style"]
 
-    return soup.prettify()
+    return str(soup)
 
 
 def replace_galley_file(article, request, galley, uploaded_file):


### PR DESCRIPTION
closes BirkbeckCTP/pandoc_plugin#17
closes #3609
Fixes an issue originally reported on pandoc plugin where prettifying any loaded HTML galleys would lead to newline characters to be injected after every tag. As a result, when a formatting tag such as `<em>` or `<strong>` was followed by punctuation marks, an unwanted whitespace character was being rendered