### PR TITLE
Display plural section name on issue page

### DIFF
--- a/src/themes/OLH/templates/elements/journal/issue_block.html
+++ b/src/themes/OLH/templates/elements/journal/issue_block.html
@@ -3,7 +3,13 @@
 <div>
     {% regroup articles by section as grouped_articles %}
     {% for section, section_articles in grouped_articles %}
-        <h4 class="em">{{ section.name }}</h4>
+        <h4 class="em">
+            {% if section.plural and section_articles|length >= 2 %}
+                {{ section.plural }}
+            {% else %}
+                {{ section.name }}
+            {% endif %}
+        </h4>
         <hr>
         {% for article in section_articles %}
             {% include "elements/journal/box_article.html" with article=article %}

--- a/src/themes/clean/templates/elements/journal/issue_block.html
+++ b/src/themes/clean/templates/elements/journal/issue_block.html
@@ -1,6 +1,12 @@
 {% regroup articles by section as grouped_articles %}
 {% for section, section_articles in grouped_articles %}
-    <h3 class="em">{{ section.name }}</h3>
+    <h3 class="em">
+        {% if section.plural and section_articles|length >= 2 %}
+            {{ section.plural }}
+        {% else %}
+            {{ section.name }}
+        {% endif %}
+    </h3>
     {% for article in section_articles %}
         {% include "elements/article_listing.html" with article=article %}
     {% endfor %}

--- a/src/themes/material/templates/elements/journal/issue_block.html
+++ b/src/themes/material/templates/elements/journal/issue_block.html
@@ -2,7 +2,13 @@
 
 {% regroup articles by section as grouped_articles %}
 {% for section, section_articles in grouped_articles %}
-    <h2 class="em">{{ section.name }}</h2>
+    <h2 class="em">
+        {% if section.plural and section_articles|length >= 2 %}
+            {{ section.plural }}
+        {% else %}
+            {{ section.name }}
+        {% endif %}
+    </h2>
     {% for article in section_articles %}
         {% include "elements/article_listing.html" with article=article %}
     {% endfor %}


### PR DESCRIPTION
Closes #4150. 

This adds support for plural section names on the issue page. If there are two or more articles in a section for a given issue, the plural name will appear on all themes:

![Screenshot from 2024-05-01 14-33-39](https://github.com/BirkbeckCTP/janeway/assets/47217308/f8e549ec-8740-4be8-a83a-9a8d5354568d)

If there is only one article for the issue and section, or no value in the plural field for that section, it is singular:

![Screenshot from 2024-05-01 14-38-51](https://github.com/BirkbeckCTP/janeway/assets/47217308/aab4d560-ec53-4363-afca-7fed35573afc)
