### PR TITLE
Add XSL support for the JATS email element in all contexts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,6 +85,7 @@ src/media/profile_images/*
 
 # PyCharm
 .idea
+*.iml
 
 # vim
 *.swp

--- a/src/transform/xsl/default.xsl
+++ b/src/transform/xsl/default.xsl
@@ -3873,6 +3873,15 @@
        </pre>
     </xsl:template>
 
+    <!-- Add support for email links in all contexts. -->
+    <xsl:template match="email">
+        <xsl:element name="a">
+            <xsl:attribute name="href"><xsl:value-of select="concat('mailto:',.)"/></xsl:attribute>
+            <xsl:attribute name="class"><xsl:value-of select="'email'"/></xsl:attribute>
+            <xsl:apply-templates/>
+        </xsl:element>
+    </xsl:template>
+
     <!-- END - general format -->
 
     <xsl:template match="sub-article//title-group | sub-article/front-stub | fn-group[@content-type='competing-interest']/fn/p | //history//*[@publication-type='journal']/article-title">

--- a/src/transform/xsl/default.xsl
+++ b/src/transform/xsl/default.xsl
@@ -3790,7 +3790,18 @@
       </xsl:template>
 
       <xsl:template match="verse-line">
-        <xsl:apply-templates/>
+        <xsl:choose>
+            <xsl:when test="@style">
+                <!-- Provide support for the verse-line/@style attribute -->
+                <xsl:element name="span">
+                    <xsl:attribute name="style"><xsl:value-of select="@style"/></xsl:attribute>
+                    <xsl:apply-templates/>
+                </xsl:element>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:apply-templates/>
+            </xsl:otherwise>
+        </xsl:choose>
       </xsl:template>
 
     <xsl:template match="title">


### PR DESCRIPTION
Request to add support for the JATS email element in all contexts.

Currently, the following JATS markup:

> `<p>Conny Liegl, Designer for Web, Graphics and UX, <email>cliegl@calpoly.edu</email></p>`

produces the following HTML display:

> ![image](https://github.com/BirkbeckCTP/janeway/assets/34096219/68f79654-81c0-4f54-9638-1d74e2a6cbf6)

This request will allow for the following HTML display and allow the generation of an email message to the address:

> ![image](https://github.com/BirkbeckCTP/janeway/assets/34096219/f7f69963-02cd-4917-877a-8af421976fe6)
