### PR TITLE
Django's admin interface will now use the email field for authentication

### DIFF
--- a/src/admin.py
+++ b/src/admin.py
@@ -1,0 +1,6 @@
+from django.contrib import admin
+
+
+class JanewayAdminSite(admin.AdminSite):
+    site_header = 'Janeway Administration'
+    site_title = 'Janeway Administration'

--- a/src/apps.py
+++ b/src/apps.py
@@ -1,0 +1,5 @@
+from django.contrib.admin.apps import AdminConfig
+
+
+class JanewayAdminConfig(AdminConfig):
+    default_site = 'admin.JanewayAdminSite'

--- a/src/core/janeway_global_settings.py
+++ b/src/core/janeway_global_settings.py
@@ -53,7 +53,7 @@ FILE_UPLOAD_PERMISSIONS = 0o644
 
 INSTALLED_APPS = [
     'modeltranslation',
-    'django.contrib.admin',
+    'apps.JanewayAdminConfig',
     'django.contrib.auth',
 
     'django.contrib.sessions',

--- a/src/core/models.py
+++ b/src/core/models.py
@@ -270,8 +270,7 @@ class Account(AbstractBaseUser, PermissionsMixin):
 
     objects = AccountManager()
 
-    USERNAME_FIELD = 'username'
-    REQUIRED_FIELDS = ['email']
+    USERNAME_FIELD = 'email'
 
     class Meta:
         ordering = ('first_name', 'last_name', 'username')


### PR DESCRIPTION
- Closes #3202 
- This PR also includes definitions for a custom Janeway admin site, currently used just to overwrite the admin page title but can be extended in the future.