### PR TITLE
Replaced use of deprecated `docker-compose` command in favour of `docker compose`

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Developer installation [instructions are available in our documentation site](ht
 A guide for installing on the live environment with [apache and mod_wsgi](https://github.com/BirkbeckCTP/janeway/wiki/Janeway%2C-Apache-and-WSGI) is also available.
 
 ## Running Janeway with docker
-Janeway's development server can be run within a docker container, avoiding the need to install and run its dependencies from your machine. A docker-compose file as well as a Makefile can be found at the root of the project wrapping the most common operations.
+Janeway's development server can be run within a docker container, avoiding the need to install and run its dependencies from your machine. A docker compose file as well as a Makefile can be found at the root of the project wrapping the most common operations.
 Docker is compatible with multiple architectures and Operating systems, if you need help installing docker, have a look at the [docker documentation](https://docs.docker.com/install/).
 
 Simarly to the native installation, Janeway can be installed in a docker environment by running ``make install`` and following the installation steps described [above](https://github.com/BirkbeckCTP/janeway/wiki/Installation). As a result, a database volume will be populated under janeway/db/postgres-data

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -2,9 +2,9 @@ Installation Guide
 ==================
 There are a number of ways to get Janeway up and running. For development we recommend you use Docker with Postgres as the DB_VENDOR. A Lando configuration is also included.
 
-Running Janeway with Docker and docker-compose
+Running Janeway with Docker and docker compose
 ----------------------------------------------
-1. Install ``docker``, ``docker-compose`` and ``GNU Make``.
+1. Install ``docker`` and ``GNU Make``.
 2. From the /path/to/janeway directory run ``make install``.
 3. A docker environment will be provisioned, and shortly after the janeway install script will run. Follow the instructions on screen to complete the installation.
 4. Once install is complete run ``make run`` to run the django development server against a Postgres backend.


### PR DESCRIPTION
It shouldn't affect most users, as `docker-compose` has not received updates since 2021 and docker itself ships with a symbolic link from `docker-compose` to `docker compose` in most distributions.

In any case, I've set the compose command as an environment variable so that systems stuck on the old python based docker-compose could still override it if needed.

closes #4190 