### PR TITLE
The OLH and Material themes no longer use header tags to display metrics.

### DIFF
--- a/src/themes/OLH/assets/scss/app.scss
+++ b/src/themes/OLH/assets/scss/app.scss
@@ -676,8 +676,14 @@ div.caption span.label {
     border-right: 1px solid rgba(255, 255, 255, 0.1);
   }
 
-  h4 {
+  p {
+    font-family: $header-font-family;
     font-size: rem-calc(36px);
+    font-weight: 300;
+    font-style: normal;
+    margin-top: 0;
+    margin-bottom: 0.5rem;
+    line-height: 1.4;
 
     span {
       display: block;
@@ -686,7 +692,7 @@ div.caption span.label {
     }
   }
 
-  h5 {
+  .bottom p {
     @extend .uppercase;
     font-size: rem-calc(14px);
   }

--- a/src/themes/OLH/templates/journal/article.html
+++ b/src/themes/OLH/templates/journal/article.html
@@ -254,22 +254,23 @@
                                         <div class="top">
                                             <div class="row">
                                                 <div class="large-{% if article.citation_count and not journal_settings.article.suppress_citations_metric %}4{% else %}6{% endif %} columns">
-                                                    <h4 class="number">
+                                                    <p class="number">
                                                         {{ article.metrics.views }}
                                                         <span>{% trans "Views" %}</span>
-                                                    </h4>
+                                                    </p>
                                                 </div>
                                                 <div class="large-{% if article.citation_count and not journal_settings.article.suppress_citations_metric %}4{% else %}6{% endif %} columns">
-                                                    <h4 class="number">
+                                                    <p class="number">
                                                         {{ article.metrics.downloads }}
                                                         <span>{% trans "Downloads" %}</span>
-                                                    </h4>
+                                                    </p>
                                                 </div>
                                                 {% if article.citation_count and not journal_settings.article.suppress_citations_metric %}
                                                 <div class="large-4 columns">
-                                                    <h4 class="number">
-                                                        {{ article.citation_count }}<span>{% trans "Citations" %}</span>
-                                                    </h4>
+                                                    <p class="number">
+                                                        {{ article.citation_count }}
+                                                        <span>{% trans "Citations" %}</span>
+                                                    </p>
                                                 </div>
                                                 {% endif %}
                                             </div>
@@ -281,10 +282,10 @@
                                         {% if article.date_published or article.date_accepted or proofing %}
                                         <div class="large-4 columns" data-equalizer-watch>
                                             {% if article.is_published or proofing %}
-                                                <h5 id="article_date_published">
+                                                <p id="article_date_published">
                                                     {% trans "Published on" %} <br>
                                                     {{ article.date_published|date:"Y-m-d" }}
-                                                </h5>
+                                                </p>
                                             {% endif %}
                                         </div>
                                         {% endif %}
@@ -294,7 +295,7 @@
                                         <div class="large-6 columns" data-equalizer-watch>
                                         {% endif %}
                                             {% if article.peer_reviewed %}
-                                                <h5>{% trans "Peer Reviewed" %}</h5>
+                                                <p>{% trans "Peer Reviewed" %}</p>
                                             {% endif %}
                                         </div>
                                         {% if article.date_published or article.date_accepted or proofing %}
@@ -302,8 +303,8 @@
                                         {% else %}
                                         <div class="large-6 columns" data-equalizer-watch>
                                         {% endif %}
-                                            <h5>{% trans "License" %}</h5>
-                                            <a class="has-tip scroll-link" rel="license" id="license" title="{{ article.license.text }}" data-tooltip="2cc6nw-tooltip" aria-haspopup="true" data-fade-out-duration="1000" title="" aria-describedby="pyltep-tooltip" data-yeti-box="pyltep-tooltip" data-toggle="pyltep-tooltip" data-resize="pyltep-tooltip" data-events="resize" href="{{ article.license.url }}"><h5>{{ article.license.name }}</h5></a>
+                                            <p>{% trans "License" %}</p>
+                                            <a class="has-tip scroll-link" rel="license" id="license" title="{{ article.license.text }}" data-tooltip="2cc6nw-tooltip" aria-haspopup="true" data-fade-out-duration="1000" title="" aria-describedby="pyltep-tooltip" data-yeti-box="pyltep-tooltip" data-toggle="pyltep-tooltip" data-resize="pyltep-tooltip" data-events="resize" href="{{ article.license.url }}"><p>{{ article.license.name }}</p></a>
                                         </div>
                                     </div>
                                 </div>

--- a/src/themes/material/assets/mat.css
+++ b/src/themes/material/assets/mat.css
@@ -343,6 +343,10 @@ a:hover .article-title {
     width: 140px;
 }
 
+.alm_numbers {
+    font-size: 1.3rem;
+}
+
 #logo-container svg {
     max-width: 100px;
     max-height: 49px;

--- a/src/themes/material/templates/journal/article.html
+++ b/src/themes/material/templates/journal/article.html
@@ -178,48 +178,48 @@
                         <div class="card">
                             <div class="card-content center">
                                 <div class="alm">
-                                    <h5>
+                                    <p class="alm_numbers">
                                         {{ article.metrics.views }}
-                                    </h5>
-                                    <p><i class="fa fa-eye"></i>{% trans "Views" %}</p>
+                                    </p>
+                                    <p><i class="fa fa-eye"></i> {% trans "Views" %}</p>
                                 </div>
                                 <div class="alm">
-                                    <h5>
+                                    <p class="alm_numbers">
                                         {{ article.metrics.downloads }}
-                                    </h5>
-                                    <p><i class="fa fa-download"></i>{% trans "Downloads" %}</p>
+                                    </p>
+                                    <p><i class="fa fa-download"></i> {% trans "Downloads" %}</p>
                                 </div>
                                 {% if article.metrics.alm.twitter %}
                                     <div class="alm">
-                                        <h5>
+                                        <p class="alm_numbers">
                                             {{ article.metrics.alm.twitter }}
-                                        </h5>
-                                        <p><i class="fa fa-twitter"></i>{% trans "Tweets" %}</p>
+                                        </p>
+                                        <p><i class="fa fa-twitter"></i> {% trans "Tweets" %}</p>
                                     </div>
                                 {% endif %}
                                 {% if article.metrics.alm.wikipedia %}
                                     <div class="alm">
-                                        <h5>
+                                        <p class="alm_numbers">
                                             {{ article.metrics.alm.wikipedia }}
-                                        </h5>
-                                        <p><i class="fa fa-wikipedia-w"></i>{% trans "Wikipedia" %}</p>
+                                        </p>
+                                        <p><i class="fa fa-wikipedia-w"></i> {% trans "Wikipedia" %}</p>
                                     </div>
                                 {% endif %}
                                 {% if article.metrics.alm.reddit %}
                                     <div class="alm">
-                                        <h5>
+                                        <p class="alm_numbers">
                                             {{ article.metrics.alm.reddit }}
-                                        </h5>
-                                        <p><i class="fa fa-reddit"></i>{% trans "Reddit" %}</p>
+                                        </p>
+                                        <p><i class="fa fa-reddit"></i> {% trans "Reddit" %}</p>
                                     </div>
                                 {% endif %}
 
                                 {% if article.citation_count and not journal_settings.article.suppress_citations_metric %}
                                     <div class="alm">
-                                        <h5>
+                                        <p class="alm_numbers">
                                             {{ article.citation_count }}
-                                        </h5>
-                                        <p><i class="fa fa-quote-left"></i>{% trans "Citations" %}</p>
+                                        </p>
+                                        <p><i class="fa fa-quote-left"></i> {% trans "Citations" %}</p>
                                     </div>
                                 {% endif %}
                             </div>


### PR DESCRIPTION
Closes #3912 