### PR TITLE
3911 do not render empty lists on article page

### DIFF
--- a/src/themes/OLH/assets/js/table_of_contents.js
+++ b/src/themes/OLH/assets/js/table_of_contents.js
@@ -30,5 +30,10 @@ $( document ).ready(function() {
 
     });
 
-    $("#toc").append(toc);
+    if(iter==0){
+        $("#toc").remove();
+    }
+    else{
+        $("#toc").append(toc);
+    }
 });

--- a/src/themes/OLH/assets/js/table_of_contents.js
+++ b/src/themes/OLH/assets/js/table_of_contents.js
@@ -1,5 +1,5 @@
 $( document ).ready(function() {
-
+    
     if (!$("#toc")) {
         return;
     }
@@ -31,7 +31,7 @@ $( document ).ready(function() {
     });
 
     if(iter==0){
-        $("#toc").remove();
+        $("#toc-section").remove();
     }
     else{
         $("#toc").append(toc);

--- a/src/themes/OLH/templates/journal/article.html
+++ b/src/themes/OLH/templates/journal/article.html
@@ -372,12 +372,12 @@
                                                 <i class="fa fa-info"></i>
                                                 Note to proofreader: Download links on this page begin to work when the article is published.
                                             </p>
-                                        {% else %}
-                                            <p> {% trans 'Downloads are not available until this article is published ' %}</p>
                                         {% endif %} 
                                     {% else %}
                                         <p> {% trans 'Downloads are not available for this article.' %}</p>
                                     {% endif %}
+                                {% else %}
+                                    <p> {% trans 'Downloads are not available until this article is published ' %}</p>
                                 {% endif %}
                             </div>
                             <div class="section">

--- a/src/themes/OLH/templates/journal/article.html
+++ b/src/themes/OLH/templates/journal/article.html
@@ -351,19 +351,24 @@
                             <div class="section">
                                 {% if article.is_published or proofing %}
                                     <h3>{% trans "Download" %}</h3>
-                                    <ul>
-                                        {% for galley in galleys %}
-                                            <li>
-                                                <a href="{% url 'article_download_galley' article.id galley.id %}">{% trans "Download" %} {{ galley.label }}</a>
-                                                {% if galley.file.mime_type == 'application/pdf' and journal.view_pdf_button %}
-                                                    </li>
-                                                    <li>
-                                                    <a target="_blank" href="{% url 'article_view_galley' article.id galley.id %}">{% trans 'View PDF' %}</a>
-                                                    </li>
-                                                {% endif %}
-                                            </li>
-                                        {% endfor %}
-                                    </ul>
+                                    {% if galleys %}
+                                        <ul>
+                                            {% for galley in galleys %}
+                                                <li>
+                                                    <a href="{% url 'article_download_galley' article.id galley.id %}">{% trans "Download" %} {{ galley.label }}</a>
+                                                    {% if galley.file.mime_type == 'application/pdf' and journal.view_pdf_button %}
+                                                        </li>
+                                                        <li>
+                                                        <a target="_blank" href="{% url 'article_view_galley' article.id galley.id %}">{% trans 'View PDF' %}</a>
+                                                        </li>
+                                                    {% endif %}
+                                                </li>
+                                            {% endfor %}
+                                        </ul>
+                                    {% else %}
+                                        <p> {% trans 'Downloads are not available for this article.' %}</p>
+                                    {% endif %}
+
                                     {% if proofing %}
                                         <p id="note_to_proofreader_2">
                                             <i class="fa fa-info"></i>
@@ -476,13 +481,17 @@
 
                         <div class="section hide-for-small-only">
                             <h3>{% trans "File Checksums" %} (MD5)</h3>
-                            <ul>
-                                {% for galley in galleys %}
-                                    <li>
-                                        <small>{{ galley.label }}: {{ galley.file.checksum }}</small>
-                                    </li>
-                                {% endfor %}
-                            </ul>
+                            {% if galleys %}
+                                <ul>
+                                    {% for galley in galleys %}
+                                        <li>
+                                            <small>{{ galley.label }}: {{ galley.file.checksum }}</small>
+                                        </li>
+                                    {% endfor %}
+                                </ul>
+                            {% else %}
+                                <p> {% trans 'File Checksums are not available for this article.' %}</p>
+                            {% endif %}
                         </div>
 
                         <div class="section hide-for-small-only">

--- a/src/themes/OLH/templates/journal/article.html
+++ b/src/themes/OLH/templates/journal/article.html
@@ -202,10 +202,10 @@
                             {% endif %}
 
                             {% if article.is_published or proofing %}
-                            {% if galleys %}
                                 <div class="show-for-small-only">
                                     <p>
-                                        <strong>{% trans 'Downloads' %}:</strong><br/>
+                                    <strong>{% trans 'Downloads' %}:</strong><br/>
+                                    {% if galleys %}
                                         {% for galley in galleys %}
                                             <a href="{% url 'article_download_galley' article.id galley.id %}">{% trans "Download" %} {{ galley.label }}</a>
                                             <br/>
@@ -213,15 +213,17 @@
                                                 <a target="_blank" href="{% url 'article_view_galley' article.id galley.id %}">{% trans 'View PDF' %}</a><br/>
                                             {% endif %}
                                         {% endfor %}
-                                    </p>
-                                    {% if proofing %}
-                                        <p id="note_to_proofreader_1">
-                                            <i class="fa fa-info"></i>
-                                            Note to proofreader: Download links on this page begin to work when the article is published.
                                         </p>
+                                        {% if proofing %}
+                                            <p id="note_to_proofreader_1">
+                                                <i class="fa fa-info"></i>
+                                                Note to proofreader: Download links on this page begin to work when the article is published.
+                                            </p>
+                                        {% endif %}
+                                    {% else %}
+                                        <p> {% trans 'Downloads are not available for this article.' %}</p>
                                     {% endif %}
                                 </div>
-                            {% endif %}
                             {% endif %}
 
                             {% if article.funders.all %}
@@ -350,7 +352,7 @@
                             {% endif %}
                             <div class="section">
                                 {% if article.is_published or proofing %}
-                                    <h3>{% trans "Download" %}</h3>
+                                    <h3>{% trans "Downloads" %}</h3>
                                     {% if galleys %}
                                         <ul>
                                             {% for galley in galleys %}
@@ -365,18 +367,17 @@
                                                 </li>
                                             {% endfor %}
                                         </ul>
+                                        {% if proofing %}
+                                            <p id="note_to_proofreader_2">
+                                                <i class="fa fa-info"></i>
+                                                Note to proofreader: Download links on this page begin to work when the article is published.
+                                            </p>
+                                        {% else %}
+                                            <p> {% trans 'Downloads are not available until this article is published ' %}</p>
+                                        {% endif %} 
                                     {% else %}
                                         <p> {% trans 'Downloads are not available for this article.' %}</p>
                                     {% endif %}
-
-                                    {% if proofing %}
-                                        <p id="note_to_proofreader_2">
-                                            <i class="fa fa-info"></i>
-                                            Note to proofreader: Download links on this page begin to work when the article is published.
-                                        </p>
-                                    {% endif %}
-                                {% else %}
-                                    <p> {% trans 'Downloads are not available until this article is published ' %}</p>
                                 {% endif %}
                             </div>
                             <div class="section">

--- a/src/themes/OLH/templates/journal/article.html
+++ b/src/themes/OLH/templates/journal/article.html
@@ -453,7 +453,7 @@
                         {% endif %}
 
                         {% if article_content %}
-                        <div class="section hide-for-small-only">
+                        <div id="toc-section" class="section hide-for-small-only">
                             <h3>{% trans "Jump to" %}</h3>
                             <ul id="toc">
 

--- a/src/themes/clean/templates/journal/article.html
+++ b/src/themes/clean/templates/journal/article.html
@@ -98,26 +98,22 @@
                 {% if article.is_published or proofing %}
                     <div class="d-lg-none d-xl-none d-md-none">
                         <p>
-                            <strong>{% trans 'Downloads' %}</strong><br/>
-                            {% if galleys %}
-                                {% for galley in galleys %}
-                                    <a href="{% url 'article_download_galley' article.id galley.id %}">{% trans "Download" %} {{ galley.label }}</a>
-                                    <br/>
-                                    {% if galley.file.mime_type == 'application/pdf' and journal.view_pdf_button %}
-                                        <a target="_blank"
-                                        href="{% url 'article_view_galley' article.id galley.id %}">View
-                                            PDF</a><br/>
-                                    {% endif %}
-                                {% endfor %}
-                                {% if proofing %}
-                                    <p id="note_to_proofreader_1">
-                                        <i class="fa fa-info"></i>
-                                        Note to proofreader: Download links on this page begin to work when the article is published.
-                                    </p>
-                                {% endif %}
-                            {% else %}
-                                <p> {% trans 'Downloads are not available for this article.' %}</p>
-                            {% endif %}
+                            <strong>{% trans 'Downloads' %}></strong><br/>
+                            {% for galley in galleys %}
+                                <a href="{% url 'article_download_galley' article.id galley.id %}">{% trans "Download" %} {{ galley.label }}</a>
+                                <br/>
+                                {% if galley.file.mime_type == 'application/pdf' and journal.view_pdf_button %}
+                                    <a target="_blank"
+                                       href="{% url 'article_view_galley' article.id galley.id %}">View
+                                        PDF</a><br/>
+                            {% endfor %}
+                        </p>
+                        {% if proofing %}
+                            <p id="note_to_proofreader_1">
+                                <i class="fa fa-info"></i>
+                                Note to proofreader: Download links on this page begin to work when the article is published.
+                            </p>
+                        {% endif %}
                     </div>
                 {% endif %}
                 {% if article.funders.all %}
@@ -186,26 +182,30 @@
                 {% endif %}
 
                 {% if article.is_published or proofing %}
-                    <h2>{% trans "Download" %}</h2>
-                    <ul>
-                        {% for galley in galleys %}
-                            {% if not galley.label == 'HTML' or not galley.file.mime_type == 'text/html' %}
-                            <li>
-                                <a href="{% url 'article_download_galley' article.id galley.id %}">{% trans "Download" %} {{ galley.label }}</a>
-                                {% if galley.file.mime_type == 'application/pdf' and journal.view_pdf_button %}
-                                    </li>
-                                    <li>
-                                        <a target="_blank" href="{% url 'article_view_galley' article.id galley.id %}">{% trans "View" %} {{ galley.label }}</a>
+                    <h2>{% trans "Downloads" %}</h2>
+                    {% if galleys %}
+                        <ul>
+                            {% for galley in galleys %}
+                                {% if not galley.label == 'HTML' or not galley.file.mime_type == 'text/html' %}
+                                <li>
+                                    <a href="{% url 'article_download_galley' article.id galley.id %}">{% trans "Download" %} {{ galley.label }}</a>
+                                    {% if galley.file.mime_type == 'application/pdf' and journal.view_pdf_button %}
+                                        </li>
+                                        <li>
+                                            <a target="_blank" href="{% url 'article_view_galley' article.id galley.id %}">{% trans "View" %} {{ galley.label }}</a>
+                                    {% endif %}
+                                </li>
                                 {% endif %}
-                            </li>
-                            {% endif %}
-                        {% endfor %}
-                    </ul>
-                    {% if proofing %}
-                        <p id="note_to_proofreader_2">
-                            <i class="fa fa-info"></i>
-                            Note to proofreader: Download links on this page begin to work when the article is published.
-                        </p>
+                            {% endfor %}
+                        </ul>
+                        {% if proofing %}
+                            <p id="note_to_proofreader_2">
+                                <i class="fa fa-info"></i>
+                                Note to proofreader: Download links on this page begin to work when the article is published.
+                            </p>
+                        {% endif %}
+                    {% else %}
+                        <p> {% trans 'Downloads are not available for this article.' %}</p>
                     {% endif %}
                 {% endif %}
                 {% if article.supplementary_files.all %}

--- a/src/themes/clean/templates/journal/article.html
+++ b/src/themes/clean/templates/journal/article.html
@@ -109,16 +109,16 @@
                                             PDF</a><br/>
                                     {% endif %}
                                 {% endfor %}
+                                {% if proofing %}
+                                    <p id="note_to_proofreader_1">
+                                        <i class="fa fa-info"></i>
+                                        Note to proofreader: Download links on this page begin to work when the article is published.
+                                    </p>
+                                {% endif %}
                             {% else %}
                                 <p> {% trans 'Downloads are not available for this article.' %}</p>
                             {% endif %}
                         </p>
-                        {% if proofing %}
-                            <p id="note_to_proofreader_1">
-                                <i class="fa fa-info"></i>
-                                Note to proofreader: Download links on this page begin to work when the article is published.
-                            </p>
-                        {% endif %}
                     </div>
                 {% endif %}
                 {% if article.funders.all %}

--- a/src/themes/clean/templates/journal/article.html
+++ b/src/themes/clean/templates/journal/article.html
@@ -98,15 +98,20 @@
                 {% if article.is_published or proofing %}
                     <div class="d-lg-none d-xl-none d-md-none">
                         <p>
-                            <strong>{% trans 'Downloads' %}></strong><br/>
-                            {% for galley in galleys %}
-                                <a href="{% url 'article_download_galley' article.id galley.id %}">{% trans "Download" %} {{ galley.label }}</a>
-                                <br/>
-                                {% if galley.file.mime_type == 'application/pdf' and journal.view_pdf_button %}
-                                    <a target="_blank"
-                                       href="{% url 'article_view_galley' article.id galley.id %}">View
-                                        PDF</a><br/>
-                            {% endfor %}
+                            <strong>{% trans 'Downloads' %}</strong><br/>
+                            {% if galleys %}
+                                {% for galley in galleys %}
+                                    <a href="{% url 'article_download_galley' article.id galley.id %}">{% trans "Download" %} {{ galley.label }}</a>
+                                    <br/>
+                                    {% if galley.file.mime_type == 'application/pdf' and journal.view_pdf_button %}
+                                        <a target="_blank"
+                                        href="{% url 'article_view_galley' article.id galley.id %}">View
+                                            PDF</a><br/>
+                                    {% endif %}
+                                {% endfor %}
+                            {% else %}
+                                <p> {% trans 'Downloads are not available for this article.' %}</p>
+                            {% endif %}
                         </p>
                         {% if proofing %}
                             <p id="note_to_proofreader_1">

--- a/src/themes/clean/templates/journal/article.html
+++ b/src/themes/clean/templates/journal/article.html
@@ -333,11 +333,11 @@
                 {% endif %}
             </div>
              {% if article_content %}
-            <div class="sticky-top">
-            <h2>{% trans "Table of Contents" %}</h2>
-            <ul id="toc" class="table-of-contents"></ul>
+                <div class="sticky-top" id="toc-section">
+                    <h2>{% trans "Table of Contents" %}</h2>
+                    <ul id="toc" class="table-of-contents"></ul>
+                </div>
              {% endif %}
-        </div>
         </div>
     </div>
 

--- a/src/themes/clean/templates/journal/article.html
+++ b/src/themes/clean/templates/journal/article.html
@@ -96,10 +96,9 @@
                         {{ article.rights | safe }} </p>
                 {% endif %}
                 {% if article.is_published or proofing %}
-                {% if galleys %}
                     <div class="d-lg-none d-xl-none d-md-none">
                         <p>
-                            <strong>{% trans 'Downloads' %}></strong><br/>
+                            <strong>{% trans 'Downloads' %}</strong><br/>
                             {% if galleys %}
                                 {% for galley in galleys %}
                                     <a href="{% url 'article_download_galley' article.id galley.id %}">{% trans "Download" %} {{ galley.label }}</a>
@@ -110,18 +109,16 @@
                                             PDF</a><br/>
                                     {% endif %}
                                 {% endfor %}
+                                {% if proofing %}
+                                    <p id="note_to_proofreader_1">
+                                        <i class="fa fa-info"></i>
+                                        Note to proofreader: Download links on this page begin to work when the article is published.
+                                    </p>
+                                {% endif %}
                             {% else %}
                                 <p> {% trans 'Downloads are not available for this article.' %}</p>
                             {% endif %}
-                        </p>
-                        {% if proofing %}
-                            <p id="note_to_proofreader_1">
-                                <i class="fa fa-info"></i>
-                                Note to proofreader: Download links on this page begin to work when the article is published.
-                            </p>
-                        {% endif %}
                     </div>
-                {% endif %}
                 {% endif %}
                 {% if article.funders.all %}
                     <strong>{% trans "Funding" %}</strong>

--- a/src/themes/clean/templates/journal/article.html
+++ b/src/themes/clean/templates/journal/article.html
@@ -100,15 +100,19 @@
                     <div class="d-lg-none d-xl-none d-md-none">
                         <p>
                             <strong>{% trans 'Downloads' %}></strong><br/>
-                            {% for galley in galleys %}
-                                <a href="{% url 'article_download_galley' article.id galley.id %}">{% trans "Download" %} {{ galley.label }}</a>
-                                <br/>
-                                {% if galley.file.mime_type == 'application/pdf' and journal.view_pdf_button %}
-                                    <a target="_blank"
-                                       href="{% url 'article_view_galley' article.id galley.id %}">View
-                                        PDF</a><br/>
-                                {% endif %}
-                            {% endfor %}
+                            {% if galleys %}
+                                {% for galley in galleys %}
+                                    <a href="{% url 'article_download_galley' article.id galley.id %}">{% trans "Download" %} {{ galley.label }}</a>
+                                    <br/>
+                                    {% if galley.file.mime_type == 'application/pdf' and journal.view_pdf_button %}
+                                        <a target="_blank"
+                                        href="{% url 'article_view_galley' article.id galley.id %}">View
+                                            PDF</a><br/>
+                                    {% endif %}
+                                {% endfor %}
+                            {% else %}
+                                <p> {% trans 'Downloads are not available for this article.' %}</p>
+                            {% endif %}
                         </p>
                         {% if proofing %}
                             <p id="note_to_proofreader_1">
@@ -313,13 +317,17 @@
                         <br/>
                     </div>
                     <h2>{% trans 'File Checksums' %}</h2> (MD5)
-                    <ul>
-                        {% for galley in galleys %}
-                            <li>
-                                <small>{{ galley.label }}: {{ galley.file.checksum }}</small>
-                            </li>
-                        {% endfor %}
-                    </ul>
+                    {% if galleys %}
+                        <ul>
+                            {% for galley in galleys %}
+                                <li>
+                                    <small>{{ galley.label }}: {{ galley.file.checksum }}</small>
+                                </li>
+                            {% endfor %}
+                        </ul>
+                    {% else %}
+                        <p> {% trans 'File Checksums are not available for this article.' %}</p>
+                    {% endif %}
                 {% endif %}
             </div>
              {% if article_content %}

--- a/src/themes/material/assets/toc.js
+++ b/src/themes/material/assets/toc.js
@@ -31,5 +31,10 @@ $( document ).ready(function() {
 
     });
 
-    $("#toc").append(toc);
+    if(iter==0){
+        $("#toc-section").remove();
+    }
+    else{
+        $("#toc").append(toc);
+    }
 });

--- a/src/themes/material/templates/journal/article.html
+++ b/src/themes/material/templates/journal/article.html
@@ -492,7 +492,7 @@
             </div>
             {% if article_content %}
             <div class="card toc-card hide-on-small-only" id="toc-card" style="display: none;">
-                <div class="card-content">
+                <div class="card-content" id="toc-section">
                     <h4>
                         {% trans "Table of Contents" %}
                     </h4>

--- a/src/themes/material/templates/journal/article.html
+++ b/src/themes/material/templates/journal/article.html
@@ -178,48 +178,48 @@
                         <div class="card">
                             <div class="card-content center">
                                 <div class="alm">
-                                    <p class="alm_numbers">
+                                    <h5>
                                         {{ article.metrics.views }}
-                                    </p>
-                                    <p><i class="fa fa-eye"></i> {% trans "Views" %}</p>
+                                    </h5>
+                                    <p><i class="fa fa-eye"></i>{% trans "Views" %}</p>
                                 </div>
                                 <div class="alm">
-                                    <p class="alm_numbers">
+                                    <h5>
                                         {{ article.metrics.downloads }}
-                                    </p>
-                                    <p><i class="fa fa-download"></i> {% trans "Downloads" %}</p>
+                                    </h5>
+                                    <p><i class="fa fa-download"></i>{% trans "Downloads" %}</p>
                                 </div>
                                 {% if article.metrics.alm.twitter %}
                                     <div class="alm">
-                                        <p class="alm_numbers">
+                                        <h5>
                                             {{ article.metrics.alm.twitter }}
-                                        </p>
-                                        <p><i class="fa fa-twitter"></i> {% trans "Tweets" %}</p>
+                                        </h5>
+                                        <p><i class="fa fa-twitter"></i>{% trans "Tweets" %}</p>
                                     </div>
                                 {% endif %}
                                 {% if article.metrics.alm.wikipedia %}
                                     <div class="alm">
-                                        <p class="alm_numbers">
+                                        <h5>
                                             {{ article.metrics.alm.wikipedia }}
-                                        </p>
-                                        <p><i class="fa fa-wikipedia-w"></i> {% trans "Wikipedia" %}</p>
+                                        </h5>
+                                        <p><i class="fa fa-wikipedia-w"></i>{% trans "Wikipedia" %}</p>
                                     </div>
                                 {% endif %}
                                 {% if article.metrics.alm.reddit %}
                                     <div class="alm">
-                                        <p class="alm_numbers">
+                                        <h5>
                                             {{ article.metrics.alm.reddit }}
-                                        </p>
-                                        <p><i class="fa fa-reddit"></i> {% trans "Reddit" %}</p>
+                                        </h5>
+                                        <p><i class="fa fa-reddit"></i>{% trans "Reddit" %}</p>
                                     </div>
                                 {% endif %}
 
                                 {% if article.citation_count and not journal_settings.article.suppress_citations_metric %}
                                     <div class="alm">
-                                        <p class="alm_numbers">
+                                        <h5>
                                             {{ article.citation_count }}
-                                        </p>
-                                        <p><i class="fa fa-quote-left"></i> {% trans "Citations" %}</p>
+                                        </h5>
+                                        <p><i class="fa fa-quote-left"></i>{% trans "Citations" %}</p>
                                     </div>
                                 {% endif %}
                             </div>
@@ -473,13 +473,17 @@
                         <h4>
                             {% trans "File Checksums" %} (MD5)
                         </h4>
-                        <ul>
-                            {% for galley in galleys %}
-                                <li>
-                                    <small>{{ galley.label }}: {{ galley.file.checksum }}</small>
-                                </li>
-                            {% endfor %}
-                        </ul>
+                        {% if galleys %}
+                            <ul>
+                                {% for galley in galleys %}
+                                    <li>
+                                        <small>{{ galley.label }}: {{ galley.file.checksum }}</small>
+                                    </li>
+                                {% endfor %}
+                            </ul>
+                        {% else %}
+                            <p> {% trans 'File Checksums are not available for this article.' %}</p>
+                        {% endif %}
                     {% endif %}
                 </div>
             </div>

--- a/src/themes/material/templates/journal/article.html
+++ b/src/themes/material/templates/journal/article.html
@@ -119,31 +119,33 @@
                     {% endif %}
 
                     {% if article.is_published or proofing %}
-                    {% if galleys %}
                         <div class="show-on-small hide-on-med-and-up">
-                            <h2>{% trans "Download" %}</h2>
-                            <p>
-                                {% for galley in galleys %}
-                                    <a href="{% url 'article_download_galley' article.id galley.id %}">{% trans "Download" %} {{ galley.label }}</a>
-                                    <br/>
-                                    {% if galley.file.mime_type == 'application/pdf' and journal.view_pdf_button %}
-                                        <a target="_blank"
-                                           href="{% url 'article_view_galley' article.id galley.id %}">View
-                                            PDF</a><br/>
-                                    {% endif %}
-                                {% endfor %}
-                            </p>
-                            {% if proofing %}
-                                <p id="note_to_proofreader_1">
-                                    <i class="material-icons left">info</i>
-                                    Note to proofreader: Download links on this page begin to work when the article is published.
+                            <h2>{% trans "Downloads" %}</h2>
+                            {% if galleys %}
+                                <p>
+                                    {% for galley in galleys %}
+                                        <a href="{% url 'article_download_galley' article.id galley.id %}">{% trans "Download" %} {{ galley.label }}</a>
+                                        <br/>
+                                        {% if galley.file.mime_type == 'application/pdf' and journal.view_pdf_button %}
+                                            <a target="_blank"
+                                            href="{% url 'article_view_galley' article.id galley.id %}">View
+                                                PDF</a><br/>
+                                        {% endif %}
+                                    {% endfor %}
                                 </p>
+                                {% if proofing %}
+                                    <p id="note_to_proofreader_1">
+                                        <i class="material-icons left">info</i>
+                                        Note to proofreader: Download links on this page begin to work when the article is published.
+                                    </p>
+                                {% endif %}
+                            {% else %}
+                                <p> {% trans 'Downloads are not available for this article.' %}</p>
                             {% endif %}
                             <div class="spacer">
                                 <div class="divider"></div>
                             </div>
                         </div>
-                    {% endif %}
                     {% endif %}
 
                     {% if article.funders.all %}
@@ -290,33 +292,34 @@
                         <div class="divider"></div>
                     </div>
                     {% if article.is_published or proofing %}
-                    {% if galleys %}
                         <h4>
-                            {% trans "Download" %}
+                            {% trans "Downloads" %}
                         </h4>
-
-                        <ul>
-                            {% for galley in galleys %}
-                                <li>
-                                    <a href="{% url 'article_download_galley' article.id galley.id %}">{% trans "Download" %} {{ galley.label }}</a>
-                                    {% if galley.file.mime_type == 'application/pdf' and journal.view_pdf_button %}
-                                        </li>
-                                        <li>
-                                            <a target="_blank" href="{% url 'article_view_galley' article.id galley.id %}">{% trans "View" %} {{ galley.label }}</a>
-                                    {% endif %}
-                                </li>
-                            {% endfor %}
-                        </ul>
-                        {% if proofing %}
-                            <p id="note_to_proofreader_2">
-                                <i class="material-icons left">info</i>
-                                Note to proofreader: Download links on this page begin to work when the article is published.
-                            </p>
+                        {% if galleys %}
+                            <ul>
+                                {% for galley in galleys %}
+                                    <li>
+                                        <a href="{% url 'article_download_galley' article.id galley.id %}">{% trans "Download" %} {{ galley.label }}</a>
+                                        {% if galley.file.mime_type == 'application/pdf' and journal.view_pdf_button %}
+                                            </li>
+                                            <li>
+                                                <a target="_blank" href="{% url 'article_view_galley' article.id galley.id %}">{% trans "View" %} {{ galley.label }}</a>
+                                        {% endif %}
+                                    </li>
+                                {% endfor %}
+                            </ul>
+                            {% if proofing %}
+                                <p id="note_to_proofreader_2">
+                                    <i class="material-icons left">info</i>
+                                    Note to proofreader: Download links on this page begin to work when the article is published.
+                                </p>
+                            {% endif %}
+                            <div class="spacer">
+                                <div class="divider"></div>
+                            </div>
+                        {% else %}
+                            <p> {% trans 'Downloads are not available for this article.' %}</p>
                         {% endif %}
-                        <div class="spacer">
-                            <div class="divider"></div>
-                        </div>
-                    {% endif %}
                     {% endif %}
 
                     {% include "elements/journal/article_issue_list.html" %}


### PR DESCRIPTION
Updated django templates to check that there are galleys before creating download and checksum lists, across all three themes. Material already checked for galleys for download lists, but not for checksums.

For empty autogenerated tables of contents in OLH theme, updated the JS to remove the `toc` element if no headings were found, i.e. if list not populated.

Marked as draft as it is the end of the day, and I have yet to test this, so that must be done before sending for review. 