### PR TITLE
[1.5.2] Fix a bug that kept some rich-text fields from saving

### DIFF
--- a/src/templates/admin/elements/review/draft_decisions_js.html
+++ b/src/templates/admin/elements/review/draft_decisions_js.html
@@ -60,7 +60,7 @@
                 "url": "{% url 'review_draft_decision_text' article.pk %}",
                 "data": data,
                 "success": function (data) {
-                    $("#id_email_message").jqteVal(data.decision_text)
+                    tinymce.get('id_email_message').setContent(data.decision_text)
                     toastr.success('Draft Email to Author reloaded.')
                 },
                 "error": function (xhr, status, error) {
@@ -81,7 +81,7 @@
         date = $('#id_revision_request_due_date').val();
 
         if (decision_selector.val() === '') {
-            $("#id_email_message").jqteVal('')
+            tinymce.get('id_email_message').setContent('')
         } else if ((decision_selector.val() === 'minor_revisions') || (decision_selector.val() === 'major_revisions')) {
             $('#div_due_date').show();
             get_decision_text(decision_selector, date)
@@ -91,8 +91,8 @@
         }
     }
     function decision_change() {
-
-        if ($('#id_email_message').val()) {
+        let emailMessagecContent = tinymce.get('id_email_message').getContent()
+        if (emailMessagecContent) {
             $('#confirm_switch_email_template').foundation();
             $('#confirm_switch_email_template').foundation('open');
         } else {

--- a/src/templates/admin/review/draft_decision.html
+++ b/src/templates/admin/review/draft_decision.html
@@ -141,7 +141,6 @@
 {% endblock %}
 
 {% block js %}
-    {% include "admin/elements/jqte.html" %}
     <script src="{% static "admin/js/csrf.js" %}"></script>
     {% include "admin/elements/review/draft_decisions_js.html" %}
 {% endblock %}

--- a/src/templates/admin/review/revision/request_revisions.html
+++ b/src/templates/admin/review/revision/request_revisions.html
@@ -70,7 +70,6 @@
 
 {% block js %}
     {% include "elements/datepicker.html" with target="#id_date_due" %}
-    {% include "elements/jqte.html" %}
     {% if form.modal %}
         {% include "admin/elements/open_modal.html" with target=form.modal.id %}
     {% endif %}


### PR DESCRIPTION
Fixes #4088.

I checked all the places we include JQTE in forms, and made sure they did not interfere with a TinyMCE-powered field. These were the only two problems:

- [x] src/templates/admin/review/revision/request_revisions.html
- [x] src/templates/admin/review/draft_decision.html

## JQTE forms that do not interfere with a TinyMCE field

I checked and cleared these fields:

- [x] src/templates/admin/press/merge_users.html: {% include "elements/jqte.html" %}
- [x] src/templates/admin/copyediting/author_review.html: {% include "elements/jqte.html" %}
- [x] src/templates/admin/copyediting/editor_review.html: {% include "elements/jqte.html" %}
- [x] src/templates/admin/copyediting/edit_assignment.html: {% include "elements/jqte.html" %}
- [x] src/templates/admin/copyediting/do_copyedit.html:{% include "elements/jqte.html" %}
- [x] src/templates/admin/copyediting/add_copyeditor_assignment.html: {% include "elements/jqte.html" %}
- [x] src/templates/admin/submission/submit_funding.html: {% include "admin/elements/jqte.html" %}
- [x] src/templates/admin/review/suggest_reviewers.html:{% include "elements/jqte.html" %}
- [x] src/templates/admin/review/revision/request_revisions_notification.html:{% include "elements/jqte.html" %}
- [x] src/templates/admin/review/send_review_reminder.html: {% include "elements/jqte.html" %}
- [x] src/templates/admin/review/revision/edit_revision_request.html: {% include "elements/jqte.html" %}
- [x] src/templates/admin/repository/notification.html: {% include "elements/jqte.html" %}
- [x] src/templates/admin/review/revision/view_revision.html:{% include "elements/jqte.html" %}
- [x] src/templates/admin/review/reset.html: {% include "elements/jqte.html" %}
- [x] src/templates/admin/repository/review/notify_reviewer.html: {% include "admin/elements/jqte.html" %}
- [x] src/templates/admin/cron/create_template.html:{% include "admin/elements/jqte.html" %}
- [x] src/core/homepage_elements/html/templates/html_settings.html: {% include "elements/jqte.html" %}
- [x] src/core/homepage_elements/about/templates/about_settings.html:{% include "elements/jqte.html" %}

## Out of scope

These fields are not actively used:

- [ ] src/templates/admin/install/journal.html:{% include "elements/jqte.html" %}
- [ ] src/core/homepage_elements/preprints/templates/preprints.html: {% include "elements/jqte.html" %}
- [ ] src/templates/admin/production/assign_typesetter.html: {% include "elements/jqte.html" %}
- [ ] src/templates/admin/production/typeset_task.html: {% include "elements/jqte.html" %}
- [ ] src/templates/admin/production/assigned_article.html: {% include "elements/jqte.html" %}
- [ ] src/templates/admin/production/edit_typesetter_assignment.html: {% include "elements/jqte.html" %}
- [ ] src/templates/admin/production/notify_typesetter.html: {% include "elements/jqte.html" %}
- [ ] src/templates/admin/proofing/proofing_article.html: {% include "elements/jqte.html" %}
- [ ] src/templates/admin/proofing/notify_typesetter_changes.html: {% include "elements/jqte.html" %}
- [ ] src/templates/admin/proofing/notify_proofreader.html: {% include "elements/jqte.html" %}
- [ ] src/templates/admin/proofing/do_proofing.html: {% include "elements/jqte.html" %}
- [ ] src/templates/admin/proofing/request_typesetting_changes.html: {% include "elements/jqte.html" %}
- [ ] src/templates/admin/proofing/edit_proofing_assignment.html: {% include "elements/jqte.html" %}
- [ ] src/templates/admin/proofing/complete_proofing.html: {% include "elements/jqte.html" %}
- [ ] src/templates/admin/proofing/typesetting/typesetting_corrections.html: {% include "elements/jqte.html" %}
- [ ] src/templates/admin/proofing/acknowledge.html: {% include "elements/jqte.html" %}