### PR TITLE
#3088 Editors can now determine whether the date submitted and date accepted display for their articles on all themes

### DIFF
--- a/src/core/logic.py
+++ b/src/core/logic.py
@@ -492,6 +492,8 @@ def get_settings_to_edit(display_group, journal, user):
             'display_altmetric_badge',
             'altmetric_badge_type',
             'hide_author_email_links',
+            'display_date_submitted',
+            'display_date_accepted',
         ]
         group_of_settings = process_setting_list(article_settings, 'article', journal)
         setting_group = 'article'

--- a/src/templates/admin/elements/forms/group_article.html
+++ b/src/templates/admin/elements/forms/group_article.html
@@ -30,4 +30,12 @@
     {% include "admin/elements/forms/field.html" with field=edit_form.suppress_citations_metric %}
 </div>
 
+<div class="title-area">
+    <h2>Article Dates</h2>
+</div>
+<div class="content">
+    <p>{% trans "Enable the display of the dates an article was submitted and accepted." %}.</p>
+    {% include "admin/elements/forms/field.html" with field=edit_form.display_date_submitted %}
+    {% include "admin/elements/forms/field.html" with field=edit_form.display_date_accepted %}
+</div>
 

--- a/src/themes/OLH/templates/journal/article.html
+++ b/src/themes/OLH/templates/journal/article.html
@@ -281,11 +281,8 @@
                                             {% if article.is_published or proofing %}
                                                 <h5 id="article_date_published">
                                                     {% trans "Published on" %} <br>
-                                                    {{ article.date_published|date:"d M Y" }}
+                                                    {{ article.date_published|date:"Y-m-d" }}
                                                 </h5>
-                                            {% else %}
-                                                <h5>{% trans "Accepted on" %} <br>
-                                                    {{ article.date_accepted|date:"d M Y" }}</h5>
                                             {% endif %}
                                         </div>
                                         {% endif %}
@@ -407,6 +404,12 @@
                                  {% if article.publication_title %}
                                  <li>{% trans "Original ISSN" %}: {{ article.ISSN_override }}</li>
                                  {% endif %}
+                                 {% if journal_settings.article.display_date_submitted and article.date_submitted %}
+                                 <li>{% trans "Submitted on" %}: {{ article.date_submitted|date:"Y-m-d" }}</li>
+                                {% endif %}
+                                {% if journal_settings.article.display_date_accepted and  article.date_accepted %}
+                                <li>{% trans "Accepted on" %}: {{ article.date_accepted|date:"Y-m-d" }}</li>
+                                {% endif %}
                              </ul>
                          </div>
                          {% endif %}

--- a/src/themes/clean/templates/journal/article.html
+++ b/src/themes/clean/templates/journal/article.html
@@ -216,12 +216,20 @@
                 {% endif %}
                 <h2>{% trans "Information" %}</h2>
                 <ul>
+                    {% if journal_settings.article.display_date_submitted and article.date_submitted %}
+                        <li>
+                            {% trans "Submitted on" %} {{ article.date_submitted|date:"Y-m-d" }}
+                        </li>
+                    {% endif %}
+                    {% if journal_settings.article.display_date_accepted and  article.date_accepted %}
+                        <li>
+                            {% trans "Accepted on" %} {{ article.date_accepted|date:"Y-m-d" }}
+                        </li>
+                    {% endif %}
                     {% if article.is_published or proofing %}
                         <li id="article_date_published">
-                            {% trans "Published on" %} {{ article.date_published|date:"d M Y" }}
+                            {% trans "Published on" %} {{ article.date_published|date:"Y-m-d" }}
                         </li>
-                    {% else %}
-                    <li>{% trans "Accepted on" %} {{ article.date_accepted|date:"d M Y" }}</li>
                     {% endif %}
                     {% if article.page_range %}
                     <li>{% trans "Pages" %}: {{ article.page_range }}</li>

--- a/src/themes/material/templates/journal/article.html
+++ b/src/themes/material/templates/journal/article.html
@@ -355,6 +355,26 @@
                                 <td>{{ article.ISSN_override}}</td>
                             </tr>
                             {% endif %}
