### PR TITLE
Registration page now uses the correct privacy policy link for presses

### DIFF
--- a/src/templates/common/accounts/register_privacy_policy.html
+++ b/src/templates/common/accounts/register_privacy_policy.html
@@ -2,7 +2,7 @@
     <a href="{{ journal_settings.general.privacy_policy_url }}">
         {% trans "Privacy Policy" %}
     </a>
-{% elif request.press and request.press.privacy_policy_url %}
+{% elif not request.journal and request.press.privacy_policy_url %}
     <a href="{{ request.press.privacy_policy_url }}">
         {% trans "Privacy Policy" %}
     </a>

--- a/src/templates/common/accounts/register_privacy_policy.html
+++ b/src/templates/common/accounts/register_privacy_policy.html
@@ -1,0 +1,13 @@
+{% if request.journal and journal_settings.general.privacy_policy_url %}
+    <a href="{{ journal_settings.general.privacy_policy_url }}">
+        {% trans "Privacy Policy" %}
+    </a>
+{% elif request.press and request.press.privacy_policy_url %}
+    <a href="{{ request.press.privacy_policy_url }}">
+        {% trans "Privacy Policy" %}
+    </a>
+{% else %}
+    <a href="{% url 'cms_page' "privacy" %}">
+        {% trans "Privacy Policy" %}
+    </a>
+{% endif %}

--- a/src/themes/OLH/templates/core/accounts/register.html
+++ b/src/themes/OLH/templates/core/accounts/register.html
@@ -81,12 +81,9 @@
                             <div class="large-12 columns">
                                 {{ form.captcha|foundation }}
                                 <br/>
-                                <p>{% trans "By registering an account you agree to our" %}
-                                  {% if journal_settings.general.privacy_policy_url %}
-                                    <a href="{{ journal_settings.general.privacy_policy_url }}">{% trans "Privacy Policy" %}</a>
-                                  {% else %}
-                                    <a href="{% url 'cms_page' "privacy" %}">{% trans "Privacy Policy" %}</a>
-                                  {% endif %}
+                                <p>
+                                    {% trans "By registering an account you agree to our" %}
+                                    {% include "common/accounts/register_privacy_policy.html" %}
                                 </p>
                             </div>
                         </div>

--- a/src/themes/clean/templates/core/accounts/register.html
+++ b/src/themes/clean/templates/core/accounts/register.html
@@ -24,12 +24,9 @@
                             <p>{% blocktrans %}For more information read our <a href="#" data-toggle="modal" data-target="#passwordmodal">password guide</a>.{% endblocktrans %}</p>
 
                             {% bootstrap_form form %}
-                            <p>{% trans "By registering an account you agree to our" %}
-                                {% if journal_settings.general.privacy_policy_url %}
-                                    <a href="{{ journal_settings.general.privacy_policy_url }}">{% trans "Privacy Policy" %}</a>
-                                {% else %}
-                                    <a href="{% url 'cms_page' "privacy" %}">{% trans "Privacy Policy" %}</a>
-                                {% endif %}
+                            <p>
+                                {% trans "By registering an account you agree to our" %}
+                                {% include "common/accounts/register_privacy_policy.html" %}
                             </p>
                             {% if journal_settings.general.display_register_page_notice %}
                             {{ journal_settings.general.register_page_notice|safe }}

--- a/src/themes/material/templates/core/accounts/register.html
+++ b/src/themes/material/templates/core/accounts/register.html
@@ -30,12 +30,9 @@
                         {% include "elements/forms/errors.html" %}
                         {% csrf_token %}
                         {{ form|materializecss }}
-                        <p>{% trans "By registering an account you agree to our" %}
-                          {% if journal_settings.general.privacy_policy_url %}
-                            <a href="{{ journal_settings.general.privacy_policy_url }}">{% trans "Privacy Policy" %}</a>
-                          {% else %}
-                            <a href="{% url 'cms_page' "privacy" %}">{% trans "Privacy Policy" %}</a>
-                          {% endif %}
+                        <p>
+                            {% trans "By registering an account you agree to our" %}
+                            {% include "common/accounts/register_privacy_policy.html" %}
                         </p>
                         {% if journal_settings.general.display_register_page_notice %}
                         {{ journal_settings.general.register_page_notice|safe }}


### PR DESCRIPTION
- The registration page now considers the press' privacy policy (following current convention this will also apply to repositories).
- Closes #4282 