### PR TITLE
Fixes a bug that stopped the Share Reviews page from loading properly.

### DIFF
--- a/src/review/forms.py
+++ b/src/review/forms.py
@@ -448,7 +448,7 @@ class ShareReviewsForm(forms.Form):
 
         for review in reviews:
             self.fields[f'{ review.pk }'] = forms.CharField(
-                widget=SummernoteWidget,
+                widget=TinyMCE,
                 label=f'Email for {review.reviewer.full_name()}',
                 initial=review.email_content,
             )


### PR DESCRIPTION
The share reviews form now uses the TinyMCE widget.

Closes #4086 

<img width="1415" alt="image" src="https://github.com/BirkbeckCTP/janeway/assets/8321378/f83f62cc-5ca2-4fab-9c39-36cb4b35b97c">
