### PR TITLE
Ensures that only staff are allowed to assign the journal manager role

### DIFF
--- a/src/api/serializers.py
+++ b/src/api/serializers.py
@@ -144,14 +144,21 @@ class AccountRoleSerializer(serializers.ModelSerializer):
         model = core_models.AccountRole
         fields = ('pk', 'journal', 'user', 'role')
 
-    def create(self, validated_data):
-        role = validated_data.get("role")
+    def validate(self, data):
+        request = self.context.get('request', None)
+        role = data.get("role")
 
-        if role.slug == 'reader':
-            raise serializers.ValidationError({"role": "You cannot add a user as a reader via the API."})
-        else:
-            account_role = core_models.AccountRole.objects.create(**validated_data)
-            return account_role
+        excluded_roles = ['reader']
+
+        # if the current user is not staff add the journal-manager role to
+        # the list of excluded roles.
+        if not request or not request.user.is_staff:
+            excluded_roles.append('journal-manager')
+
+        if role.slug in excluded_roles:
+            raise serializers.ValidationError({"error": "You cannot add a user to that role via the API."})
+
+        return data
 
 class RepositoryFieldAnswerSerializer(serializers.ModelSerializer):
     class Meta:
@@ -190,18 +197,3 @@ class PreprintSerializer(serializers.ModelSerializer):
         many=True,
         read_only=True,
     )
-    def validate(self, data):
-        request = self.context.get('request', None)
-        role = data.get("role")
-
-        excluded_roles = ['reader']
-
-        # if the current user is not staff add the journal-manager role to
-        # the list of excluded roles.
-        if not request or not request.user.is_staff:
-            excluded_roles.append('journal-manager')
-
-        if role.slug in excluded_roles:
-            raise serializers.ValidationError({"error": "You cannot add a user to that role via the API."})
-
-        return data

--- a/src/core/views.py
+++ b/src/core/views.py
@@ -1321,13 +1321,15 @@ def enrol_users(request):
     first_name = request.GET.get('first_name', '')
     last_name = request.GET.get('last_name', '')
     email = request.GET.get('email', '')
-    roles = models.Role.objects.exclude(
+    assignable_roles = models.Role.objects.exclude(
         slug__in=['reader'],
     ).order_by(('name'))
 
     # if the current user is not staff, exclude the journal-manager role.
     if not request.user.is_staff:
-        roles.exclude(slug__in='journal-manager')
+        assignable_roles = assignable_roles.exclude(
+            slug='journal-manager',
+        )
 
     if first_name or last_name or email:
         filters = {}
@@ -1343,7 +1345,7 @@ def enrol_users(request):
     template = 'core/manager/users/enrol_users.html'
     context = {
         'user_search': user_search,
-        'roles': roles,
+        'roles': assignable_roles,
         'first_name': first_name,
         'last_name': last_name,
         'email': email,


### PR DESCRIPTION
Two issues here:

1. A bed merge had moved `AccountRoleSerializer`'s `validate` method into `PreprintSerializer`.
2. The `enrol_users` view was not filtering out the journal manager role properly.

2 would not have been a serious issue without 1, as the API would have refused to assign the role and let the non-staff user know.

Additionally, I've renamed the roles variable as it shadows a an outer scope definition.

Closes #4141 