### PR TITLE
A warning will show in prepublication when an article has no license set.

### DIFF
--- a/src/templates/admin/journal/publish_article.html
+++ b/src/templates/admin/journal/publish_article.html
@@ -197,9 +197,10 @@
                     {% if journal_settings.general.abstract_required and not article.abstract %}
                         <li>This journal requires article to have an abstract - this article does not have one <a target="_blank" href="{% url 'edit_metadata' article.pk %}?return={{ request.path|urlencode }}">[change]</a></li>{% endif %}
                     <li>This article has been marked as {% if not article.peer_reviewed %}not {% endif %}peer reviewed <a target="_blank" href="{% url 'edit_metadata' article.pk %}?return={{ request.path|urlencode }}">[change]</a>
-                    {% if not article.get_doi %}<li>No DOI has been asigned <a target="_blank" href="{% url 'edit_identifiers' article.pk %}">[change]</a></li>{% endif %}
+                    {% if not article.get_doi %}<li>No DOI has been assigned <a target="_blank" href="{% url 'edit_identifiers' article.pk %}">[change]</a></li>{% endif %}
                     {% if not article.keywords.count > 0 %}<li>No keywords have been set <a target="_blank" href="{% url 'edit_metadata' article.pk %}?return={{ request.path|urlencode }}">[change]</a></li>{% endif %}
                     {% if not article.issues_list.count > 0 %}<li>This article has not been assigned to an Issue yet{% if article.projected_issue %} It was projected to be in {{ article.projected_issue }}{% endif %} <a href="?m=issue">[change]</a></li>{% endif %}
+                    {% if not article.license %}<li>No license has been set <a target="_blank" href="{% url 'edit_metadata' article.pk %}?return={{ request.path|urlencode }}">[change]</a>.</li>{% endif %}
                 </ul>
             </div>
         </div>

--- a/src/templates/admin/journal/publish_article.html
+++ b/src/templates/admin/journal/publish_article.html
@@ -201,6 +201,7 @@
                     {% if not article.keywords.count > 0 %}<li>No keywords have been set <a target="_blank" href="{% url 'edit_metadata' article.pk %}?return={{ request.path|urlencode }}">[change]</a></li>{% endif %}
                     {% if not article.issues_list.count > 0 %}<li>This article has not been assigned to an Issue yet{% if article.projected_issue %} It was projected to be in {{ article.projected_issue }}{% endif %} <a href="?m=issue">[change]</a></li>{% endif %}
                     {% if not article.license %}<li>No license has been set <a target="_blank" href="{% url 'edit_metadata' article.pk %}?return={{ request.path|urlencode }}">[change]</a>.</li>{% endif %}
+                    {% if article.license and not article.license.url %}<li>The set license has no URL <a href="{% url 'submission_licenses_id' article.license.pk %}">[edit license]</a>.</li>{% endif %}
                 </ul>
             </div>
         </div>

--- a/src/templates/admin/journal/publish_article.html
+++ b/src/templates/admin/journal/publish_article.html
@@ -195,13 +195,13 @@
                 <p><strong><span class="fa fa-warning"> </span> Warnings</strong></p>
                 <ul>
                     {% if journal_settings.general.abstract_required and not article.abstract %}
-                        <li>This journal requires article to have an abstract - this article does not have one <a target="_blank" href="{% url 'edit_metadata' article.pk %}?return={{ request.path|urlencode }}">[change]<span class="sr-only"> Opens in new tab</span></a></li>{% endif %}
-                    <li>This article has been marked as {% if not article.peer_reviewed %}not {% endif %}peer reviewed <a target="_blank" href="{% url 'edit_metadata' article.pk %}?return={{ request.path|urlencode }}">[change]<span class="sr-only"> Opens in new tab</span></a>
-                    {% if not article.get_doi %}<li>No DOI has been assigned <a target="_blank" href="{% url 'edit_identifiers' article.pk %}">[change]<span class="sr-only"> Opens in new tab</span></a></li>{% endif %}
-                    {% if not article.keywords.count > 0 %}<li>No keywords have been set <a target="_blank" href="{% url 'edit_metadata' article.pk %}?return={{ request.path|urlencode }}">[change]<span class="sr-only"> Opens in new tab</span></a></li>{% endif %}
+                        <li>This journal requires article to have an abstract - this article does not have one <a target="_blank" href="{% url 'edit_metadata' article.pk %}?return={{ request.path|urlencode }}">[change]<span class="show-for-sr"> Opens in new tab</span></a></li>{% endif %}
+                    <li>This article has been marked as {% if not article.peer_reviewed %}not {% endif %}peer reviewed <a target="_blank" href="{% url 'edit_metadata' article.pk %}?return={{ request.path|urlencode }}">[change]<span class="show-for-sr"> Opens in new tab</span></a>
+                    {% if not article.get_doi %}<li>No DOI has been assigned <a target="_blank" href="{% url 'edit_identifiers' article.pk %}">[change]<span class="show-for-sr"> Opens in new tab</span></a></li>{% endif %}
+                    {% if not article.keywords.count > 0 %}<li>No keywords have been set <a target="_blank" href="{% url 'edit_metadata' article.pk %}?return={{ request.path|urlencode }}">[change]<span class="show-for-sr"> Opens in new tab</span></a></li>{% endif %}
                     {% if not article.issues_list.count > 0 %}<li>This article has not been assigned to an Issue yet{% if article.projected_issue %} It was projected to be in {{ article.projected_issue }}{% endif %} <a href="?m=issue">[change]</a></li>{% endif %}
