### PR TITLE
#4102 additional fields with the date type now display the correct widget

### DIFF
--- a/src/submission/forms.py
+++ b/src/submission/forms.py
@@ -12,7 +12,11 @@ from submission import models
 from core import models as core_models
 from identifiers import models as ident_models
 from review.logic import render_choices
-from utils.forms import KeywordModelForm, JanewayTranslationModelForm
+from utils.forms import (
+    KeywordModelForm,
+    JanewayTranslationModelForm,
+    HTMLDateInput,
+)
 from utils import setting_handler
 
 from tinymce.widgets import TinyMCE
@@ -169,7 +173,9 @@ class ArticleInfo(KeywordModelForm, JanewayTranslationModelForm):
                         )
                     elif element.kind == 'date':
                         self.fields[element.name] = forms.CharField(
-                            widget=forms.DateInput(attrs={'class': 'datepicker', 'div_class': element.width}),
+                            widget=HTMLDateInput(
+                                attrs={'div_class': element.width},
+                            ),
                             required=element.required)
 
                     elif element.kind == 'select':


### PR DESCRIPTION
When addtional fields are set to the date type they now use the HTMLDateInput widget.

<img width="781" alt="Screenshot 2024-04-16 at 14 09 31" src="https://github.com/BirkbeckCTP/janeway/assets/8321378/2f8715bc-6fa1-41d7-b702-c4aa089c0178">

Closes #4102