### PR TITLE
3933 article menu focus tab order bugfix

### DIFF
--- a/src/themes/OLH/templates/journal/article.html
+++ b/src/themes/OLH/templates/journal/article.html
@@ -123,13 +123,13 @@
                             <ul class="menu vertical medium-horizontal align-right"
                                 data-responsive-menu="dropdown">
                                 {% hook 'article_buttons' %}
-                                <li><a href="{{ article.local_url }}print/"><i class="fa fa-print">&nbsp;</i></a></li>
-                                <li><a href="javascript:resizeText(-1)">A-</a></li>
-                                <li><a href="javascript:resizeText(1)">A+</a></li>
+                                <li><a href="{{ article.local_url }}print/" aria-label="print article"><i class="fa fa-print">&nbsp;</i></a></li>
+                                <li><a href="javascript:resizeText(-1)" aria-label="decrease text size">A-</a></li>
+                                <li><a href="javascript:resizeText(1)" aria-label="increase text size">A+</a></li>
                                 {% if author.display_email and not journal_settings.article.hide_author_email_links %}<li><a href="mailto:{{ article.correspondence_author.email }}"><i class="fa fa-envelope"></i></a></li>{% endif %}
-                                <li><a href="#" id="dyslexia-mode">{% trans "Dyslexia" %}</a></li>
+                                <li><a href="#" id="dyslexia-mode" aria-label="Dyslexia mode">{% trans "Dyslexia" %}</a></li>
                                 <li>
-                                    <a><i class="fa fa-comments"></i></a>
+                                    <a aria-label="Cite article"><i class="fa fa-comments"></i></a>
                                     <ul class="menu vertical">
                                         <li><a data-open="HarvardModal">{% trans "Harvard Citation Style" %}</a></li>
                                         <li><a data-open="VancouverModal">{% trans "Vancouver Citation Style" %}</a></li>

--- a/src/themes/OLH/templates/journal/article.html
+++ b/src/themes/OLH/templates/journal/article.html
@@ -104,7 +104,7 @@
             <div class="mini-bar sticky" data-sticky data-margin-top="0" data-sticky data-anchor="content">
                 <div class="row">
                     <div class="title-bar" data-responsive-toggle="options-menu" data-hide-for="medium">
-                        <button class="menu-icon" type="button" data-toggle></button>
+                        <button class="menu-icon" type="button" data-toggle aria-label="Options"></button>
                         <div class="title-bar-title">{% trans 'Options' %}</div>
                     </div>
                     <div id="options-menu">

--- a/src/themes/OLH/templates/journal/article.html
+++ b/src/themes/OLH/templates/journal/article.html
@@ -108,7 +108,7 @@
                         <div class="title-bar-title">{% trans 'Options' %}</div>
                     </div>
                     <div id="options-menu">
-                        <div class="large-6 columns">
+                        <div class="large-3 medium-4 columns">
                             <ul class="menu vertical medium-horizontal pad-left-15"
                                 data-responsive-menu="drilldown medium-dropdown">
                               {% with article.get_doi_url as doi_url %}
@@ -119,8 +119,8 @@
                               {% endwith %}
                             </ul>
                         </div>
-                        <div class="large-6 columns">
-                            <ul class="menu vertical medium-horizontal align-right"
+                        <div class="large-4 medium-5 columns">
+                            <ul class="menu vertical medium-horizontal"
                                 data-responsive-menu="dropdown">
                                 {% hook 'article_buttons' %}
                                 <li><a href="{{ article.local_url }}print/" aria-label="print article"><i class="fa fa-print">&nbsp;</i></a></li>

--- a/src/themes/OLH/templates/journal/article.html
+++ b/src/themes/OLH/templates/journal/article.html
@@ -129,7 +129,7 @@
                                 {% if author.display_email and not journal_settings.article.hide_author_email_links %}<li><a href="mailto:{{ article.correspondence_author.email }}"><i class="fa fa-envelope"></i></a></li>{% endif %}
                                 <li><a href="#" id="dyslexia-mode" aria-label="Dyslexia mode">{% trans "Dyslexia" %}</a></li>
                                 <li>
