### PR TITLE
XSLT: Fixed Page ranges on element-citation objects and figure labels being rendered twice

### DIFF
--- a/src/core/janeway_global_settings.py
+++ b/src/core/janeway_global_settings.py
@@ -539,7 +539,7 @@ HTTP_TIMEOUT_SECONDS = 5
 
 # New XML galleys will be associated with this stylesheet by default when they
 # are first uploaded
-DEFAULT_XSL_FILE_LABEL = 'Janeway default (1.5.1)'
+DEFAULT_XSL_FILE_LABEL = 'Janeway default (1.6.0)'
 
 # Skip migrations by default on sqlite for faster execution
 if (

--- a/src/transform/xsl/default.xsl
+++ b/src/transform/xsl/default.xsl
@@ -3111,7 +3111,7 @@
   <xsl:template match="fpage" mode="none">
     <xsl:variable name="fpgct" select="count(../fpage)"/>
     <xsl:variable name="lpgct" select="count(../lpage)"/>
-    <xsl:variable name="hermano" select="name(following-sibling::node())"/>
+    <xsl:variable name="siblingName" select="name(following-sibling::*)"/>
     <xsl:choose>
       <xsl:when test="preceding-sibling::fpage">
         <xsl:choose>
@@ -3119,7 +3119,7 @@
             <xsl:text> </xsl:text>
             <xsl:apply-templates/>
 
-            <xsl:if test="$hermano='lpage'">
+            <xsl:if test="$siblingName='lpage'">
               <xsl:text>&#8211;</xsl:text>
               <xsl:apply-templates select="following-sibling::lpage[1]" mode="none"/>
             </xsl:if>
@@ -3128,7 +3128,7 @@
           <xsl:otherwise>
             <xsl:text> </xsl:text>
             <xsl:apply-templates/>
-            <xsl:if test="$hermano='lpage'">
+            <xsl:if test="$siblingName='lpage'">
               <xsl:text>&#8211;</xsl:text>
               <xsl:apply-templates select="following-sibling::lpage[1]" mode="none"/>
             </xsl:if>
@@ -3175,7 +3175,7 @@
         </xsl:choose>
         <xsl:apply-templates/>
         <xsl:choose>
-          <xsl:when test="$hermano='lpage'">
+          <xsl:when test="$siblingName='lpage'">
             <xsl:text>&#8211;</xsl:text>
             <xsl:apply-templates select="following-sibling::lpage[1]" mode="write"/>
             <xsl:choose>
@@ -3187,7 +3187,7 @@
               </xsl:otherwise>
             </xsl:choose>
           </xsl:when>
-          <xsl:when test="$hermano='fpage'">
+          <xsl:when test="$siblingName='fpage'">
             <xsl:text>,</xsl:text>
           </xsl:when>
           <xsl:otherwise>

--- a/src/transform/xsl/default.xsl
+++ b/src/transform/xsl/default.xsl
@@ -445,8 +445,9 @@
          -->
         <h2>Notes</h2>
       </xsl:if>
+      <xsl:apply-templates select="title" />
         <ol class="footnotes">
-            <xsl:apply-templates/>
+          <xsl:apply-templates select="*[not(self::title)]"/>
         </ol>
     </xsl:template>
 

--- a/src/transform/xsl/default.xsl
+++ b/src/transform/xsl/default.xsl
@@ -1584,7 +1584,8 @@
                 </div>
             </div>
 	    </xsl:for-each>
-            <xsl:apply-templates/>
+          <!-- label is handled directly rather than with a template -->
+          <xsl:apply-templates select="*[not(self::label)]" />
         </div>
     </xsl:template>
 


### PR DESCRIPTION
As noted on latest XML files from UCL:

- Fixed `lpage` in `element-citation` not being rendered
- Fixed figure labels being procesed twice due to explicit handle + apply-templates
- Titles in notes section have been moved out of `<ol>` so that they no longer are indented accidentally
