### PR TITLE
use timezone when recording date_published at preprint acceptance

### DIFF
--- a/src/repository/models.py
+++ b/src/repository/models.py
@@ -642,25 +642,15 @@ class Preprint(models.Model):
             version=self.next_version_number(),
         )
 
-    def update_date_published(self, date, time):
-        self.date_published = dateparser.parse(
-            '{date} {time}'.format(
-                date=date,
-                time=time,
-            )
-        )
+    def update_date_published(self, date_published):
+        self.date_published = date_published
         self.save()
 
-    def accept(self, date, time):
+    def accept(self, date_published):
         self.date_accepted = timezone.now()
         self.date_declined = None
         self.stage = STAGE_PREPRINT_PUBLISHED
-        self.date_published = dateparser.parse(
-            '{date} {time}'.format(
-                date=date,
-                time=time,
-            )
-        )
+        self.date_published = date_published
         self.save()
 
     def decline(self, note):

--- a/src/repository/tests/test_views.py
+++ b/src/repository/tests/test_views.py
@@ -13,7 +13,11 @@ from utils.testing import helpers
 from utils.install import update_settings
 from core import models as cm
 from repository import models as rm, install
+from freezegun import freeze_time
 
+from dateutil import tz
+
+FROZEN_DATETIME = timezone.datetime(2024, 3, 25, 10, 0, tzinfo=tz.gettz("America/Chicago"))
 
 class TestModels(TestCase):
     def setUp(self):
@@ -269,3 +273,20 @@ class TestModels(TestCase):
             comment.body,
             'This is my slightly different review.',
         )
+
+    @override_settings(URL_CONFIG='domain')
+    @freeze_time(FROZEN_DATETIME, tz_offset=5)
+    def test_accept_preprint(self):
+        self.preprint_one.make_new_version(self.preprint_one.submission_file)
+        path = reverse('repository_manager_article',
+                       kwargs={'preprint_id': self.preprint_one.pk,})
+        self.client.force_login(self.repo_manager)
+        self.client.post(path,
+                        data={
+                            'accept': '',
+                            'datetime': "2024-03-25 10:00",
+                            'timezone': "America/Chicago"
+                        },
+                        SERVER_NAME=self.server_name,)
+        p = rm.Preprint.objects.get(pk=self.preprint_one.pk)
+        self.assertEqual(p.date_published, p.date_accepted)

--- a/src/repository/views.py
+++ b/src/repository/views.py
@@ -6,6 +6,7 @@ __maintainer__ = "Birkbeck Centre for Technology and Publishing"
 import operator
 from dateutil.relativedelta import relativedelta
 from datetime import datetime
+from dateutil import tz
 
 from django.shortcuts import render, redirect, get_object_or_404
 from django.utils import timezone
@@ -879,9 +880,11 @@ def repository_manager_article(request, preprint_id):
                     'You must assign at least one galley file.',
                 )
             else:
+                d = datetime.fromisoformat(request.POST.get('datetime', timezone.now().strftime("%Y-%m-%d %H:%M")))
+                t = tz.gettz(request.POST.get('timezone', str(timezone.get_current_timezone())))
+                date_published = datetime(d.year, d.month, d.day, d.hour, d.minute, tzinfo=t)
                 date_kwargs = {
-                    'date': request.POST.get('date', timezone.now().date()),
-                    'time': request.POST.get('time', timezone.now().time()),
+                    'date_published': date_published
                 }
                 if preprint.date_published:
                     preprint.update_date_published(**date_kwargs)

--- a/src/templates/admin/elements/repository/accept_preprint.html
+++ b/src/templates/admin/elements/repository/accept_preprint.html
@@ -1,3 +1,4 @@
+{% load tz %}
 <div class="reveal" id="accept_preprint" data-reveal data-animation-in="slide-in-up"
      data-animation-out="slide-out-down">
     <div class="card">
@@ -19,14 +20,12 @@
         <form method="POST" enctype="multipart/form-data">
             {% csrf_token %}
             <div class="row">
-                        <div class="large-8 columns">
-                            <label for="date">Date</label>
-                            <input type="date" name="date" id="date" required value="{% if preprint.date_published %}{{ preprint.date_published|date:'Y-m-d' }}{% else %}{% now "Y-m-d" %}{% endif %}">
-                        </div>
-                        <div class="large-4 columns">
-                            <label for="time">Time</label>
-                            <input type="time" name="time" id="time" required value="{% if preprint.date_published %}{{ preprint.date_published|date:'H:i' }}{% else %}{% now "H:i" %}{% endif %}">
-                        </div>
+                <div class="large-12 columns">
+                    <label for="datetime">Date and time</label>
+                    <input type="datetime-local" name="datetime" id="datetime" required value="{% if preprint.date_published %}{{ preprint.date_published|date:'Y-m-d\TH:i' }}{% else %}{% now 'Y-m-d\TH:i' %}{% endif %}">
+                    {% get_current_timezone as TIME_ZONE %}
+                    <input type="hidden" id="timezone" name="timezone" value="{{ TIME_ZONE }}" />
+                </div>
                         <div class="large-12 columns">
                             <button type="submit" name="accept" class="small success button">Save</button>
                         </div>


### PR DESCRIPTION
When a publication date was selected during preprint acceptance the default date was shown in local time but recorded as if it were in UTC. Add the timezone info to the datetime object created at acceptance.