### PR TITLE
Adds a skip to content link to all themes that is tab navigable

### DIFF
--- a/src/static/common/css/common.css
+++ b/src/static/common/css/common.css
@@ -298,3 +298,26 @@ article .list-romanupper {
     padding: 15px;
     margin-top: 15px;
 }
+
+.skip-container {
+    position: absolute;
+    top: -100px;
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: 100;
+    transition: top 0.3s;
+}
+
+.skip-to-content {
+    background: #f0f0f0;
+    color: #000;
+    padding: 8px 16px;
+    text-decoration: none;
+    display: inline-block;
+}
+
+.skip-to-content:focus,
+.skip-to-content:hover,
+.skip-container:focus-within {
+    top: 10px;
+}

--- a/src/static/common/css/common.css
+++ b/src/static/common/css/common.css
@@ -299,25 +299,31 @@ article .list-romanupper {
     margin-top: 15px;
 }
 
+/* Styling for skip to main content link */
 .skip-container {
-    position: absolute;
-    top: -100px;
-    left: 50%;
-    transform: translateX(-50%);
-    z-index: 100;
-    transition: top 0.3s;
+    position: relative;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: 0;
+    overflow: hidden;
 }
 
-.skip-to-content {
-    background: #f0f0f0;
-    color: #000;
-    padding: 8px 16px;
-    text-decoration: none;
-    display: inline-block;
+.skip-to-content,
+.skip-to-nav {
+    position: absolute;
+    left: -999px;
 }
 
 .skip-to-content:focus,
-.skip-to-content:hover,
+.skip-to-nav:focus {
+    position: relative;
+    left: 0;
+    margin-block-start: 10px;
+    margin-block-end: 10px;
+}
+
 .skip-container:focus-within {
-    top: 10px;
+    height: auto;
+    overflow: visible;
 }

--- a/src/templates/common/elements/skip_to_main_content.html
+++ b/src/templates/common/elements/skip_to_main_content.html
@@ -1,0 +1,5 @@
+<div class="skip-container">
+  <a class="skip-to-content" href="#main-content">
+    {% trans 'Skip to main content' %}
+  </a>
+</div>

--- a/src/themes/OLH/assets/js/app.js
+++ b/src/themes/OLH/assets/js/app.js
@@ -7,7 +7,6 @@ $(function() {
         $('html,body').animate({
           scrollTop: target.offset().top - $(".mini-bar").outerHeight()
         }, 1000);
-        return false;
       }
     }
   });

--- a/src/themes/OLH/templates/core/base.html
+++ b/src/themes/OLH/templates/core/base.html
@@ -51,6 +51,7 @@
 
 </head>
 <body>
+{% include "common/elements/skip_to_main_content.html" %}
 <div class="wrapper">
     <header class="main-header" role="banner">
         <div class="main top-bar">
@@ -171,7 +172,7 @@
         {% endblock navbar %}
     </header>
 
-    <main>
+    <main id="main-content">
         {% block body %}{% endblock body %}
     </main>
 </div>

--- a/src/themes/clean/templates/core/base.html
+++ b/src/themes/clean/templates/core/base.html
@@ -34,7 +34,7 @@
     {% hook 'base_head_css' %}
 </head>
 <body>
-<div class="skipnav"><a href="#main">{% trans 'Skip to main content' %}</a></div>
+{% include "common/elements/skip_to_main_content.html" %}
 <div class="container">
     <header class="site-header" role="banner">
         <div id="journal-title">
@@ -72,7 +72,7 @@
             {% include "press/nav.html" %}
         {% endif %}
     </header>
-    <main id="main">
+    <main id="main-content">
         {% for message in messages %}
             <div class="alert alert-{{ message.tags }} alert-dismissable">
                 <a href="#" class="close" data-dismiss="alert" aria-label="close">&times;</a>

--- a/src/themes/material/templates/core/base.html
+++ b/src/themes/material/templates/core/base.html
@@ -46,7 +46,7 @@
     <link rel="alternate" type="application/rss+xml" title="RSS Feed" href="{% url 'rss_articles' %}"/>
 </head>
 <body>
-
+{% include "common/elements/skip_to_main_content.html" %}
 <header>
 {% block navbar %}
     {% if request.journal %}
@@ -58,7 +58,7 @@
     {% endif %}
 {% endblock navbar %}
 </header>
-<main>
+<main id="main-content">
     <div class="container">
         <div class="section">
             {% block body %}{% endblock %}


### PR DESCRIPTION
- Adds a new common template
- Replaces existing skip to content for clean
- Adds ID to `<main>`
- Closes #3932 
<img width="538" alt="Screenshot 2024-07-22 at 12 20 43" src="https://github.com/user-attachments/assets/0c675036-cbb3-4f49-89ba-380871369d27">
<img width="509" alt="Screenshot 2024-07-22 at 12 20 32" src="https://github.com/user-attachments/assets/40112c5c-aebd-4884-96de-93f7cad2b285">
<img width="1441" alt="Screenshot 2024-07-22 at 12 20 16" src="https://github.com/user-attachments/assets/43763872-6444-4361-85fc-fce0632c32da">