-                                    <a aria-label="Cite article"><i class="fa fa-comments"></i></a>
+                                    <a href="#" aria-label="Cite article"><i class="fa fa-comments">&nbsp;</i></a>
                                     <ul class="menu vertical">
                                         <li><a data-open="HarvardModal">{% trans "Harvard Citation Style" %}</a></li>
                                         <li><a data-open="VancouverModal">{% trans "Vancouver Citation Style" %}</a></li>

--- a/src/themes/OLH/templates/journal/article.html
+++ b/src/themes/OLH/templates/journal/article.html
@@ -113,9 +113,9 @@
                                 data-responsive-menu="drilldown medium-dropdown">
                               {% with article.get_doi_url as doi_url %}
                                 <li>{% trans "Share" %}:</li>
-                                <li><a href="https://www.facebook.com/share.php?p[url]={% if doi_url %}{{ doi_url }}{% else %}{{ article.url }}{% endif %}" target="_blank"><i class="fa fa-facebook"></i></a></li>
-                                <li><a href="https://twitter.com/intent/tweet?text={{ article.title }} {% if doi_url %}{{ doi_url }}{% else %}{{ article.url }}{% endif %}" target="_blank"><i class="fa fa-twitter"></i></a></li>
-                                <li><a href="https://www.linkedin.com/sharing/share-offsite?url={% if doi_url %}{{ doi_url }}{% else %}{{ article.url }}{% endif %}" target="_blank"><i class="fa fa-linkedin"></i></a></li>
+                                <li><a href="https://www.facebook.com/share.php?p[url]={% if doi_url %}{{ doi_url }}{% else %}{{ article.url }}{% endif %}" target="_blank" aria-label="Share on Facebook"><i class="fa fa-facebook"></i></a></li>
+                                <li><a href="https://twitter.com/intent/tweet?text={{ article.title }} {% if doi_url %}{{ doi_url }}{% else %}{{ article.url }}{% endif %}" target="_blank" aria-label="Share on X"><i class="fa fa-twitter"></i></a></li>
+                                <li><a href="https://www.linkedin.com/sharing/share-offsite?url={% if doi_url %}{{ doi_url }}{% else %}{{ article.url }}{% endif %}" target="_blank" aria-label="Share on Linked In"><i class="fa fa-linkedin"></i></a></li>
                               {% endwith %}
                             </ul>
                         </div>

--- a/src/themes/OLH/templates/journal/article.html
+++ b/src/themes/OLH/templates/journal/article.html
@@ -131,9 +131,9 @@
                                 <li>
                                     <a href="#" aria-label="Cite article"><i class="fa fa-comments">&nbsp;</i></a>
                                     <ul class="menu vertical">
-                                        <li><a data-open="HarvardModal">{% trans "Harvard Citation Style" %}</a></li>
-                                        <li><a data-open="VancouverModal">{% trans "Vancouver Citation Style" %}</a></li>
-                                        <li><a data-open="APAModal">{% trans "APA Citation Style" %}</a></li>
+                                        <li><a href="#" data-open="HarvardModal">{% trans "Harvard Citation Style" %}</a></li>
+                                        <li><a href="#" data-open="VancouverModal">{% trans "Vancouver Citation Style" %}</a></li>
+                                        <li><a href="#" data-open="APAModal">{% trans "APA Citation Style" %}</a></li>
                                         <li><a href="{% url 'serve_article_ris' 'id' article.pk %}"> {% trans 'Download' %} RIS</a></li>
                                         <li><a href="{% url 'serve_article_bib' 'id' article.pk %}">{% trans ' Download' %} BibTeX</a></li>
                                     </ul>

--- a/src/themes/OLH/templates/journal/article.html
+++ b/src/themes/OLH/templates/journal/article.html
@@ -113,9 +113,9 @@
                                 data-responsive-menu="drilldown medium-dropdown">
                               {% with article.get_doi_url as doi_url %}
                                 <li>{% trans "Share" %}:</li>
