### PR TITLE
#4256 updates views with journal filters.

### DIFF
--- a/src/copyediting/views.py
+++ b/src/copyediting/views.py
@@ -38,8 +38,10 @@ def copyediting(request):
     :return: a contextualised template
     """
 
-    articles_in_copyediting = submission_models.Article.objects.filter(stage__in=submission_models.COPYEDITING_STAGES,
-                                                                       journal=request.journal)
+    articles_in_copyediting = submission_models.Article.objects.filter(
+        stage__in=submission_models.COPYEDITING_STAGES,
+        journal=request.journal,
+    )
 
     if not request.user.is_editor(request) and request.user.is_section_editor(request):
         articles_in_copyediting = core_logic.filter_articles_to_editor_assigned(
@@ -64,7 +66,11 @@ def article_copyediting(request, article_id):
     :return: a contextualised template
     """
 
-    article = get_object_or_404(submission_models.Article, pk=article_id)
+    article = get_object_or_404(
+        submission_models.Article,
+        pk=article_id,
+        journal=request.journal,
+    )
     copyeditor_assignments = models.CopyeditAssignment.objects.filter(
         article=article,
     )
@@ -128,7 +134,11 @@ def add_copyeditor_assignment(request, article_id):
     :param article_id: a submission.models.Article PK
     :return: HttpRequest object
     """
-    article = get_object_or_404(submission_models.Article, pk=article_id)
+    article = get_object_or_404(
+        submission_models.Article,
+        pk=article_id,
+        journal=request.journal,
+    )
     copyeditors = logic.get_copyeditors(article)
     copyeditor_pks = [copyeditor.user.pk for copyeditor in copyeditors]
     files = article.manuscript_files.all() | article.data_figure_files.all()
@@ -181,7 +191,11 @@ def notify_copyeditor_assignment(request, article_id, copyedit_id):
     :param copyedit_id: a CopyeditAssignment PK
     :return: HttpRequest object
     """
