### PR TITLE
Patch Notify Author email field with TinyMCE

### DIFF
--- a/src/core/forms/__init__.py
+++ b/src/core/forms/__init__.py
@@ -26,6 +26,7 @@ from core.forms.forms import (
     RegistrationForm,
     SectionForm,
     SettingEmailForm,
+    SimpleTinyMCEForm,
     UserCreationFormExtended,
     XSLFileForm,
 )

--- a/src/core/forms/forms.py
+++ b/src/core/forms/forms.py
@@ -13,7 +13,6 @@ from django.utils.translation import gettext_lazy as _
 from django.contrib.auth.forms import UserCreationForm
 from django.core.validators import validate_email, ValidationError
 
-from swapper import ImproperlyConfigured
 from tinymce.widgets import TinyMCE
 
 from core import email, models, validators

--- a/src/core/forms/forms.py
+++ b/src/core/forms/forms.py
@@ -13,6 +13,7 @@ from django.utils.translation import gettext_lazy as _
 from django.contrib.auth.forms import UserCreationForm
 from django.core.validators import validate_email, ValidationError
 
+from swapper import ImproperlyConfigured
 from tinymce.widgets import TinyMCE
 
 from core import email, models, validators
@@ -816,3 +817,11 @@ class SettingEmailForm(EmailForm):
             email_context,
             setting_name,
         )
+
+class SimpleTinyMCEForm(forms.Form):
+    """ A one-field form for populating a TinyMCE textarea
+    """
+
+    def __init__(self, field_name, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.fields[field_name] = forms.CharField(widget=TinyMCE)

--- a/src/journal/logic.py
+++ b/src/journal/logic.py
@@ -279,7 +279,7 @@ def notify_author(request, article):
     kwargs = {
         'request': request,
         'article': article,
-        'user_message': request.POST.get('notify_author_email', 'No message from Editor.'),
+        'user_message': request.POST.get('email_to_author', 'No message from Editor.'),
         'section_editors': request.POST.get('section_editors', False),
         'peer_reviewers': request.POST.get('peer_reviewers', False),
     }

--- a/src/journal/views.py
+++ b/src/journal/views.py
@@ -32,7 +32,6 @@ from core import (
     models as core_models,
     plugin_loader,
     logic as core_logic,
-    forms as core_forms,
     views as core_views,
 )
 from identifiers import models as id_models
@@ -1018,6 +1017,12 @@ def publish_article(request, article_id):
     doi_data, doi = logic.get_doi_data(article)
     issues = request.journal.issues
     new_issue_form = issue_forms.NewIssue(journal=article.journal)
+    notify_author_email_form = core_forms.SimpleTinyMCEForm(
+        'email_to_author',
+        initial = {
+            'email_to_author': logic.get_notify_author_text(request, article)
+        }
+    )
     modal = request.GET.get('m', None)
     pubdate_errors = []
 
@@ -1186,7 +1191,7 @@ def publish_article(request, article_id):
         'new_issue_form': new_issue_form,
         'modal': modal,
         'pubdate_errors': pubdate_errors,
-        'notify_author_text': logic.get_notify_author_text(request, article)
+        'notify_author_email_form': notify_author_email_form,
     }
 
     return render(request, template, context)

--- a/src/templates/admin/elements/publish/author.html
+++ b/src/templates/admin/elements/publish/author.html
@@ -1,3 +1,5 @@
+{% load foundation %}
+
 <div class="reveal small" id="author" data-reveal data-animation-in="slide-in-up"
      data-animation-out="slide-out-down">
     <div class="card">
@@ -15,11 +17,7 @@
                         <i>From: </i> {{ request.user.full_name }}({{ request.user.email }})<br />
                         <i>Subject: </i>{{ article.safe_title }} Publication
                     </p>
-                    <textarea
-                        id="notify_author_email"
-                        name="notify_author_email">
-                        {{ notify_author_text|linebreaks }}
-                    </textarea>
+                    {{ notify_author_email_form|foundation }}
 
                     <input type="checkbox" name="section_editors" id="section_editors"><label for="section_editors" class="toggle">Notify Section Editors</label>
                     <br />
@@ -37,11 +35,3 @@
         <span aria-hidden="true">&times;</span>
     </button>
 </div>
-<script type="module">
-    document.addEventListener('DOMContentLoaded', () => {
-        tinymce.init({
-            selector: '#notify_author_email',
-        })
-    })
-</script>
-

--- a/src/templates/admin/elements/publish/author.html
+++ b/src/templates/admin/elements/publish/author.html
@@ -15,7 +15,11 @@
                         <i>From: </i> {{ request.user.full_name }}({{ request.user.email }})<br />
                         <i>Subject: </i>{{ article.safe_title }} Publication
                     </p>
-                    <textarea name="notify_author_email">{{ notify_author_text|linebreaksbr }}</textarea>
+                    <textarea
+                        id="notify_author_email"
+                        name="notify_author_email">
+                        {{ notify_author_text|linebreaks }}
+                    </textarea>
 
                     <input type="checkbox" name="section_editors" id="section_editors"><label for="section_editors" class="toggle">Notify Section Editors</label>
                     <br />
@@ -33,3 +37,11 @@
         <span aria-hidden="true">&times;</span>
     </button>
 </div>
+<script type="module">
+    document.addEventListener('DOMContentLoaded', () => {
+        tinymce.init({
+            selector: '#notify_author_email',
+        })
+    })
+</script>
+


### PR DESCRIPTION
This uses a bare-bones Django form to put TinyMCE into an arbitrary template as a hotfix for #4089. It does not fully address #4089 because we would like to refactor it a bit more in a later minor version of Janeway--see #4094.

![Screenshot from 2024-04-22 16-52-57](https://github.com/BirkbeckCTP/janeway/assets/47217308/e7339d9c-4c34-4072-90bc-664b6fe3e22b)
