### PR TITLE
Updates clean to use frozen authors for citation modals.

### DIFF
--- a/src/themes/clean/templates/elements/journal/citation_modals.html
+++ b/src/themes/clean/templates/elements/journal/citation_modals.html
@@ -9,7 +9,7 @@
                     </button>
                 </div>
                 <div class="modal-body">
-                    <p>{% for author in article.authors.all %}{% if not forloop.first and not forloop.last %},
+                    <p>{% for author in article.frozenauthor_set.all %}{% if not forloop.first and not forloop.last %},
                     {% elif forloop.last and not forloop.first %}& {% endif %}{{ author.last_name }},
                         {{ author.first_name|slice:"1" }}{% if forloop.last %}.{% endif %} {% endfor %}
                         ({{ article.date_published.year }}) '{{ article.title|safe }}',
@@ -31,7 +31,7 @@
                     </button>
                 </div>
                 <div class="modal-body">
-                    <p>{% for author in article.authors.all %}{% if not forloop.first and not forloop.last %},
+                    <p>{% for author in article.frozenauthor_set.all %}{% if not forloop.first and not forloop.last %},
                     {% elif forloop.last and not forloop.first %}& {% endif %}{{ author.last_name }},
                         {{ author.first_name|slice:"1" }}{% if forloop.last %}.{% endif %} {% endfor %}
                         {{ article.title|safe }}. {% if journal.name %}{{ journal.name }}{% else %}{{ request.press.name }} Preprints{% endif %}. {{ article.date_published.year }} {{ article.date_published.month }};{% if article.issue %} %}{{ article.issue.volume }}({{ article.issue.issue }}){% endif %}{% if article.page_range %}:{{ article.page_range }}.{% endif %}
@@ -52,7 +52,7 @@
                     </button>
                 </div>
                 <div class="modal-body">
-                    <p>{% for author in article.authors.all %}{% if forloop.last %}{% if not forloop.first %}
+                    <p>{% for author in article.frozenauthor_set.all %}{% if forloop.last %}{% if not forloop.first %}
                         &amp; {% endif %}{% endif %}{{ author.last_name }},
                         {{ author.first_name|slice:"1" }}{% if forloop.last %}.{% endif %} {% endfor %}
                         ({{ article.date_published.year }}, {{ article.date_published.month }} {{ article.date_published.day }}). {{ article.title|safe }}.


### PR DESCRIPTION
Clean now uses `frozenauthor_set` like OLH already does.

Closes #2422 