### PR TITLE
Buttons and labels for complicated forms

### DIFF
--- a/src/copyediting/models.py
+++ b/src/copyediting/models.py
@@ -51,7 +51,11 @@ class CopyeditAssignment(models.Model):
     date_decided = models.DateTimeField(null=True, blank=True)
 
     files_for_copyediting = models.ManyToManyField('core.File', related_name='files_for_copyediting')
-    copyeditor_files = models.ManyToManyField('core.File', blank=True)
+    copyeditor_files = models.ManyToManyField(
+        'core.File',
+        blank=True,
+        related_name='copyeditor_files',
+    )
     copyeditor_completed = models.DateTimeField(blank=True, null=True)
 
     copyedit_reopened = models.DateTimeField(blank=True, null=True)

--- a/src/core/models.py
+++ b/src/core/models.py
@@ -1228,10 +1228,8 @@ class Galley(AbstractLastModifiedModel):
 
     def detail(self):
         return format_html(
-            'Galley {}, {}, modified {}, linked to <a href="#file_{}">file {} - {}</a>',
-            self.pk,
+            '{} galley linked to <a href="#file_{}">file {}: {}</a>',
             self.label,
-            self.file.last_modified.strftime('%Y-%m-%d %H:%M'),
             self.file.pk,
             self.file.pk,
             self.file.original_filename,

--- a/src/core/models.py
+++ b/src/core/models.py
@@ -8,6 +8,7 @@ import uuid
 import statistics
 import json
 from datetime import timedelta
+from django.utils.html import format_html
 import pytz
 from hijack.signals import hijack_started, hijack_ended
 import warnings
@@ -32,7 +33,7 @@ from django.db.models.signals import post_save
 from django.dispatch import receiver
 from django.urls import reverse
 from django.utils.functional import cached_property
-from django.template.defaultfilters import linebreaksbr
+from django.template.defaultfilters import date
 import swapper
 
 from core import files, validators
@@ -1224,6 +1225,17 @@ class Galley(AbstractLastModifiedModel):
 
     def __str__(self):
         return "{0} ({1})".format(self.id, self.label)
+
+    def detail(self):
+        return format_html(
+            'Galley {}, {}, modified {}, linked to <a href="#file_{}">file {} - {}</a>',
+            self.pk,
+            self.label,
+            self.file.last_modified.strftime('%Y-%m-%d %H:%M'),
+            self.file.pk,
+            self.file.pk,
+            self.file.original_filename,
+        )
 
     def render(self, recover=False):
         return files.render_xml(

--- a/src/core/templatetags/dates.py
+++ b/src/core/templatetags/dates.py
@@ -5,10 +5,23 @@ from django.utils import timezone
 register = template.Library()
 
 @register.simple_tag
-def due_date(days=0, input_type="date"):
+def offset_date(days=0, input_type="date"):
     """
     Get a string representing today's date or the now datetime,
     with an offset of X days.
+    :param days: number of days from now that the date should be set
+    :param date: date or datetime-local
+
+    Usage:
+
+    <input
+      id="due"
+      name="due"
+      type="{{ input_type }}"
+      value="{% offset_date days=3 input_type=input_type %}">
+
+    See admin.core.widgets.soon_date_buttons for a use case.
+
     """
     due = timezone.now() + timezone.timedelta(days=days)
     if input_type == "date":

--- a/src/core/templatetags/due_dates.py
+++ b/src/core/templatetags/due_dates.py
@@ -1,0 +1,17 @@
+from django import template
+from django.utils import timezone
+
+
+register = template.Library()
+
+@register.simple_tag
+def due_date(days=0, input_type="date"):
+    """
+    Get a string representing today's date or the now datetime,
+    with an offset of X days.
+    """
+    due = timezone.now() + timezone.timedelta(days=days)
+    if input_type == "date":
+        return due.strftime("%Y-%m-%d")
+    elif input_type == "datetime-local":
+        return due.strftime("%Y-%m-%dT%H:%M")

--- a/src/core/templatetags/uuid.py
+++ b/src/core/templatetags/uuid.py
@@ -1,0 +1,8 @@
+from django import template
+from uuid import uuid4
+
+register = template.Library()
+
+@register.simple_tag
+def short_uuid4():
+    return f'u{str(uuid4())[:8]}'

--- a/src/core/templatetags/uuid.py
+++ b/src/core/templatetags/uuid.py
@@ -4,5 +4,5 @@ from uuid import uuid4
 register = template.Library()
 
 @register.simple_tag
-def short_uuid4():
-    return f'u{str(uuid4())[:8]}'
+def get_uuid4():
+    return f'u{str(uuid4())}'

--- a/src/static/admin/js/check_all.js
+++ b/src/static/admin/js/check_all.js
@@ -1,3 +1,5 @@
+// Deprecated. Use select_all.html instead.
+
  $("#checkall").click(function () {
      $('input:checkbox').not(this).prop('checked', this.checked);
  });

--- a/src/templates/admin/core/widgets/select_all.html
+++ b/src/templates/admin/core/widgets/select_all.html
@@ -16,7 +16,7 @@ Usage:
 
 {% load uuid %}
 
-{% short_uuid4 as pid %}
+{% get_uuid4 as pid %}
 
 <div id="{{ pid }}" style="button-group">
     <button class="button selectall" type="button">

--- a/src/templates/admin/core/widgets/select_all.html
+++ b/src/templates/admin/core/widgets/select_all.html
@@ -1,0 +1,44 @@
+{% comment %}
+Easily select or deselect all the checkboxes for a given field.
+
+Make sure to wrap this widget and the checkboxes in fieldset.
+
+Usage:
+
+<fieldset>
+    <legend>Which colours?</legend>
+    {% include "admin/core/widgets/select_all.html" %}
+    <input id="red" name="red" type="checkbox"><label for="red">Red</label>
+    <input id="blue" name="blue" type="checkbox"><label for="blue">Blue</label>
+</fieldset>
+
+{% endcomment %}
+
+{% load uuid %}
+
+{% short_uuid4 as pid %}
+
+<div id="{{ pid }}" style="button-group">
+    <button class="button selectall" type="button">
+        <span class="fa fa-check"></span>
+        Select all
+    </button>
+    <button class="button deselectall" type="button">
+        <span class="fa fa-close"></span>
+        Deselect all
+    </button>
+</div>
+<script defer type="module">
+    function toggleInputsInFieldset(event) {
+        const checked = event.currentTarget.classList.contains('selectall');
+        const fieldset = event.currentTarget.closest('fieldset');
+        const checkboxes = fieldset.querySelectorAll('input[type="checkbox"]');
+        Array.from(checkboxes).forEach(checkbox => {
+          checkbox.checked = checked;
+        });
+    }
+    const selectAll = document.querySelector('#{{ pid }} .selectall');
+    selectAll.addEventListener('click', toggleInputsInFieldset);
+    const deselectAll = document.querySelector('#{{ pid }} .deselectall');
+    deselectAll.addEventListener('click', toggleInputsInFieldset);
+</script>

--- a/src/templates/admin/core/widgets/soon_date_buttons.html
+++ b/src/templates/admin/core/widgets/soon_date_buttons.html
@@ -1,0 +1,86 @@
+{% comment %}
+Easily fill in a date or datetime field.
+
+date_input_id - str: the id of the input these buttons should control.
+
+Usage:
+
+{% include "admin/core/widgets/soon_date_buttons.html" with date_input_id="due" %}
+<label for="due">Due date</label>
+<input id="due" name="due" type="date">
+
+{% endcomment %}
+
+{% load uuid %}
+{% load due_dates %}
+
+{% short_uuid4 as pid %}
+
+<div id="{{ pid }}" style="button-group">
+  <button
+    class="button set-date"
+    type="button"
+    aria-controls="{{ date_input_id }}"
+    value="{% due_date days=0 input_type=input_type %}">
+    Now
+  </button>
+  <button
+    class="button set-date"
+    type="button"
+    aria-controls="{{ date_input_id }}"
+    value="{% due_date days=1 input_type=input_type %}">
+    1 day
+  </button>
+  <button
+    class="button set-date"
+    type="button"
+    aria-controls="{{ date_input_id }}"
+    value="{% due_date days=2 input_type=input_type %}">
+    2 days
+  </button>
+  <button
+    class="button set-date"
+    type="button"
+    aria-controls="{{ date_input_id }}"
+    value="{% due_date days=3 input_type=input_type %}">
+    3 days
+  </button>
+  <button
+    class="button set-date"
+    type="button"
+    aria-controls="{{ date_input_id }}"
+    value="{% due_date days=5 input_type=input_type %}">
+    5 days
+  </button>
+  <button
+    class="button set-date"
+    type="button"
+    aria-controls="{{ date_input_id }}"
+    value="{% due_date days=7 input_type=input_type %}">
+    1 week
+  </button>
+  <button
+    class="button set-date"
+    type="button"
+    aria-controls="{{ date_input_id }}"
+    value="{% due_date days=14 input_type=input_type %}">
+    2 weeks
+  </button>
+  <button
+    class="button set-date"
+    type="button"
+    aria-controls="{{ date_input_id }}"
+    value="{% due_date days=28 input_type=input_type %}">
+    4 weeks
+  </button>
+</div>
+<script defer type="module">
+  function setDate(event) {
+    const dateInput = document.querySelector('#{{ date_input_id }}');
+    dateInput.value = event.currentTarget.value;
+  }
+  const setDateButtons = document.querySelectorAll('#{{ pid }} .set-date');
+  Array.from(setDateButtons).forEach(dateButton => {
+    dateButton.addEventListener('click', setDate);
+  });
+</script>

--- a/src/templates/admin/core/widgets/soon_date_buttons.html
+++ b/src/templates/admin/core/widgets/soon_date_buttons.html
@@ -12,7 +12,7 @@ Usage:
 {% endcomment %}
 
 {% load uuid %}
-{% load due_dates %}
+{% load dates %}
 
 {% get_uuid4 as pid %}
 
@@ -21,56 +21,56 @@ Usage:
     class="button set-date"
     type="button"
     aria-controls="{{ date_input_id }}"
-    value="{% due_date days=0 input_type=input_type %}">
-    Now
+    value="{% offset_date days=0 input_type=input_type %}">
+    {% if input_type == "datetime-local" %}Now{% else %}Today{% endif %}
   </button>
   <button
     class="button set-date"
     type="button"
     aria-controls="{{ date_input_id }}"
-    value="{% due_date days=1 input_type=input_type %}">
+    value="{% offset_date days=1 input_type=input_type %}">
     1 day
   </button>
   <button
     class="button set-date"
     type="button"
     aria-controls="{{ date_input_id }}"
-    value="{% due_date days=2 input_type=input_type %}">
+    value="{% offset_date days=2 input_type=input_type %}">
     2 days
   </button>
   <button
     class="button set-date"
     type="button"
     aria-controls="{{ date_input_id }}"
-    value="{% due_date days=3 input_type=input_type %}">
+    value="{% offset_date days=3 input_type=input_type %}">
     3 days
   </button>
   <button
     class="button set-date"
     type="button"
     aria-controls="{{ date_input_id }}"
-    value="{% due_date days=5 input_type=input_type %}">
+    value="{% offset_date days=5 input_type=input_type %}">
     5 days
   </button>
   <button
     class="button set-date"
     type="button"
     aria-controls="{{ date_input_id }}"
-    value="{% due_date days=7 input_type=input_type %}">
+    value="{% offset_date days=7 input_type=input_type %}">
     1 week
   </button>
   <button
     class="button set-date"
     type="button"
     aria-controls="{{ date_input_id }}"
-    value="{% due_date days=14 input_type=input_type %}">
+    value="{% offset_date days=14 input_type=input_type %}">
     2 weeks
   </button>
   <button
     class="button set-date"
     type="button"
     aria-controls="{{ date_input_id }}"
-    value="{% due_date days=28 input_type=input_type %}">
+    value="{% offset_date days=28 input_type=input_type %}">
     4 weeks
   </button>
 </div>

--- a/src/templates/admin/core/widgets/soon_date_buttons.html
+++ b/src/templates/admin/core/widgets/soon_date_buttons.html
@@ -14,7 +14,7 @@ Usage:
 {% load uuid %}
 {% load due_dates %}
 
-{% short_uuid4 as pid %}
+{% get_uuid4 as pid %}
 
 <div id="{{ pid }}" style="button-group">
   <button

--- a/src/templates/admin/elements/datatables.html
+++ b/src/templates/admin/elements/datatables.html
@@ -5,15 +5,17 @@
 <script type="text/javascript">
 
 $(document).ready(function() {
-    $('{{target}}').DataTable({
-        "lengthMenu": [[25, 50, 10, 5, -1], [25, 50, 10, 5, "All"]],
-    {% if hide_length %}"bLengthChange": false,{% endif %}
-    {% if hide_page %}"bPaginate": false,{% endif %}
-    {% if sort and order %}"order": [[ {{ sort }}, "{{ order }}" ]],{% endif %}
-    {% if sort_list %}"order": [{{ sort_list }}],{% endif %}
-    {% if disable_ordering %}"ordering": false,{% endif %}
-    {% if page_length %}"pageLength": {{ page_length }},{% endif %}
+  '{{ target }}'.split(' ').forEach(target => {
+    $(target).DataTable({
+      "lengthMenu": [[25, 50, 10, 5, -1], [25, 50, 10, 5, "All"]],
+      {% if hide_length %}"bLengthChange": false,{% endif %}
+      {% if hide_page %}"bPaginate": false,{% endif %}
+      {% if sort and order %}"order": [[ {{ sort }}, "{{ order }}" ]],{% endif %}
+      {% if sort_list %}"order": [{{ sort_list }}],{% endif %}
+      {% if disable_ordering %}"ordering": false,{% endif %}
+      {% if page_length %}"pageLength": {{ page_length }},{% endif %}
     });
-} );
+  });
+});
 
 </script>

--- a/src/templates/admin/elements/publish/pubdate.html
+++ b/src/templates/admin/elements/publish/pubdate.html
@@ -19,6 +19,7 @@
             {% endif %}
             <form method="POST">
                 {% csrf_token %}
+                {% include "admin/core/widgets/soon_date_buttons.html" with date_input_id=pub_date_form.date_published.id_for_label input_type="datetime-local" %}
                 {{ pub_date_form|foundation }}
                 <button type="submit" name="pubdate" class="small success button">Set Publication Date</button>
             </form>


### PR DESCRIPTION
This adds a few template tags, widgets, and model properties that I used in fixing BirkbeckCTP/typesetting#166.

- A set of buttons that select or deselect all the checkbox inputs in a fieldset (an upgrade of of the jquery-based check_all.js, which could only be used once per page and was not accessible)
- A `detail` method on the galley object to make it possible to provide information about the linked file in a form choice
![image](https://github.com/user-attachments/assets/5601b17b-28a4-42fa-ac01-c1dbccd77c71)

- A set of buttons that make it easier to quickly infill a date
![image](https://github.com/user-attachments/assets/33b99741-14a6-4e8a-a957-556e52bf3b27)


- Support for initiating multiple datatables on a single page