### PR TITLE
#4342 revision requests now show on the review dashboard even when no review assignments have been created

### DIFF
--- a/src/templates/admin/review/home.html
+++ b/src/templates/admin/review/home.html
@@ -54,7 +54,7 @@
                                 None{% endif %}</td>
                             {% if journal_settings.general.enable_expanded_review_details %}
                                 <td>
-                                    {% if article.reviewassignment_set.exists %}
+                                    {% if article.reviewassignment_set.exists or article.revisionrequest_set.exists %}
                                         <table style="width:100%; min-width:230px;"
                                                class="table table-stack small no-pad no-bottom-margin">
                                             {% for review in article.reviews_not_withdrawn %}
@@ -113,7 +113,7 @@
                                             {% endfor %}
                                         </table>
                                     {% else %}
-                                        No Review assignments
+                                        No review or revision assignments
                                     {% endif %}
                                 </td>
                             {% else %}


### PR DESCRIPTION
Closes #4342 

Example article with only a revision request post change:
<img width="278" alt="Screenshot 2024-08-05 at 09 30 44" src="https://github.com/user-attachments/assets/608894c7-0468-494a-a22c-69c07369e323">
