### PR TITLE
Update the HTML tags and CSS styles that are allowed in rich-text content

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ chardet==3.0.4
 crossrefapi==1.5.0
 Django==3.2.20
 django-bleach==3.0.1
+bleach-allowlist==1.0.3
 django-bootstrap4==22.3
 -e git+https://github.com/BirkbeckCTP/django-foundation-form.git@284fc5f08e58d8655c7301eddb49f920fda516d2#egg=foundationform
 django-countries[pyuca]==7.5.1

--- a/src/core/janeway_global_settings.py
+++ b/src/core/janeway_global_settings.py
@@ -24,6 +24,7 @@ import logging
 from django.contrib import messages
 
 from core import plugin_installed_apps
+from utils.const import get_allowed_html_tags, get_allowed_css_styles
 
 # X_FRAME_OPTIONS must be set to SAMEORIGIN or the embedded PDF viewer will not work
 X_FRAME_OPTIONS = "SAMEORIGIN"
@@ -282,26 +283,7 @@ if ENABLE_TEXTURE:
     STATICFILES_DIRS.append(os.path.join(BASE_DIR, 'texture'))
 
 # Django bleach settings
-# Base case is to allow all tags except for <script>. Individual form instances
-# can further reduce the set of allowed tags
-BLEACH_ALLOWED_TAGS = [
-    "html", "head", "title", "meta", "link", "style",
-    "body", "article", "section", "nav", "aside",
-    "h1", "h2", "h3", "h4", "h5", "h6",
-    "header", "footer", "address", "main", "p", "hr", "pre",
-    "blockquote", "ol", "ul", "li", "dl", "dt", "dd",
-    "figure", "figcaption", "div", "a", "em", "strong", "small",
-    "s", "cite", "q", "dfn", "abbr", "data", "time",
-    "code", "var", "samp", "kbd", "sub", "sup", "i",
-    "b", "u", "mark", "ruby", "rt", "rp", "bdi",
-    "bdo", "span", "br", "wbr", "ins", "del", "picture",
-    "source", "img", "iframe", "embed", "object", "param", "video",
-    "audio", "track", "map", "area", "table", "caption", "colgroup",
-    "col", "tbody", "thead", "tfoot", "tr", "td", "th",
-    "form", "fieldset", "legend", "label", "input", "button", "select",
-    "datalist", "optgroup", "option", "textarea", "output", "progress", "meter",
-    "details", "summary", "menu", "menuitem", "dialog", "slot", "canvas"
-]
+BLEACH_ALLOWED_TAGS = get_allowed_html_tags()
 
 # Which HTML attributes are allowed
 BLEACH_ALLOWED_ATTRIBUTES = [
@@ -317,7 +299,7 @@ BLEACH_ALLOWED_PROTOCOLS = ["http", "https", "mailto"]
 
 # Which CSS properties are allowed in 'style' attributes (assuming
 # style is an allowed attribute)
-# BLEACH_ALLOWED_STYLES = []
+BLEACH_ALLOWED_STYLES = get_allowed_css_styles()
 
 # Strip unknown tags if True, replace with HTML escaped characters if
 # False

--- a/src/core/model_utils.py
+++ b/src/core/model_utils.py
@@ -42,7 +42,7 @@ from django.utils.functional import cached_property
 from django.utils import translation, timezone
 from django.conf import settings
 from django.db.models.query import QuerySet
-from django_bleach.models import BleachField
+from django_bleach.models import BleachField, CSSSanitizer
 
 from modeltranslation.manager import MultilingualManager, MultilingualQuerySet
 from modeltranslation.utils import auto_populate
@@ -579,6 +579,11 @@ class JanewayBleachField(BleachField):
     not when using the value elsewhere (XML encoding)
     https://github.com/marksweb/django-bleach/blob/504b3784c525886ba1974eb9ecbff89314688491/django_bleach/models.py#L76
     """
+
+    def __init__(self, *args, **kwargs):
+        kwargs['css_sanitizer'] = CSSSanitizer()
+        super().__init__(*args, **kwargs)
+
     def from_db_value(self, value,expression, connection):
         return value
 

--- a/src/core/model_utils.py
+++ b/src/core/model_utils.py
@@ -42,7 +42,7 @@ from django.utils.functional import cached_property
 from django.utils import translation, timezone
 from django.conf import settings
 from django.db.models.query import QuerySet
-from django_bleach.models import BleachField, CSSSanitizer
+from django_bleach.models import BleachField
 
 from modeltranslation.manager import MultilingualManager, MultilingualQuerySet
 from modeltranslation.utils import auto_populate
@@ -579,10 +579,6 @@ class JanewayBleachField(BleachField):
     not when using the value elsewhere (XML encoding)
     https://github.com/marksweb/django-bleach/blob/504b3784c525886ba1974eb9ecbff89314688491/django_bleach/models.py#L76
     """
-
-    def __init__(self, *args, **kwargs):
-        kwargs['css_sanitizer'] = CSSSanitizer()
-        super().__init__(*args, **kwargs)
 
     def from_db_value(self, value,expression, connection):
         return value

--- a/src/core/tests/test_models.py
+++ b/src/core/tests/test_models.py
@@ -371,26 +371,3 @@ class TestLastModifiedModel(TestCase):
 
         # Test
         self.assertEqual(self.article.best_last_modified_date(), file_date)
-
-
-class TestModelUtils(TestCase):
-
-    @classmethod
-    def setUpTestData(cls):
-        cls.press = helpers.create_press()
-        cls.journal, _ = helpers.create_journals()
-        cls.article = helpers.create_article(
-            journal=cls.journal,
-        )
-
-    def test_bleach_style_attr(self):
-        html_with_style = '''
-            In <span style="font-style: italic;">Passing</span> Larsen...
-        '''
-        self.article.abstract = html_with_style
-        self.article.save()
-        self.article.refresh_from_db()
-        self.assertEqual(
-            html_with_style,
-            self.article.abstract,
-        )

--- a/src/core/tests/test_models.py
+++ b/src/core/tests/test_models.py
@@ -371,3 +371,26 @@ class TestLastModifiedModel(TestCase):
 
         # Test
         self.assertEqual(self.article.best_last_modified_date(), file_date)
+
+
+class TestModelUtils(TestCase):
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.press = helpers.create_press()
+        cls.journal, _ = helpers.create_journals()
+        cls.article = helpers.create_article(
+            journal=cls.journal,
+        )
+
+    def test_bleach_style_attr(self):
+        html_with_style = '''
+            In <span style="font-style: italic;">Passing</span> Larsen...
+        '''
+        self.article.abstract = html_with_style
+        self.article.save()
+        self.article.refresh_from_db()
+        self.assertEqual(
+            html_with_style,
+            self.article.abstract,
+        )

--- a/src/utils/const.py
+++ b/src/utils/const.py
@@ -1,4 +1,8 @@
 from enum import Enum, EnumMeta
+from bleach_allowlist import (
+    all_styles as _all_styles,
+    generally_xss_safe as _generally_xss_safe
+)
 
 class EnumContainsMeta(EnumMeta):
 
@@ -11,3 +15,11 @@ class EnumContainsMeta(EnumMeta):
 
 class EnumContains(Enum, metaclass=EnumContainsMeta):
     pass
+
+
+def get_allowed_html_tags():
+    return _generally_xss_safe
+
+
+def get_allowed_css_styles():
+    return _all_styles


### PR DESCRIPTION
This implements the discussed solution of borrowing from `bleach-allowlist` to cover the standard set of HTML elements and CSS properties that are safe to include in bleached fields.

Fixes #4195.