-                                <li><a href="https://www.facebook.com/share.php?p[url]={% if doi_url %}{{ doi_url }}{% else %}{{ article.url }}{% endif %}" target="_blank" aria-label="Share on Facebook"><i class="fa fa-facebook"></i></a></li>
-                                <li><a href="https://twitter.com/intent/tweet?text={{ article.title }} {% if doi_url %}{{ doi_url }}{% else %}{{ article.url }}{% endif %}" target="_blank" aria-label="Share on X"><i class="fa fa-twitter"></i></a></li>
-                                <li><a href="https://www.linkedin.com/sharing/share-offsite?url={% if doi_url %}{{ doi_url }}{% else %}{{ article.url }}{% endif %}" target="_blank" aria-label="Share on Linked In"><i class="fa fa-linkedin"></i></a></li>
+                                <li><a href="https://www.facebook.com/share.php?p[url]={% if doi_url %}{{ doi_url }}{% else %}{{ article.url }}{% endif %}" target="_blank" aria-label={% trans "Share on Facebook" %}><i class="fa fa-facebook"></i></a></li>
+                                <li><a href="https://twitter.com/intent/tweet?text={{ article.title }} {% if doi_url %}{{ doi_url }}{% else %}{{ article.url }}{% endif %}" target="_blank" aria-label={% trans "Share on X" %}><i class="fa fa-twitter"></i></a></li>
+                                <li><a href="https://www.linkedin.com/sharing/share-offsite?url={% if doi_url %}{{ doi_url }}{% else %}{{ article.url }}{% endif %}" target="_blank" aria-label={% trans "Share on Linked In" %}><i class="fa fa-linkedin"></i></a></li>
                               {% endwith %}
                             </ul>
                         </div>
@@ -123,13 +123,13 @@
                             <ul class="menu vertical medium-horizontal"
                                 data-responsive-menu="dropdown">
                                 {% hook 'article_buttons' %}
-                                <li><a href="{{ article.local_url }}print/" aria-label="print article"><i class="fa fa-print">&nbsp;</i></a></li>
-                                <li><a href="javascript:resizeText(-1)" aria-label="decrease text size">A-</a></li>
-                                <li><a href="javascript:resizeText(1)" aria-label="increase text size">A+</a></li>
+                                <li><a href="{{ article.local_url }}print/" aria-label={% trans "print article" %}><i class="fa fa-print">&nbsp;</i></a></li>
+                                <li><a href="javascript:resizeText(-1)" aria-label={% trans "decrease text size" %}>A-</a></li>
+                                <li><a href="javascript:resizeText(1)" aria-label={% trans "increase text size" %}>A+</a></li>
                                 {% if author.display_email and not journal_settings.article.hide_author_email_links %}<li><a href="mailto:{{ article.correspondence_author.email }}"><i class="fa fa-envelope"></i></a></li>{% endif %}
-                                <li><a href="#" id="dyslexia-mode" aria-label="Dyslexia mode">{% trans "Dyslexia" %}</a></li>
+                                <li><a href="#" id="dyslexia-mode" aria-label={% trans "Dyslexia mode" %}>{% trans "Dyslexia" %}</a></li>
                                 <li>
-                                    <a href="#" aria-label="Cite article"><i class="fa fa-comments">&nbsp;</i></a>
+                                    <a href="#" aria-label={% trans "Cite article" %}><i class="fa fa-comments">&nbsp;</i></a>
                                     <ul class="menu vertical">
                                         <li><a href="#" data-open="HarvardModal">{% trans "Harvard Citation Style" %}</a></li>
                                         <li><a href="#" data-open="VancouverModal">{% trans "Vancouver Citation Style" %}</a></li>

