### PR TITLE
3746 document manager upload improvements

### DIFF
--- a/src/journal/views.py
+++ b/src/journal/views.py
@@ -2443,22 +2443,23 @@ def document_management(request, article_id):
     if request.POST and request.FILES:
 
         label = request.POST.get('label') if request.POST.get('label') else 'File'
+        file_type = request.POST.get('file-type-chooser', None)
 
-        if 'manu' in request.POST:
+        if file_type == 'manu':
             from core import files as core_files
-            file = request.FILES.get('manu-file')
+            file = request.FILES.get('new-file')
             new_file = core_files.save_file_to_article(file, document_article,
                                                        request.user, label=label, is_galley=False)
             document_article.manuscript_files.add(new_file)
             messages.add_message(
                 request,
                 messages.SUCCESS,
-                _('Production file uploaded.'),
+                _('Manuscript file uploaded.'),  
             )
 
-        if 'fig' in request.POST:
+        if file_type =='fig':
             from core import files as core_files
-            file = request.FILES.get('fig-file')
+            file = request.FILES.get('new-file')
             new_file = core_files.save_file_to_article(
                 file,
                 document_article,
@@ -2470,12 +2471,12 @@ def document_management(request, article_id):
             messages.add_message(
                 request,
                 messages.SUCCESS,
-                _('Production file uploaded.'),
+                _('Figure or Data file uploaded.'),
             )
 
-        if 'prod' in request.POST:
+        if file_type == 'prod':
             from production import logic as prod_logic
-            file = request.FILES.get('prod-file')
+            file = request.FILES.get('new-file')
             prod_logic.save_prod_file(document_article, request, file, label)
             messages.add_message(
                 request,
@@ -2483,14 +2484,14 @@ def document_management(request, article_id):
                 _('Production file uploaded.'),
             )
 
-        if 'proof' in request.POST:
+        if file_type == 'proof':
             from production import logic as prod_logic
-            file = request.FILES.get('proof-file')
+            file = request.FILES.get('new-file')
             prod_logic.save_galley(document_article, request, file, True, label)
             messages.add_message(
                 request,
                 messages.SUCCESS,
-                _('Proofing file uploaded.'),
+                _('Galley file uploaded.'),
             )
 
         return redirect(

--- a/src/templates/admin/journal/document_management.html
+++ b/src/templates/admin/journal/document_management.html
@@ -116,6 +116,7 @@
                 <h4>Choose file type:</h4>
                 <div class="clearfix">
                     <fieldset id="file-type-chooser">
+                        <legend>File types</legend>
                         <label> <input type="radio" value="manu" name="file-type-chooser"> <strong>Manuscript File</strong> - used in review and copyediting.</label>
                         <label> <input type="radio" value="fig" name="file-type-chooser"> <strong>Figure/Data File</strong> - Figure files are images from manuscripts. Data files are any other file not an image or manuscript that relate to the paper.</label>
                         <label> <input type="radio" value="prod" name="file-type-chooser"> <strong>Production File</strong> - for use in Production/Typesetting.</label>

--- a/src/templates/admin/journal/document_management.html
+++ b/src/templates/admin/journal/document_management.html
@@ -93,7 +93,7 @@
          data-animation-out="slide-out-down">
         <div class="card">
             <div class="card-divider">
-                <h4><i class="fa fa-upload">&nbsp;</i>Upload File</h4>
+                <h2><span class="fa fa-upload" aria-hidden="true"></span>&nbsp; Upload File</h4>
             </div>
         </div>
         <div class="card-section">
@@ -107,30 +107,30 @@
             <form method="POST" enctype="multipart/form-data">
                 {% csrf_token %}
 
-                <h4>Label the file:</h4>
+                <h3>Label the file:</h4>
                 <div class="clearfix">
-                    <label for="label">File Label*</label>
-                    <input type="text" maxlength="200" id="label" name="label" placeholder="Add file label here." required="required" />
+                    <label for="label">File Label <span aria-hidden="true">*</span></label>
+                    <input type="text" maxlength="200" id="label" name="label" placeholder="e.g. figure 3 version 2" required="required" />
                     <input type="hidden" name="upload" value="upload">
                 </div>
-                <h4>Choose file type:</h4>
+                <h3>Choose file type:</h4>
                 <div class="clearfix">
                     <fieldset id="file-type-chooser">
                         <legend>File types</legend>
-                        <label> <input type="radio" value="manu" name="file-type-chooser"> <strong>Manuscript File</strong> - used in review and copyediting.</label>
+                        <label> <input type="radio" value="manu" name="file-type-chooser"><strong>Manuscript File</strong> - used in review and copy-editing.</label>
                         <label> <input type="radio" value="fig" name="file-type-chooser"> <strong>Figure/Data File</strong> - Figure files are images from manuscripts. Data files are any other file not an image or manuscript that relate to the paper.</label>
                         <label> <input type="radio" value="prod" name="file-type-chooser"> <strong>Production File</strong> - for use in Production/Typesetting.</label>
                         <label> <input type="radio" value="proof" name="file-type-chooser"> <strong>Proofing</strong> - for use in Proofing.</label>
                     </fieldset>
                 </div>
-                <h4>Select and Upload:</h4>
+                <h3>Select and Upload:</h4>
                 <div class="clearfix">
                     <input name="new-file" type="file" class="float-left" style="width:50%;"
                                 data-placeholder="No file"
-                                data-buttonName="btn-primary">
-                    <button type="submit" class="button success float-right" name="file-upload"><i
-                            class="fa fa-upload">
-                        &nbsp;</i>Upload
+                                data-buttonName="btn-primary"
+                                aria-label="file chooser">
+                    <button type="submit" class="button success float-right" name="file-upload">
+                        <span class="fa fa-upload" aria-hidden="true"></span> &nbsp; Upload
                     </button>
                 </div>
             </form>

--- a/src/templates/admin/journal/document_management.html
+++ b/src/templates/admin/journal/document_management.html
@@ -97,7 +97,6 @@
             </div>
         </div>
         <div class="card-section">
-            <p>Add a label and then upload a file. You can only upload one file type at a <time class=""></time></p>
             {% if error %}
                 <div class="alert alert-warning" role="alert">{{ error }}</div>
             {% endif %}
@@ -107,63 +106,31 @@
 
             <form method="POST" enctype="multipart/form-data">
                 {% csrf_token %}
-                <label for="label">File Label*</label>
-                <input type="text" maxlength="200" id="label" name="label" placeholder="Add file label here." required="required" />
-                <input type="hidden" name="upload" value="upload">
-                <h4>New Manuscript File</h4>
-                <div class="clearfix">
-                    <div>
-                        <p><small>MS files are used in review and copyediting.</small></p>
-                        <input name="manu-file" type="file" class="float-left" style="width:50%;"
-                               data-placeholder="No file"
-                               data-buttonName="btn-primary">
-                        <button type="submit" class="button success float-right" name="manu"><i
-                                class="fa fa-upload">
-                            &nbsp;</i>Upload
-                        </button>
-                    </div>
-                </div>
 
-                <h4>Figure/Data File</h4>
+                <h4>Label the file:</h4>
                 <div class="clearfix">
-                    <div>
-                        <p><small>Figure files are images from manuscripts. Data files are any other file not an image or Manuscript that relate to the paper.</small></p>
-                        <input name="fig-file" type="file" class="float-left" style="width:50%;"
-                               data-placeholder="No file"
-                               data-buttonName="btn-primary">
-                        <button type="submit" class="button success float-right" name="fig"><i
-                                class="fa fa-upload">
-                            &nbsp;</i>Upload
-                        </button>
-                    </div>
+                    <label for="label">File Label*</label>
+                    <input type="text" maxlength="200" id="label" name="label" placeholder="Add file label here." required="required" />
+                    <input type="hidden" name="upload" value="upload">
                 </div>
-
-                <h4>Production</h4>
+                <h4>Choose file type:</h4>
                 <div class="clearfix">
-                    <div>
-                        <p><small>Upload a new file for use in Production/Typesetting.</small></p>
-                        <input name="prod-file" type="file" class="float-left" style="width:50%;"
-                               data-placeholder="No file"
-                               data-buttonName="btn-primary">
-                        <button type="submit" class="button success float-right" name="prod"><i
-                                class="fa fa-upload">
-                            &nbsp;</i>Upload
-                        </button>
-                    </div>
+                    <fieldset id="file-type-chooser">
+                        <label> <input type="radio" value="manu" name="file-type-chooser"> <strong>Manuscript File</strong> - used in review and copyediting.</label>
+                        <label> <input type="radio" value="fig" name="file-type-chooser"> <strong>Figure/Data File</strong> - Figure files are images from manuscripts. Data files are any other file not an image or manuscript that relate to the paper.</label>
+                        <label> <input type="radio" value="prod" name="file-type-chooser"> <strong>Production File</strong> - for use in Production/Typesetting.</label>
+                        <label> <input type="radio" value="proof" name="file-type-chooser"> <strong>Proofing</strong> - for use in Proofing.</label>
+                    </fieldset>
                 </div>
-
-                <h4>Proofing</h4>
+                <h4>Select and Upload:</h4>
                 <div class="clearfix">
-                    <div>
-                        <p><small>Upload a new file for use in Proofing.</small></p>
-                        <input name="proof-file" type="file" class="float-left" style="width:50%;"
-                               data-placeholder="No file"
-                               data-buttonName="btn-primary">
-                        <button type="submit" class="button success float-right" name="proof"><i
-                                class="fa fa-upload">
-                            &nbsp;</i>Upload
-                        </button>
-                    </div>
+                    <input name="new-file" type="file" class="float-left" style="width:50%;"
+                                data-placeholder="No file"
+                                data-buttonName="btn-primary">
+                    <button type="submit" class="button success float-right" name="file-upload"><i
+                            class="fa fa-upload">
+                        &nbsp;</i>Upload
+                    </button>
                 </div>
             </form>
         </div>


### PR DESCRIPTION
### Work done
Taking into account the changes requested on #3847 I have started again and addressed this issue.

The request was for a select for the file type, rather than a popup for each file type.  On careful consideration, I implemented this with a radio group instead, so the file type can be selected and there is only one popup.  The change to radio group rather than select is because each file type has both name and description, and the user needs to choose which file - this is more possible when all file types are onscreen at the same time (i.e. with a radio group) than when the description is within a select so that it is only visible when viewing the list or for the selected item. 

I did consider having the file descriptions separate from the file selection, but this again felt less helpful to the user.  If they have to choose between file types, far better for them to mark it adjacent to the description, than have to look elsewhere for that description.

As I was substantially rewriting  this modal, I have also made minor accessibility improvements to the
- heading structure (modal starts with an H2 and other headings now consistent), 
- the icons (marked as decorative, including the * for required field)
- the placeholder text now serves as an example rather than an instruction.

### Before:
<img width="1385" alt="image" src="https://github.com/BirkbeckCTP/janeway/assets/5330770/1fbbfc95-3d85-45d2-8f79-c6746fc3ded4">

### After:
<img width="1395" alt="image" src="https://github.com/BirkbeckCTP/janeway/assets/5330770/54c22e45-4a9c-4df1-a5c0-60d964582510">


Closes #3746 