### PR TITLE
Close incomplete review assignments when an article is rejected

### DIFF
--- a/src/review/tests.py
+++ b/src/review/tests.py
@@ -275,6 +275,37 @@ class ReviewTests(TestCase):
             self.review_assignment_complete,
         )
 
+    def test_incomplete_reviews(self):
+        article1 = helpers.create_article(self.journal_one,
+                                          **{'owner': self.regular_user,
+                                             'title': 'Test Article',
+                                             'stage': submission_models.STAGE_UNDER_REVIEW,})
+
+        article1.correspondence_author = self.regular_user
+        article1.save()
+
+        round =  review_models.ReviewRound.objects.create(article=article1, round_number=1,)
+
+        assignment = helpers.create_review_assignment(journal=self.journal_one,
+                                                      article=article1,
+                                                      is_complete=False,
+                                                      review_round=round,
+                                                      reviewer=self.regular_user,)
+        assignment.decision = None
+        assignment.save()
+
+        self.client.force_login(self.editor)
+        decline_url = reverse('review_decision',
+                              kwargs={'article_id': article1.pk,
+                                      'decision': 'decline'})
+        response = self.client.get(decline_url, SERVER_NAME=self.journal_one.domain,)
+        self.assertContains(response, "The following incomplete reviews will be marked as withdrawn")
+
+        data = {'cc': [''], 'bcc': [''], 'subject': ['Article Declined'], 'body': ['Article Declined'], 'attachments': [''], 'skip': ['skip']}
+        response = self.client.post(decline_url, data, SERVER_NAME=self.journal_one.domain,)
+        self.assertEqual(article1.reviewassignment_set.filter(is_complete=True).count(), 1)
+        self.assertEqual(article1.reviewassignment_set.filter(is_complete=False).count(), 0)
+
     def test_completed_reviews_shared_setting(self):
         # setup data
         article_with_completed_reviews = helpers.create_article(

--- a/src/submission/models.py
+++ b/src/submission/models.py
@@ -1515,7 +1515,7 @@ class Article(AbstractLastModifiedModel):
         self.date_accepted = None
         self.stage = STAGE_REJECTED
 
-        self.incomplete_reviews().update(decision='withdrawn',
+        self.incomplete_reviews().update(decision=RD.DECISION_WITHDRAWN.value,
                                          date_complete=timezone.now(),
                                          is_complete=True,)
         self.save()

--- a/src/submission/models.py
+++ b/src/submission/models.py
@@ -1514,6 +1514,10 @@ class Article(AbstractLastModifiedModel):
         self.date_declined = timezone.now()
         self.date_accepted = None
         self.stage = STAGE_REJECTED
+
+        self.incomplete_reviews().update(decision='withdrawn',
+                                         date_complete=timezone.now(),
+                                         is_complete=True,)
         self.save()
 
     def undo_review_decision(self):
@@ -1830,6 +1834,11 @@ class Article(AbstractLastModifiedModel):
         ).exclude(
             decision='withdrawn',
         )
+
+    def incomplete_reviews(self):
+        return self.reviewassignment_set.filter(is_complete=False,
+                                                date_declined__isnull=True,
+                                                decision__isnull=True)
 
     def ms_and_figure_files(self):
         return chain(self.manuscript_files.all(), self.data_figure_files.all())

--- a/src/templates/admin/review/decision.html
+++ b/src/templates/admin/review/decision.html
@@ -39,6 +39,19 @@
                         </div>
                     {% endif %}
                 {% endif %}
+                {% if decision == 'decline' and article.incomplete_reviews.count > 0 %}
+                <p>The following incomplete reviews will be marked as withdrawn:</p>
+                {% for review in article.incomplete_reviews %}
+                    <div class="bs-callout bs-callout-warning">
+                        <h4>{{ review.reviewer.full_name }} (Round {{ review.review_round.round_number }})</h4>
+                        <p>This review was assigned
+                            on {{ review.date_requested }} and was due
+                            on {{ review.date_due }}</p>
+                            <p>{% if review.date_accepted %}The reviewer agreed to do this review on {{ review.date_accepted }}.{% else %}The reviewer has not agreed to complete this review.{% endif %}</p>
+                    </div>
+                    <br />
+                {% endfor %}
+                {% endif %}
                 {% if article.hidden_completed_reviews %}
                     <div class="bs-callout bs-callout-danger">
                         <p>{% trans 'Note: This article has completed reviews that have not been made available to the author:' %}</p>


### PR DESCRIPTION
Closes https://github.com/BirkbeckCTP/janeway/issues/4251

We found that open review counts for some reviewers were higher than expected because incomplete reviews from rejected articles were still open.

- Close incomplete review assignments when an article is rejected
- Add a callout to the "decline" email form that tells the user this will happen.