-                    {% if not article.license %}<li>No license has been set <a target="_blank" href="{% url 'edit_metadata' article.pk %}?return={{ request.path|urlencode }}">[change]<span class="sr-only"> Opens in new tab</span></a>.</li>{% endif %}
-                    {% if article.license and not article.license.url %}<li>The set license has no URL <a target="_blank" href="{% url 'submission_licenses_id' article.license.pk %}">[edit license]<span class="sr-only"> Opens in new tab</span></a>.</li>{% endif %}
+                    {% if not article.license %}<li>No license has been set <a target="_blank" href="{% url 'edit_metadata' article.pk %}?return={{ request.path|urlencode }}">[change]<span class="show-for-sr"> Opens in new tab</span></a>.</li>{% endif %}
+                    {% if article.license and not article.license.url %}<li>The set license has no URL <a target="_blank" href="{% url 'submission_licenses_id' article.license.pk %}">[edit license]<span class="show-for-sr"> Opens in new tab</span></a>.</li>{% endif %}
                 </ul>
             </div>
         </div>

--- a/src/templates/admin/journal/publish_article.html
+++ b/src/templates/admin/journal/publish_article.html
@@ -195,13 +195,13 @@
                 <p><strong><span class="fa fa-warning"> </span> Warnings</strong></p>
                 <ul>
                     {% if journal_settings.general.abstract_required and not article.abstract %}
-                        <li>This journal requires article to have an abstract - this article does not have one <a target="_blank" href="{% url 'edit_metadata' article.pk %}?return={{ request.path|urlencode }}">[change]</a></li>{% endif %}
-                    <li>This article has been marked as {% if not article.peer_reviewed %}not {% endif %}peer reviewed <a target="_blank" href="{% url 'edit_metadata' article.pk %}?return={{ request.path|urlencode }}">[change]</a>
-                    {% if not article.get_doi %}<li>No DOI has been assigned <a target="_blank" href="{% url 'edit_identifiers' article.pk %}">[change]</a></li>{% endif %}
-                    {% if not article.keywords.count > 0 %}<li>No keywords have been set <a target="_blank" href="{% url 'edit_metadata' article.pk %}?return={{ request.path|urlencode }}">[change]</a></li>{% endif %}
+                        <li>This journal requires article to have an abstract - this article does not have one <a target="_blank" href="{% url 'edit_metadata' article.pk %}?return={{ request.path|urlencode }}">[change]<span class="sr-only"> Opens in new tab</span></a></li>{% endif %}
+                    <li>This article has been marked as {% if not article.peer_reviewed %}not {% endif %}peer reviewed <a target="_blank" href="{% url 'edit_metadata' article.pk %}?return={{ request.path|urlencode }}">[change]<span class="sr-only"> Opens in new tab</span></a>
+                    {% if not article.get_doi %}<li>No DOI has been assigned <a target="_blank" href="{% url 'edit_identifiers' article.pk %}">[change]<span class="sr-only"> Opens in new tab</span></a></li>{% endif %}
+                    {% if not article.keywords.count > 0 %}<li>No keywords have been set <a target="_blank" href="{% url 'edit_metadata' article.pk %}?return={{ request.path|urlencode }}">[change]<span class="sr-only"> Opens in new tab</span></a></li>{% endif %}
                     {% if not article.issues_list.count > 0 %}<li>This article has not been assigned to an Issue yet{% if article.projected_issue %} It was projected to be in {{ article.projected_issue }}{% endif %} <a href="?m=issue">[change]</a></li>{% endif %}
-                    {% if not article.license %}<li>No license has been set <a target="_blank" href="{% url 'edit_metadata' article.pk %}?return={{ request.path|urlencode }}">[change]</a>.</li>{% endif %}
-                    {% if article.license and not article.license.url %}<li>The set license has no URL <a href="{% url 'submission_licenses_id' article.license.pk %}">[edit license]</a>.</li>{% endif %}
+                    {% if not article.license %}<li>No license has been set <a target="_blank" href="{% url 'edit_metadata' article.pk %}?return={{ request.path|urlencode }}">[change]<span class="sr-only"> Opens in new tab</span></a>.</li>{% endif %}
+                    {% if article.license and not article.license.url %}<li>The set license has no URL <a target="_blank" href="{% url 'submission_licenses_id' article.license.pk %}">[edit license]<span class="sr-only"> Opens in new tab</span></a>.</li>{% endif %}
                 </ul>
             </div>
         </div>


### PR DESCRIPTION
- Adds two warnings, one when there is no set license and another when the set license has no URL.

Closes #2270 

<img width="351" alt="image" src="https://github.com/BirkbeckCTP/janeway/assets/8321378/dd3270d8-0ed4-4468-a61d-92fe63c7dee7"> <img width="350" alt="image" src="https://github.com/BirkbeckCTP/janeway/assets/8321378/500e55ae-dd04-42d0-beaa-5a64e109bad3">