-    article = get_object_or_404(submission_models.Article, pk=article_id)
+    article = get_object_or_404(
+        submission_models.Article,
+        pk=article_id,
+        journal=request.journal,
+    )
     copyedit = get_object_or_404(models.CopyeditAssignment, pk=copyedit_id)
     email_context = logic.get_copyeditor_notification_context(
         request, article, copyedit,
@@ -234,7 +248,11 @@ def edit_assignment(request, article_id, copyedit_id):
     :param copyedit_id: a CopyeditAssignment PK
     :return:
     """
-    article = get_object_or_404(submission_models.Article, pk=article_id)
+    article = get_object_or_404(
+        submission_models.Article,
+        pk=article_id,
+        journal=request.journal,
+    )
     copyedit = get_object_or_404(models.CopyeditAssignment, pk=copyedit_id)
 
     if copyedit.decision:

--- a/src/core/views.py
+++ b/src/core/views.py
@@ -741,7 +741,11 @@ def dashboard_article(request, article_id):
     :param article_id: int, Article object primary key
     :return: HttpResponse object
     """
-    article = get_object_or_404(submission_models.Article, pk=article_id)
+    article = get_object_or_404(
+        submission_models.Article,
+        pk=article_id,
+        journal=request.journal,
+    )
 
     template = 'core/article.html'
     context = {

--- a/src/journal/views.py
+++ b/src/journal/views.py
@@ -805,7 +805,11 @@ def submit_files_info(request, article_id, file_id):
     :param file_id: the file ID for which to submit information
     :return: a rendered template to submit file information
     """
-    article_object = get_object_or_404(submission_models.Article, pk=article_id)
+    article_object = get_object_or_404(
+        submission_models.Article,
+        pk=article_id,
+        journal=request.journal,
+    )
     file_object = get_object_or_404(core_models.File, pk=file_id)
 
     form = review_forms.ReplacementFileDetails(instance=file_object)
@@ -841,7 +845,11 @@ def file_history(request, article_id, file_id):
     if request.POST:
         return redirect(request.GET['return'])
 
-    article_object = get_object_or_404(submission_models.Article, pk=article_id)
+    article_object = get_object_or_404(
+        submission_models.Article,
+        pk=article_id,
+        journal=request.journal,
+    )
     file_object = get_object_or_404(core_models.File, pk=file_id)
 
     template = "journal/file_history.html"
@@ -882,7 +890,11 @@ def file_delete(request, article_id, file_id):
     :param file_id: the file ID for which to view the history
     :return: a redirect to the URL at the GET parameter 'return'
     """
-    article_object = get_object_or_404(submission_models.Article, pk=article_id)
+    article_object = get_object_or_404(
+        submission_models.Article,
+        pk=article_id,
+        journal=request.journal,
+    )
     file_object = get_object_or_404(core_models.File, pk=file_id)
 
     file_object.delete()
@@ -900,7 +912,11 @@ def article_file_make_galley(request, article_id, file_id):
     :param file_id: the file ID for which to view the history
     :return: a redirect to the URL at the GET parameter 'return'
     """
-    article_object = get_object_or_404(submission_models.Article, pk=article_id)
+    article_object = get_object_or_404(
+        submission_models.Article,
+        pk=article_id,
+        journal=request.journal,
+    )
     janeway_file = get_object_or_404(core_models.File, pk=file_id)
     blob = janeway_file.get_file(article_object, as_bytes=True)
     content_file = ContentFile(blob)
@@ -969,6 +985,7 @@ def article_figure(request, article_id, galley_id, file_name):
     figure_article = get_object_or_404(
         submission_models.Article,
         pk=article_id,
+        journal=request.journal,
     )
     galley = get_object_or_404(
         core_models.Galley,
@@ -1233,10 +1250,13 @@ def publish_article_check(request, article_id):
     :param article_id: Artcle object PK
     :return: HttpResponse object
     """
-    article = get_object_or_404(submission_models.Article,
-                                Q(stage=submission_models.STAGE_READY_FOR_PUBLICATION) |
-                                Q(stage=submission_models.STAGE_PUBLISHED),
-                                pk=article_id)
+    article = get_object_or_404(
+        submission_models.Article,
+        Q(stage=submission_models.STAGE_READY_FOR_PUBLICATION) |
+        Q(stage=submission_models.STAGE_PUBLISHED),
+        pk=article_id,
+        journal=request.journal,
+    )
 
     task_type = request.POST.get('task_type')
     id = request.POST.get('id')
@@ -1759,7 +1779,11 @@ def manage_archive_article(request, article_id):
     from identifiers import models as identifier_models
     from submission import forms as submission_forms
 
-    article = get_object_or_404(submission_models.Article, pk=article_id)
+    article = get_object_or_404(
+        submission_models.Article,
+        pk=article_id,
+        journal=request.journal,
+    )
     galleys = production_logic.get_all_galleys(article)
     identifiers = identifier_models.Identifier.objects.filter(article=article)
     galley_form = production_forms.GalleyForm()
@@ -2177,7 +2201,11 @@ def manage_article_log(request, article_id):
     :param article_id: Article object PK
     :return: HttpResponse object
     """
-    article = get_object_or_404(submission_models.Article, pk=article_id)
+    article = get_object_or_404(
+        submission_models.Article,
+        pk=article_id,
+        journal=request.journal,
+    )
     content_type = ContentType.objects.get_for_model(article)
     log_entries = utils_models.LogEntry.objects.filter(content_type=content_type, object_id=article.pk)
 
@@ -2197,7 +2225,11 @@ def manage_article_log(request, article_id):
 
 @editor_user_required
 def resend_logged_email(request, article_id, log_id):
-    article = get_object_or_404(submission_models.Article, pk=article_id)
+    article = get_object_or_404(
+        submission_models.Article,
+        pk=article_id,
+        journal=request.journal,
+    )
     log_entry = get_object_or_404(utils_models.LogEntry, pk=log_id)
     form = forms.ResendEmailForm(log_entry=log_entry)
     close = False
@@ -2234,7 +2266,8 @@ def send_user_email(request, user_id, article_id=None):
     if article_id:
         article = get_object_or_404(
             submission_models.Article,
-            pk=article_id
+            pk=article_id,
+            journal=request.journal,
         )
 
     if request.POST and 'send' in request.POST:
@@ -2271,7 +2304,11 @@ def new_note(request, article_id):
     :param article_id: Article object PK
     :return: HttpResponse object
     """
-    article = get_object_or_404(submission_models.Article, pk=article_id)
+    article = get_object_or_404(
+        submission_models.Article,
+        pk=article_id,
+        journal=request.journal,
+    )
 
     if request.POST:
 
@@ -2339,9 +2376,16 @@ def download_table(request, identifier_type, identifier, table_name):
 
 
 def download_supp_file(request, article_id, supp_file_id):
-    article = get_object_or_404(submission_models.Article, pk=article_id,
-                                stage=submission_models.STAGE_PUBLISHED)
-    supp_file = get_object_or_404(core_models.SupplementaryFile, pk=supp_file_id)
+    article = get_object_or_404(
+        submission_models.Article,
+        pk=article_id,
+        journal=request.journal,
+        stage=submission_models.STAGE_PUBLISHED,
+    )
+    supp_file = get_object_or_404(
+        core_models.SupplementaryFile,
+        pk=supp_file_id,
+    )
 
     return files.serve_file(request, supp_file.file, article, public=True)
 
@@ -2361,7 +2405,11 @@ def texture_edit(request, file_id):
 
 @editor_user_required
 def document_management(request, article_id):
-    document_article = get_object_or_404(submission_models.Article, pk=article_id)
+    document_article = get_object_or_404(
+        submission_models.Article,
+        pk=article_id,
+        journal=request.journal,
+    )
     article_files = core_models.File.objects.filter(article_id=document_article.pk)
     return_url = request.GET.get('return', '/dashboard/')
 

--- a/src/proofing/views.py
+++ b/src/proofing/views.py
@@ -281,9 +281,11 @@ def edit_proofing_assignment(request, article_id, proofing_task_id):
     :param proofing_task_id: ProofingTask PK
     :return: HttpRedirect or HttpResponse
     """
-    article = get_object_or_404(submission_models.Article,
-                                pk=article_id,
-                                journal=request.journal)
+    article = get_object_or_404(
+        submission_models.Article,
+        pk=article_id,
+        journal=request.journal,
+    )
     proofing_task = get_object_or_404(models.ProofingTask,
                                       pk=proofing_task_id)
 
@@ -384,7 +386,11 @@ def notify_proofreader(request, article_id, proofing_task_id):
     :param proofing_task_id: ProofingTask PK
     :return: HttpRedirect or HttpResponse
     """
-    article = get_object_or_404(submission_models.Article.objects.select_related('productionassignment'), pk=article_id)
+    article = get_object_or_404(
+        submission_models.Article.objects.select_related('productionassignment'),
+        pk=article_id,
+        journal=request.journal,
+    )
     proofing_task = get_object_or_404(models.ProofingTask, pk=proofing_task_id)
     user_message_content = logic.get_notify_proofreader(request, article, proofing_task)
 
@@ -628,7 +634,11 @@ def notify_typesetter_changes(request, article_id, proofing_task_id, typeset_tas
     :param typeset_task_id: TypesetterProofingTask PK
     :return: HttpRedirect or HttpResponse
     """
-    article = get_object_or_404(submission_models.Article, pk=article_id)
+    article = get_object_or_404(
+        submission_models.Article,
+        pk=article_id,
+        journal=request.journal,
+    )
     proofing_task = get_object_or_404(models.ProofingTask, pk=proofing_task_id)
     typeset_task = get_object_or_404(models.TypesetterProofingTask, pk=typeset_task_id)
     notification_email_content = logic.get_notify_typesetter(request, article, proofing_task, typeset_task)
@@ -717,7 +727,11 @@ def acknowledge(request, article_id, model_name, model_pk):
     :return: HttpRedirect or HttpResponse
     """
     model, model_object = logic.get_model_and_object(model_name, model_pk)
-    article = get_object_or_404(submission_models.Article, pk=article_id)
+    article = get_object_or_404(
+        submission_models.Article,
+        pk=article_id,
+        journal=request.journal,
+    )
     text = logic.get_ack_message(request, article, model_name, model_object)
 
     if request.POST:
@@ -753,9 +767,12 @@ def complete_proofing(request, article_id):
     :param article_id: Article object PK
     :return: HttpResponse object
     """
-    article = get_object_or_404(submission_models.Article,
-                                stage=submission_models.STAGE_PROOFING,
-                                pk=article_id)
+    article = get_object_or_404(
+        submission_models.Article,
+        stage=submission_models.STAGE_PROOFING,
+        pk=article_id,
+        journal=request.journal,
+    )
     message = logic.get_complete_proofing_message(request, article)
 
     if request.POST:

--- a/src/review/views.py
+++ b/src/review/views.py
@@ -107,7 +107,11 @@ def unassigned_article(request, article_id):
     :param article_id: Article PK
     :return: HttpResponse or Redirect if POST
     """
-    article = get_object_or_404(submission_models.Article, pk=article_id)
+    article = get_object_or_404(
+        submission_models.Article,
+        pk=article_id,
+        journal=request.journal,
+    )
 
     if article.ithenticate_id and not article.ithenticate_score:
         ithenticate.fetch_percentage(request.journal, [article])
@@ -162,6 +166,7 @@ def add_projected_issue(request, article_id):
     article = get_object_or_404(
         submission_models.Article,
         pk=article_id,
+        journal=request.journal,
     )
 
     form = submission_forms.ProjectedIssueForm(instance=article)
@@ -208,6 +213,7 @@ def view_ithenticate_report(request, article_id):
         submission_models.Article,
         pk=article_id,
         ithenticate_id__isnull=False,
+        journal=request.journal,
     )
 
     ithenticate_url = ithenticate.fetch_url(article)
@@ -241,7 +247,11 @@ def assign_editor(request, article_id, editor_id, assignment_type, should_redire
     :param should_redirect: if true, we redirect the user to the notification page
     :return: HttpResponse or HttpRedirect
     """
-    article = get_object_or_404(submission_models.Article, pk=article_id)
+    article = get_object_or_404(
+        submission_models.Article,
+        pk=article_id,
+        journal=request.journal,
+    )
     editor = get_object_or_404(core_models.Account, pk=editor_id)
 
     if not editor.has_an_editor_role(request):
@@ -264,7 +274,11 @@ def assign_editor(request, article_id, editor_id, assignment_type, should_redire
 @senior_editor_user_required
 def unassign_editor(request, article_id, editor_id):
     """Unassigns an editor from an article"""
-    article = get_object_or_404(submission_models.Article, pk=article_id)
+    article = get_object_or_404(
+        submission_models.Article,
+        pk=article_id,
+        journal=request.journal,
+    )
     editor = get_object_or_404(core_models.Account, pk=editor_id)
     assignment = get_object_or_404(
         models.EditorAssignment, article=article, editor=editor
@@ -330,7 +344,11 @@ def assignment_notification(request, article_id, editor_id):
     :param editor_id: Account PK
     :return: HttpResponse or HttpRedirect
     """
-    article = get_object_or_404(submission_models.Article, pk=article_id)
+    article = get_object_or_404(
+        submission_models.Article,
+        pk=article_id,
+        journal=request.journal,
+    )
     editor = get_object_or_404(core_models.Account, pk=editor_id)
     assignment = get_object_or_404(models.EditorAssignment, article=article, editor=editor, notified=False)
 
@@ -378,7 +396,11 @@ def assignment_notification(request, article_id, editor_id):
 @editor_user_required
 def move_to_review(request, article_id, should_redirect=True):
     """Moves an article into the review stage"""
-    article = get_object_or_404(submission_models.Article, pk=article_id)
+    article = get_object_or_404(
+        submission_models.Article,
+        pk=article_id,
+        journal=request.journal,
+    )
 
     if article.editorassignment_set.all().count() > 0:
         article.stage = submission_models.STAGE_ASSIGNED
@@ -407,7 +429,11 @@ def in_review(request, article_id):
     :param article_id: Article PK
     :return: HttpResponse
     """
-    article = get_object_or_404(submission_models.Article, pk=article_id)
+    article = get_object_or_404(
+        submission_models.Article,
+        pk=article_id,
+        journal=request.journal,
+    )
     review_rounds = models.ReviewRound.objects.filter(article=article)
     revisions_requests = models.RevisionRequest.objects.filter(article=article)
 
@@ -563,7 +589,11 @@ def delete_review_round(request, article_id, round_id):
     :param round_id: Round PK
     :return: HttpResponse or HttpRedirect
     """
-    article = get_object_or_404(submission_models.Article, pk=article_id)
+    article = get_object_or_404(
+        submission_models.Article,
+        pk=article_id,
+        journal=request.journal,
+    )
     review_round = get_object_or_404(models.ReviewRound, pk=round_id)
 
     if request.POST:
@@ -601,8 +631,15 @@ def add_files(request, article_id, round_id):
     :param round_id: Round PK
     :return: HttpResponse or HttpRedirect
     """
-    article = get_object_or_404(submission_models.Article.objects.prefetch_related('manuscript_files'), pk=article_id)
-    review_round = get_object_or_404(models.ReviewRound.objects.prefetch_related('review_files'), pk=round_id)
+    article = get_object_or_404(
+        submission_models.Article.objects.prefetch_related('manuscript_files'),
+        pk=article_id,
+        journal=request.journal,
+    )
+    review_round = get_object_or_404(
+        models.ReviewRound.objects.prefetch_related('review_files'),
+        pk=round_id,
+    )
 
     if request.POST:
 
@@ -644,7 +681,11 @@ def add_files(request, article_id, round_id):
 @editor_user_required
 def remove_file(request, article_id, round_id, file_id):
     """Removes a file from a review round."""
-    article = get_object_or_404(submission_models.Article, pk=article_id)
+    article = get_object_or_404(
+        submission_models.Article,
+        pk=article_id,
+        journal=request.journal,
+    )
     review_round = get_object_or_404(models.ReviewRound, pk=round_id)
     file = get_object_or_404(core_models.File, pk=file_id)
 
@@ -1084,7 +1125,11 @@ def add_review_assignment(request, article_id):
     :param article_id: Article PK
     :return: HttpResponse
     """
-    article = get_object_or_404(submission_models.Article, pk=article_id)
+    article = get_object_or_404(
+        submission_models.Article,
+        pk=article_id,
+        journal=request.journal,
+    )
     reviewers = logic.get_reviewer_candidates(
         article,
         user=request.user,
@@ -1186,7 +1231,11 @@ def notify_reviewer(request, article_id, review_id):
     :param review_id: ReviewAssignment PK
     :return: HttpResponse or HttpRedirect
     """
-    article = get_object_or_404(submission_models.Article, pk=article_id)
+    article = get_object_or_404(
+        submission_models.Article,
+        pk=article_id,
+        journal=request.journal,
+    )
     review = get_object_or_404(models.ReviewAssignment, pk=review_id)
 
     email_context = logic.get_reviewer_notification_context(
@@ -1244,7 +1293,11 @@ def view_review(request, article_id, review_id):
     :param review_id: ReviewAssignment PK
     :return: a rendered django template
     """
-    article = get_object_or_404(submission_models.Article, pk=article_id)
+    article = get_object_or_404(
+        submission_models.Article,
+        pk=article_id,
+        journal=request.journal,
+    )
     review = get_object_or_404(models.ReviewAssignment, pk=review_id)
     visibility_form = forms.ReviewVisibilityForm(
         instance=review,
@@ -1327,7 +1380,11 @@ def edit_review_answer(request, article_id, review_id, answer_id):
     :param answer_id: ReviewAssignmentAnswer PK
     :return: HttpResponse or HttpRedirect
     """
-    article = get_object_or_404(submission_models.Article, pk=article_id)
+    article = get_object_or_404(
+        submission_models.Article,
+        pk=article_id,
+        journal=request.journal,
+    )
     review = get_object_or_404(models.ReviewAssignment, pk=review_id)
     answer = get_object_or_404(models.ReviewAssignmentAnswer, pk=answer_id)
 
@@ -1370,7 +1427,11 @@ def edit_review(request, article_id, review_id):
     :param review_id: ReviewAssignment PK
     :return: a rendered django template
     """
-    article = get_object_or_404(submission_models.Article, pk=article_id)
+    article = get_object_or_404(
+        submission_models.Article,
+        pk=article_id,
+        journal=request.journal,
+    )
     review = get_object_or_404(models.ReviewAssignment, pk=review_id)
 
     if review.date_complete:
@@ -1410,7 +1471,11 @@ def delete_review(request, article_id, review_id):
     :param review_id: ReviewAssignment PK
     :return: a rendered django template
     """
-    article = get_object_or_404(submission_models.Article, pk=article_id)
+    article = get_object_or_404(
+        submission_models.Article,
+        pk=article_id,
+        journal=request.journal,
+    )
     review = get_object_or_404(models.ReviewAssignment, pk=review_id)
 
     if review.date_complete:
@@ -1452,7 +1517,11 @@ def withdraw_review(request, article_id, review_id):
     :param review_id: ReviewAssignment PK
     :return:a rendered django template
     """
-    article = get_object_or_404(submission_models.Article, pk=article_id)
+    article = get_object_or_404(
+        submission_models.Article,
+        pk=article_id,
+        journal=request.journal,
+    )
     review = get_object_or_404(models.ReviewAssignment, pk=review_id)
 
     if review.date_complete:
@@ -1535,7 +1604,11 @@ def reset_review(request, article_id, review_id):
     :param review_id: pk of a ReviewAssignment
     :return: a contextualised django template
     """
-    article = get_object_or_404(submission_models.Article, pk=article_id)
+    article = get_object_or_404(
+        submission_models.Article,
+        pk=article_id,
+        journal=request.journal,
+    )
     review = get_object_or_404(models.ReviewAssignment, pk=review_id)
 
     if request.POST:
@@ -1569,7 +1642,11 @@ def review_decision(request, article_id, decision):
     :param decision
     :return: a contextualised django template
     """
-    article = get_object_or_404(submission_models.Article, pk=article_id)
+    article = get_object_or_404(
+        submission_models.Article,
+        pk=article_id,
+        journal=request.journal,
+    )
     author_review_url = request.journal.site_url(
             reverse('review_author_view', kwargs={'article_id': article.id})
     )
@@ -1698,7 +1775,12 @@ def rate_reviewer(request, article_id, review_id):
     :return: a contextualised django template
     """
 
-    review = get_object_or_404(models.ReviewAssignment, pk=review_id, article__pk=article_id)
+    review = get_object_or_404(
+        models.ReviewAssignment,
+        pk=review_id,
+        article__pk=article_id,
+        article__journal=request.journal,
+    )
     if not review.is_complete:
         messages.add_message(request, messages.INFO, 'You cannot rate a reviewer until their review is complete.'
                                                      'You should withdraw this review if you want to rate the reviewer'
@@ -1737,7 +1819,11 @@ def author_view_reviews(request, article_id):
     :param article_id: Article pk
     :return: a contextualised django template
     """
-    article = get_object_or_404(submission_models.Article, pk=article_id)
+    article = get_object_or_404(
+        submission_models.Article,
+        pk=article_id,
+        journal=request.journal,
+    )
     reviews = models.ReviewAssignment.objects.filter(
         article=article,
         is_complete=True,
@@ -1774,7 +1860,11 @@ def request_revisions(request, article_id):
     :param article_id: Article PK
     :return: a contextualised django template
     """
-    article = get_object_or_404(submission_models.Article, pk=article_id)
+    article = get_object_or_404(
+        submission_models.Article,
+        pk=article_id,
+        journal=request.journal,
+    )
     form = forms.RevisionRequest(article=article, editor=request.user)
     review_round = models.ReviewRound.latest_article_round(
         article=article,
@@ -1825,7 +1915,11 @@ def request_revisions_notification(request, article_id, revision_id):
     :param revision_id: PK of a RevisionRequest
     :return: a contextualised django template
     """
-    article = get_object_or_404(submission_models.Article, pk=article_id)
+    article = get_object_or_404(
+        submission_models.Article,
+        pk=article_id,
+        journal=request.journal,
+    )
     revision = get_object_or_404(models.RevisionRequest, pk=revision_id)
     email_content = logic.get_revision_request_content(request, article, revision)
 
@@ -1866,9 +1960,12 @@ def edit_revision_request(request, article_id, revision_id):
     :param revision_id: Revision PK
     :return: HttpResponse
     """
-    revision_request = get_object_or_404(models.RevisionRequest,
-                                         article__pk=article_id,
-                                         pk=revision_id)
+    revision_request = get_object_or_404(
+        models.RevisionRequest,
+        article__pk=article_id,
+        article__journal=request.journal,
+        pk=revision_id
+    )
     form = forms.EditRevisionDue(instance=revision_request)
 
     if revision_request.date_completed:
@@ -1924,6 +2021,7 @@ def do_revisions(request, article_id, revision_id):
     revision_request = get_object_or_404(
         models.RevisionRequest,
         article__pk=article_id,
+        article__journal=request.journal,
         pk=revision_id,
         date_completed__isnull=True,
         article__stage__in=submission_models.REVIEW_STAGES,
@@ -2026,8 +2124,13 @@ def do_revisions(request, article_id, revision_id):
 
 @article_author_required
 def replace_file(request, article_id, revision_id, file_id):
-    revision_request = get_object_or_404(models.RevisionRequest, article__pk=article_id, pk=revision_id,
-                                         date_completed__isnull=True)
+    revision_request = get_object_or_404(
+        models.RevisionRequest,
+        article__pk=article_id,
+        article__journal=request.journal,
+        pk=revision_id,
+        date_completed__isnull=True,
+    )
     file = get_object_or_404(core_models.File, pk=file_id)
 
     if request.GET.get('download', None):
@@ -2073,10 +2176,15 @@ def upload_new_file(request, article_id, revision_id):
     :param request: HttpRequest object
     :param article_id: Article PK
     :param revision_id: RevisionRequest PK
-    :return: Httpresponse or HttpRedirect
+    :return: HttpResponse or HttpRedirect
     """
-    revision_request = get_object_or_404(models.RevisionRequest, article__pk=article_id, pk=revision_id,
-                                         date_completed__isnull=True)
+    revision_request = get_object_or_404(
+        models.RevisionRequest,
+        article__pk=article_id,
+        article__journal=request.journal,
+        pk=revision_id,
+        date_completed__isnull=True,
+    )
     article = revision_request.article
 
     if request.POST and request.FILES:
@@ -2125,9 +2233,12 @@ def view_revision(request, article_id, revision_id):
     :param revision_id: RevisionRequest PK
     :return: HttpResponse
     """
-    revision_request = get_object_or_404(models.RevisionRequest.objects.select_related('article'),
-                                         pk=revision_id,
-                                         article__pk=article_id)
+    revision_request = get_object_or_404(
+        models.RevisionRequest.objects.select_related('article'),
+        pk=revision_id,
+        article__pk=article_id,
+        article__journal=request.journal,
+    )
 
     template = 'review/revision/view_revision.html'
     context = {
@@ -2148,7 +2259,11 @@ def review_warning(request, article_id, decision):
     :param article_id: Article PK
     :return: HttpResponse or HttpRedirect
     """
-    article = get_object_or_404(submission_models.Article, pk=article_id)
+    article = get_object_or_404(
+        submission_models.Article,
+        pk=article_id,
+        journal=request.journal,
+    )
 
     if request.POST and request.user.is_editor(request):
         override = models.EditorOverride.objects.create(
@@ -2202,7 +2317,10 @@ def editor_article_file(request, article_id, file_id):
     :param file_id: the file ID to serve
     :return: a streaming response of the requested file or 404
     """
-    article_object = submission_models.Article.objects.get(pk=article_id)
+    article_object = submission_models.Article.objects.get(
+        pk=article_id,
+        journal=request.journal,
+    )
     file_object = get_object_or_404(core_models.File, pk=file_id)
 
     return files.serve_file(request, file_object, article_object)
@@ -2253,7 +2371,11 @@ def draft_decision(request, article_id):
     :return: a django template with context
     """
 
-    article = get_object_or_404(submission_models.Article, pk=article_id)
+    article = get_object_or_404(
+        submission_models.Article,
+        pk=article_id,
+        journal=request.journal,
+    )
     drafts = models.DecisionDraft.objects.filter(article=article)
     message_to_editor = logic.get_draft_email_message(request, article)
     editors = request.journal.editors()
@@ -2380,7 +2502,11 @@ def draft_decision_text(request, article_id):
 @editor_is_not_author
 @editor_user_required
 def manage_draft(request, article_id, draft_id):
-    article = get_object_or_404(submission_models.Article, pk=article_id)
+    article = get_object_or_404(
+        submission_models.Article,
+        pk=article_id,
+        journal=request.journal,
+    )
     draft = get_object_or_404(models.DecisionDraft, pk=draft_id)
 
     if 'decline_draft' in request.POST:
@@ -2413,7 +2539,11 @@ def manage_draft(request, article_id, draft_id):
 @editor_is_not_author
 @editor_user_required
 def edit_draft_decision(request, article_id, draft_id):
-    article = get_object_or_404(submission_models.Article, pk=article_id)
+    article = get_object_or_404(
+        submission_models.Article,
+        pk=article_id,
+        journal=request.journal,
+    )
     draft = get_object_or_404(models.DecisionDraft, pk=draft_id)
     drafts = models.DecisionDraft.objects.filter(article=article)
     editors = request.journal.editors()
@@ -2674,7 +2804,9 @@ def decision_helper(request, article_id):
     :return: a django response
     """
     article = get_object_or_404(
-        submission_models.Article, pk=article_id,
+        submission_models.Article,
+        pk=article_id,
+        journal=request.journal,
     )
 
     reviews = models.ReviewAssignment.objects.filter(

--- a/src/submission/views.py
+++ b/src/submission/views.py
@@ -86,6 +86,7 @@ def submit_submissions(request):
     # gets a list of submissions for the logged in user
     articles = models.Article.objects.filter(
         owner=request.user,
+        journal=request.journal,
     ).exclude(
         stage=models.STAGE_UNSUBMITTED,
     )
@@ -111,7 +112,11 @@ def submit_funding(request, article_id):
     :param article_id: Article PK
     :return: HttpResponse or HttpRedirect
     """
-    article = get_object_or_404(models.Article, pk=article_id)
+    article = get_object_or_404(
+        models.Article,
+        pk=article_id,
+        journal=request.journal,
+    )
     additional_fields = models.Field.objects.filter(journal=request.journal)
     submission_summary = setting_handler.get_setting(
         'general',
@@ -167,7 +172,11 @@ def submit_info(request, article_id):
     :return: HttpResponse or HttpRedirect
     """
     with translation.override(settings.LANGUAGE_CODE):
-        article = get_object_or_404(models.Article, pk=article_id)
+        article = get_object_or_404(
+            models.Article,
+            pk=article_id,
+            journal=request.journal,
+        )
         additional_fields = models.Field.objects.filter(journal=request.journal)
         submission_summary = setting_handler.get_setting(
             'general',
@@ -223,7 +232,10 @@ def publisher_notes_order(request, article_id):
         ids = request.POST.getlist('note[]')
         ids = [int(_id) for _id in ids]
 
-        article = models.Article.objects.get(pk=article_id)
+        article = models.Article.objects.get(
+            pk=article_id,
+            journal=request.journal,
+        )
 
         for he in article.publisher_notes.all():
             he.sequence = ids.index(he.pk)
@@ -244,7 +256,11 @@ def submit_authors(request, article_id):
     :param article_id: Article PK
     :return: HttpRedirect or HttpResponse
     """
-    article = get_object_or_404(models.Article, pk=article_id)
+    article = get_object_or_404(
+        models.Article,
+        pk=article_id,
+        journal=request.journal,
+    )
 
     if article.current_step < 2 and not request.user.is_staff:
         return redirect(reverse('submit_info', kwargs={'article_id': article_id}))
@@ -426,7 +442,11 @@ def submit_files(request, article_id):
     :param article_id: Article PK
     :return: HttpResponse
     """
-    article = get_object_or_404(models.Article, pk=article_id)
+    article = get_object_or_404(
+        models.Article,
+        pk=article_id,
+        journal=request.journal,
+    )
     form = forms.FileDetails()
     configuration = request.journal.submissionconfiguration
 
@@ -524,7 +544,11 @@ def submit_review(request, article_id):
     :param article_id: Article PK
     :return: HttpResponse or HttpRedirect
     """
-    article = get_object_or_404(models.Article, pk=article_id)
+    article = get_object_or_404(
+        models.Article,
+        pk=article_id,
+        journal=request.journal,
+    )
 
     if article.current_step < 4 and not request.user.is_staff:
         return redirect(
@@ -595,7 +619,11 @@ def edit_metadata(request, article_id):
     :return: contextualised django template
     """
     with translation.override(request.override_language):
-        article = get_object_or_404(models.Article, pk=article_id)
+        article = get_object_or_404(
+            models.Article,
+            pk=article_id,
+            journal=request.journal,
+        )
         additional_fields = models.Field.objects.filter(
             journal=request.journal,
         )


### PR DESCRIPTION
- Some older views that pre-date multitenancy were not filtering by the current `request.journal`.
- Added filters where gaps were identified.
- Closes #4256 

Note: Two other approaches were discussed and should be considered for future:

1. Switching these views to a new decorator that includes these checks
2. Switching these views to CBVs that inherit from a parent that has these checks