+                            {% if journal_settings.article.display_date_submitted and article.date_submitted %}
+                                <tr>
+                                    <th>{% trans "Submitted on" %}</th>
+                                    <td>{{ article.date_submitted|date:"Y-m-d" }}</td>
+                                </tr>
+                            {% endif %}
+                            {% if journal_settings.article.display_date_accepted and article.date_accepted %}
+                                <tr>
+                                    <th>{% trans "Accepted on" %}</th>
+                                    <td>{{ article.date_accepted|date:"Y-m-d" }}</td>
+                                </tr>
+                            {% endif %}
+                            {% if article.date_published or proofing %}
+                            <tr>
+                                <th>{% trans "Published on" %}</th>
+                                <td id="article_date_published">
+                                    {{ article.date_published|date:"Y-m-d" }}
+                                </td>
+                            </tr>
+                            {% endif %}
                         </table>
                     </div>
                     <div class="spacer">
@@ -383,32 +403,6 @@
                             <div class="divider"></div>
                         </div>
                     {% endif %}
-
-                    {% if article.date_accepted or article.date_published or proofing %}
-                    <h4>
-                        {% trans "Dates" %}
-                    </h4>
-                    <table class="sidebar-table">
-                        {% if article.date_accepted %}
-                            <tr>
-                                <th>{% trans "Accepted" %}</th>
-                                <td>{{ article.date_accepted|date:"Y-m-d" }}</td>
-                            </tr>
-                        {% endif %}
-                        {% if article.date_published or proofing %}
-                        <tr>
-                            <th>{% trans "Published" %}</th>
-                            <td id="article_date_published">
-                                {{ article.date_published|date:"Y-m-d" }}
-                            </td>
-                        </tr>
-                        {% endif %}
-                    </table>
-                    <div class="spacer">
-                        <div class="divider"></div>
-                    </div>
-                    {% endif %}
-
                     <h4>
                         {% trans "Licence" %}
                     </h4>

--- a/src/utils/install/journal_defaults.json
+++ b/src/utils/install/journal_defaults.json
@@ -5064,5 +5064,43 @@
             "editor",
             "journal-manager"
         ]
+    },
+    {
+        "group": {
+            "name": "article"
+        },
+        "setting": {
+            "description": "When enabled the date this article was submitted will be displayed along with the date accepted and date published on the article page.",
+            "is_translatable": false,
+            "name": "display_date_submitted",
+            "pretty_name": "Display Date Submitted",
+            "type": "boolean"
+        },
+        "value": {
+            "default": ""
+        },
+        "editable_by": [
+            "editor",
+            "journal-manager"
+        ]
+    },
+    {
+        "group": {
+            "name": "article"
+        },
+        "setting": {
+            "description": "When enabled the date this article was accepted will be displayed along with the date accepted and date published on the article page.",
+            "is_translatable": false,
+            "name": "display_date_accepted",
+            "pretty_name": "Display Date Accepted",
+            "type": "boolean"
+        },
+        "value": {
+            "default": "on"
+        },
+        "editable_by": [
+            "editor",
+            "journal-manager"
+        ]
     }
 ]

--- a/src/utils/install/journal_defaults.json
+++ b/src/utils/install/journal_defaults.json
@@ -5070,7 +5070,7 @@
             "name": "article"
         },
         "setting": {
-            "description": "When enabled the date this article was submitted will be displayed along with the date accepted and date published on the article page.",
+            "description": "When enabled the date an article was submitted will be displayed on the article page.",
             "is_translatable": false,
             "name": "display_date_submitted",
             "pretty_name": "Display Date Submitted",
@@ -5089,7 +5089,7 @@
             "name": "article"
         },
         "setting": {
-            "description": "When enabled the date this article was accepted will be displayed along with the date accepted and date published on the article page.",
+            "description": "When enabled the date an article was accepted will be displayed on the article page.",
             "is_translatable": false,
             "name": "display_date_accepted",
             "pretty_name": "Display Date Accepted",


### PR DESCRIPTION
- Closes #3088
- Unifies the display of date_submitted and date_accepted by introducing settings and adding them to all themes.

<img width="393" alt="Screenshot 2024-03-28 at 10 43 26" src="https://github.com/BirkbeckCTP/janeway/assets/8321378/85b41d72-1cf6-45a6-b50e-3de020673641">

<img width="391" alt="Screenshot 2024-03-28 at 10 42 21" src="https://github.com/BirkbeckCTP/janeway/assets/8321378/8a6e486d-3236-4190-ae67-0ab33f1ea410">

<img width="360" alt="Screenshot 2024-03-28 at 10 42 29" src="https://github.com/BirkbeckCTP/janeway/assets/8321378/6c513df4-8c8d-405b-85ee-f4ddd7191445">

Note: OLH displays date published in the metrics/summary box.