### PR TITLE
Rich text editor now supports escape to close the full screen view

### DIFF
--- a/src/core/janeway_global_settings.py
+++ b/src/core/janeway_global_settings.py
@@ -670,7 +670,8 @@ TINYMCE_COMPRESSOR = False
 TINYMCE_DEFAULT_CONFIG = {
     "width": "100%",
     "min-height": "300px",
-    "resize": "height",
+    "resize": True,
+    "fullscreen_native": True,
     "promotion": False,
     "branding": False,
     "menubar": "edit view insert format tools table help",


### PR DESCRIPTION
closes #4034 
closes #4035 

Configures our default TinyMCE editor to use the browser native API for full screen. Allows using Esc for closing full screen natively, regardless of keybinds on TinyMCE