--- a/src/themes/OLH/templates/journal/article.html
+++ b/src/themes/OLH/templates/journal/article.html
@@ -108,7 +108,7 @@
                         <div class="title-bar-title">{% trans 'Options' %}</div>
                     </div>
                     <div id="options-menu">
-                        <div class="large-3 medium-4 columns">
+                        <div class="small-4 medium-3 large-2 columns">
                             <ul class="menu vertical medium-horizontal pad-left-15"
                                 data-responsive-menu="drilldown medium-dropdown">
                               {% with article.get_doi_url as doi_url %}
@@ -119,26 +119,28 @@
                               {% endwith %}
                             </ul>
                         </div>
-                        <div class="large-4 medium-5 columns">
-                            <ul class="menu vertical medium-horizontal"
-                                data-responsive-menu="dropdown">
-                                {% hook 'article_buttons' %}
-                                <li><a href="{{ article.local_url }}print/" aria-label={% trans "print article" %}><i class="fa fa-print">&nbsp;</i></a></li>
-                                <li><a href="javascript:resizeText(-1)" aria-label={% trans "decrease text size" %}>A-</a></li>
-                                <li><a href="javascript:resizeText(1)" aria-label={% trans "increase text size" %}>A+</a></li>
-                                {% if author.display_email and not journal_settings.article.hide_author_email_links %}<li><a href="mailto:{{ article.correspondence_author.email }}"><i class="fa fa-envelope"></i></a></li>{% endif %}
-                                <li><a href="#" id="dyslexia-mode" aria-label={% trans "Dyslexia mode" %}>{% trans "Dyslexia" %}</a></li>
-                                <li>
-                                    <a href="#" aria-label={% trans "Cite article" %}><i class="fa fa-comments">&nbsp;</i></a>
-                                    <ul class="menu vertical">
-                                        <li><a href="#" data-open="HarvardModal">{% trans "Harvard Citation Style" %}</a></li>
-                                        <li><a href="#" data-open="VancouverModal">{% trans "Vancouver Citation Style" %}</a></li>
-                                        <li><a href="#" data-open="APAModal">{% trans "APA Citation Style" %}</a></li>
-                                        <li><a href="{% url 'serve_article_ris' 'id' article.pk %}"> {% trans 'Download' %} RIS</a></li>
-                                        <li><a href="{% url 'serve_article_bib' 'id' article.pk %}">{% trans ' Download' %} BibTeX</a></li>
-                                    </ul>
-                                </li>
-                            </ul>
+                        <div class="small-8 medium-9 large-10 columns">
+                            <div class="float-right">
+                                <ul class="menu vertical medium-horizontal"
+                                    data-responsive-menu="dropdown">
+                                    {% hook 'article_buttons' %}
+                                    <li><a href="{{ article.local_url }}print/" aria-label={% trans "print article" %}><i class="fa fa-print">&nbsp;</i></a></li>
+                                    <li><a href="javascript:resizeText(-1)" aria-label={% trans "decrease text size" %}>A-</a></li>
+                                    <li><a href="javascript:resizeText(1)" aria-label={% trans "increase text size" %}>A+</a></li>
+                                    {% if author.display_email and not journal_settings.article.hide_author_email_links %}<li><a href="mailto:{{ article.correspondence_author.email }}"><i class="fa fa-envelope"></i></a></li>{% endif %}
+                                    <li><a href="#" id="dyslexia-mode" aria-label={% trans "Dyslexia mode" %}>{% trans "Dyslexia" %}</a></li>
+                                    <li>
+                                        <a href="#" aria-label={% trans "Cite article" %}><i class="fa fa-comments">&nbsp;</i></a>
+                                        <ul class="menu vertical">
+                                            <li><a href="#" data-open="HarvardModal">{% trans "Harvard Citation Style" %}</a></li>
+                                            <li><a href="#" data-open="VancouverModal">{% trans "Vancouver Citation Style" %}</a></li>
+                                            <li><a href="#" data-open="APAModal">{% trans "APA Citation Style" %}</a></li>
+                                            <li><a href="{% url 'serve_article_ris' 'id' article.pk %}"> {% trans 'Download' %} RIS</a></li>
+                                            <li><a href="{% url 'serve_article_bib' 'id' article.pk %}">{% trans ' Download' %} BibTeX</a></li>
+                                        </ul>
+                                    </li>
+                                </ul>
+                            </div>
                         </div>
                     </div>
                 </div>

