### PR TITLE
Update psycopg2-binary version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -44,7 +44,7 @@ orcid==1.0.3
 packaging==23.2
 pdfkit==1.0.0
 pdfminer.six
-psycopg2-binary~=2.8.6
+psycopg2-binary~=2.9.8
 pyasn1==0.1.9
 pycparser==2.14
 PyJWT==2.4.0


### PR DESCRIPTION
During a recent fresh installation I ran into an issue with pip install of psycopg2-binary. Version 2.8.6 uses an outdated installation method.

I am proposing bumping this to 2.9.8. I've read the changelog and don't believe there are any breaking changes for us between these versions, but please double-check. Version 2.9.9 drops support for python 3.6, so I don't think we should
go that far until we drop python 3.6.