### PR TITLE
Adds a new column to the copyediting dashboard showing assigned copyeditors.

### DIFF
--- a/src/copyediting/views.py
+++ b/src/copyediting/views.py
@@ -38,8 +38,12 @@ def copyediting(request):
     :return: a contextualised template
     """
 
-    articles_in_copyediting = submission_models.Article.objects.filter(stage__in=submission_models.COPYEDITING_STAGES,
-                                                                       journal=request.journal)
+    articles_in_copyediting = submission_models.Article.objects.filter(
+        stage__in=submission_models.COPYEDITING_STAGES,
+        journal=request.journal,
+    ).prefetch_related(
+        'copyeditassignment_set',
+    )
 
     if not request.user.is_editor(request) and request.user.is_section_editor(request):
         articles_in_copyediting = core_logic.filter_articles_to_editor_assigned(

--- a/src/templates/admin/copyediting/copyediting.html
+++ b/src/templates/admin/copyediting/copyediting.html
@@ -40,7 +40,7 @@
                         <td>{{ article.section.name }}</td>
                         <td>{% if article.projected_issue %}{{ article.projected_issue.display_title }}{% else %}None{% endif %}</td>
                         <td>{{ article.stage }}</td>
-                        <td>{% for assignment in article.copyeditassignment_set.all %}<a href="{% url 'editor_review' article.pk assignment.pk %}">{{ assignment.copyeditor.full_name }}</a>{% if not forloop.last %}, {% endif %}{% endfor %}</td>
+                        <td>{% for assignment in article.copyeditassignment_set.all %}<a href="{% url 'editor_review' article.pk assignment.pk %}">{{ assignment.copyeditor.full_name }}</a>{% if not forloop.last %}, {% endif %}{% empty %}No assignments{% endfor %}</td>
                     </tr>
                 {% empty %}
                     <tr>

--- a/src/templates/admin/copyediting/copyediting.html
+++ b/src/templates/admin/copyediting/copyediting.html
@@ -1,6 +1,7 @@
 {% extends "admin/core/base.html" %}
 
 {% block page_title %}Copyediting{% endblock %}
+{% block title %}Copyediting{% endblock %}
 {% block admin-header %}Articles in Copyediting{% endblock %}
 
 {% block breadcrumbs %}
@@ -25,21 +26,21 @@
                     <th>Section</th>
                     <th>Projected Issue</th>
                     <th>Stage</th>
-                    <th></th>
+                    <th>Assignments</th>
                 </tr>
                 </thead>
                 <tbody>
                 {% for article in articles_in_copyediting %}
                     <tr>
                         <td>{{ article.pk }}</td>
-                        <td>{{ article.safe_title }}</td>
+                        <td><a href="{% url 'article_copyediting' article.pk %}">{{ article.safe_title }}</a></td>
                         <td>{{ article.date_submitted }}</td>
                         <td>{{ article.date_accepted }}</td>
                         <td>{{ article.correspondence_author.full_name }}</td>
                         <td>{{ article.section.name }}</td>
                         <td>{% if article.projected_issue %}{{ article.projected_issue.display_title }}{% else %}None{% endif %}</td>
                         <td>{{ article.stage }}</td>
-                        <td><a href="{% url 'article_copyediting' article.pk %}">View</a></td>
+                        <td>{% for assignment in article.copyeditassignment_set.all %}<a href="{% url 'editor_review' article.pk assignment.pk %}">{{ assignment.copyeditor.full_name }}</a>{% if not forloop.last %}, {% endif %}{% endfor %}</td>
                     </tr>
                 {% empty %}
                     <tr>


### PR DESCRIPTION
- Added a new column that displays a list of copyeditors with links to the editor review page
- Moved the link to open an article's copyediting page from the "view" column (now deleted) to the title column
- Closes #4159 

<img width="1566" alt="image" src="https://github.com/BirkbeckCTP/janeway/assets/8321378/26f4cc2b-6517-4903-91da-eba2b9ec4557">
