### PR TITLE
Add XSL support for the JATS verse-line/@style attribute

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,6 +85,7 @@ src/media/profile_images/*
 
 # PyCharm
 .idea
+*.iml
 
 # vim
 *.swp

--- a/src/transform/xsl/default.xsl
+++ b/src/transform/xsl/default.xsl
@@ -3790,7 +3790,18 @@
       </xsl:template>
 
       <xsl:template match="verse-line">
-        <xsl:apply-templates/>
+        <xsl:choose>
+            <xsl:when test="@style">
+                <!-- Provide support for the verse-line/@style attribute -->
+                <xsl:element name="span">
+                    <xsl:attribute name="style"><xsl:value-of select="@style"/></xsl:attribute>
+                    <xsl:apply-templates/>
+                </xsl:element>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:apply-templates/>
+            </xsl:otherwise>
+        </xsl:choose>
       </xsl:template>
 
     <xsl:template match="title">


### PR DESCRIPTION
Request to enhance the **verse-line** element template to support the **style** attribute. If the **style** attribute is present, then its value is passed to the resulting HTML via the inclusion of a **span** element. If the **style** attribute is not present, then behavior is not changed.

Currently, it appears the default behavior is inline and monospaced. This request allows for the ability to control the styling of the content within the verse-line element.

For example, the following JATS markup:

```
<disp-quote content-type="epig">
<verse-group>
<verse-line style="display:block;font-style:italic;font-family:serif">"Make no little plans. They have no power to stir men’s blood."</verse-line>
<verse-line style="display:block;font-style:italic;font-family:serif">Daniel Burnham, as quoted in <italic>Devil in the White City</italic></verse-line>
</verse-group>
</disp-quote>
```

currently produces the following HTML display:

![verse_line_default](https://github.com/BirkbeckCTP/janeway/assets/34096219/1efcab53-c83e-4c8b-bddd-626235f9ab32)

This request will allow for the following HTML display:

![verse_line_request](https://github.com/BirkbeckCTP/janeway/assets/34096219/b57c027e-d6ee-49e1-bc60-2c81c86947ad)