### PR TITLE
When serving an article's PDF via the identifier URL, don't try to read an attribute from a None object

### DIFF
--- a/src/journal/views.py
+++ b/src/journal/views.py
@@ -2646,7 +2646,7 @@ def serve_article_pdf(request, identifier_type, identifier):
         identifier,
     )
 
-    if not article_object and not article_object.is_published:
+    if not article_object or not article_object.is_published:
         raise Http404
 
     pdf = article_object.pdfs.first()


### PR DESCRIPTION
URLs in the form `/article/<identifier_type>/<identifier>/download/pdf/` call a view that tries to get the article using the identifier.

If the article does not exist (maybe because there was a typo in the identifier), or if the article has not yet been published, the view should return a 404.

This MR tries to fix a small bug that makes the clause above to fail badly when the article does not exists, because, ATM, the code checks if the non-existing article has been published :slightly_smiling_face: 


Unfortunately I wasn't able to replicate the issue on any online system where I tried. For instance, both the following URLs return a neat 404, but AFAICT the first should work and the second should give 500:
- https://olh.openlibhums.org/article/doi/10.16995%2Folh.16937/download/pdf
- https://olh.openlibhums.org/article/doi/10.16995%2Folh.16937xxxxxxxxxxxxxxxx/download/pdf

So, it's very possible I'm missing something here (i.e. please feel free to trash this MR).