--- a/src/themes/material/templates/journal/article.html
+++ b/src/themes/material/templates/journal/article.html
@@ -254,13 +254,13 @@
                       {% with article.get_doi_url as doi_url%}
                         <a class="waves-effect waves-light btn btn-small facebook-bg"
                             href="https://www.facebook.com/share.php?p[url]={% if doi_url %}{{ doi_url }}{% else %}{{ article.url }}{% endif %}" 
-                            target="_blank"><i class="fa fa-facebook"></i></a>
+                            target="_blank" aria-label="Share on Facebook"><i class="fa fa-facebook"></i></a>
                         <a class="waves-effect waves-light btn btn-small twitter-bg" 
                             href="https://twitter.com/intent/tweet?text={{ article.title }} {% if doi_url %}{{ doi_url }}{% else %}{{ article.url }}{% endif %}"
-                            target="_blank"><i class="fa fa-twitter"></i></a>
+                            target="_blank" aria-label="Share on X"><i class="fa fa-twitter"></i></a>
                         <a class="waves-effect waves-light btn btn-small linkedin-bg"
                             href="https://www.linkedin.com/sharing/share-offsite?url={% if doi_url %}{{ doi_url }}{% else %}{{ article.url }}{% endif %}"
-                            target="_blank"><i class="fa fa-linkedin"></i></a></button>
+                            target="_blank" aria-label="Share on Linked In"><i class="fa fa-linkedin"></i></a></button>
                       {% endwith %}
 
                     {% if article.frozen_authors.count > 0 %}

--- a/src/themes/material/templates/journal/article.html
+++ b/src/themes/material/templates/journal/article.html
@@ -254,13 +254,13 @@
                       {% with article.get_doi_url as doi_url%}
                         <a class="waves-effect waves-light btn btn-small facebook-bg"
                             href="https://www.facebook.com/share.php?p[url]={% if doi_url %}{{ doi_url }}{% else %}{{ article.url }}{% endif %}" 
-                            target="_blank" aria-label="Share on Facebook"><i class="fa fa-facebook"></i></a>
+                            target="_blank" aria-label= {% trans "Share on Facebook" %}><i class="fa fa-facebook"></i></a>
                         <a class="waves-effect waves-light btn btn-small twitter-bg" 
                             href="https://twitter.com/intent/tweet?text={{ article.title }} {% if doi_url %}{{ doi_url }}{% else %}{{ article.url }}{% endif %}"
-                            target="_blank" aria-label="Share on X"><i class="fa fa-twitter"></i></a>
+                            target="_blank" aria-label={% trans "Share on X" %}><i class="fa fa-twitter"></i></a>
                         <a class="waves-effect waves-light btn btn-small linkedin-bg"
                             href="https://www.linkedin.com/sharing/share-offsite?url={% if doi_url %}{{ doi_url }}{% else %}{{ article.url }}{% endif %}"
-                            target="_blank" aria-label="Share on Linked In"><i class="fa fa-linkedin"></i></a></button>
+                            target="_blank" aria-label={% trans "Share on Linked In" %}><i class="fa fa-linkedin"></i></a></button>
                       {% endwith %}
 
                     {% if article.frozen_authors.count > 0 %}


### PR DESCRIPTION
- items not showing were corrected in #4178 so this branches off that.
- With all items now present, but in wrong order two further changes required:
    - remove 'align-right' which was reversing the visual order of the menu items.
    - adjust column widths within the Foundation Flex layout so that the menu itself remained 'right aligned' (while contents was not reordered).  Small is covered by the hamburger menu, so this required settings for medium and large.  

Closes #3933 