### PR TITLE
#3909 table popups updated to have unique ids

### DIFF
--- a/src/journal/logic.py
+++ b/src/journal/logic.py
@@ -595,9 +595,19 @@ def get_all_tables_from_html(content):
     tables = []
 
     for table in soup.findAll('div', attrs={'class': 'table-expansion'}):
+        original_id = table.get("id")
+        if original_id:
+            table["id"] = "copy-of-" + original_id
+        for child in table.descendants:
+            # try / except because .decendants sometimes returns a string, sometimes an object
+            try:
+                if child.get("id"):
+                    child["id"] = "copy-of-" + child["id"]
+            except AttributeError:
+                pass
         tables.append(
             {
-                'id': table.get('id'),
+                'id': original_id,
                 'content': str(table)
             }
         )


### PR DESCRIPTION
Table modal originally was a copy of table, so all ids were same as original ids.  Not all elements in table have id.

- prefix `copy-of-`
- added to table id
- added to all child ids of that table

paired programming with @mauromsl 

Closes #3909 