### PR TITLE
4353 article page sharelinks a11y update

### DIFF
--- a/src/static/common/css/common.css
+++ b/src/static/common/css/common.css
@@ -327,3 +327,11 @@ article .list-romanupper {
     height: auto;
     overflow: visible;
 }
+
+a.twitter-x{
+  color: black;
+  text-decoration: none;
+  font-size: large;
+  font-weight: bold;
+  line-height: 1.25;
+}

--- a/src/themes/OLH/templates/journal/article.html
+++ b/src/themes/OLH/templates/journal/article.html
@@ -101,44 +101,47 @@
     {% endif %}
 
         <div data-sticky-container class="row">
-            <div class="mini-bar sticky" data-sticky data-margin-top="0" data-sticky data-anchor="content">
+            <div class="mini-bar sticky columns" data-sticky data-margin-top="0" data-sticky data-anchor="content">
                 <div class="row">
                     <div class="title-bar" data-responsive-toggle="options-menu" data-hide-for="medium">
                         <button class="menu-icon" type="button" data-toggle aria-label="{% trans 'Options' %}"></button>
                         <div class="title-bar-title">{% trans 'Options' %}</div>
                     </div>
                     <div id="options-menu">
-                        <div class="large-6 columns">
+                        <div class="small-4 medium-3 large-2 columns">
                             <ul class="menu vertical medium-horizontal pad-left-15"
                                 data-responsive-menu="drilldown medium-dropdown">
                               {% with article.get_doi_url as doi_url %}
                                 <li>{% trans "Share" %}:</li>
                                 <li><a href="https://www.facebook.com/share.php?p[url]={% if doi_url %}{{ doi_url }}{% else %}{{ article.url }}{% endif %}" target="_blank" aria-label="{% trans 'Share on Facebook' %}"><i class="fa fa-facebook"></i></a></li>
-                                <li><a href="https://twitter.com/intent/tweet?text={{ article.title }} {% if doi_url %}{{ doi_url }}{% else %}{{ article.url }}{% endif %}" target="_blank" aria-label="{% trans 'Share on X' %}"><i class="fa fa-twitter"></i></a></li>
+                                <li><a class= "twitter-x"
+                                    href="https://twitter.com/intent/tweet?text={{ article.title }} {% if doi_url %}{{ doi_url }}{% else %}{{ article.url }}{% endif %}" target="_blank" aria-label="{% trans 'Share on X' %}">&#120143;</a></li>
                                 <li><a href="https://www.linkedin.com/sharing/share-offsite?url={% if doi_url %}{{ doi_url }}{% else %}{{ article.url }}{% endif %}" target="_blank" aria-label="{% trans 'Share on LinkedIn' %}"><i class="fa fa-linkedin"></i></a></li>
                               {% endwith %}
                             </ul>
                         </div>
-                        <div class="large-6 columns">
-                            <ul class="menu vertical medium-horizontal align-right"
-                                data-responsive-menu="dropdown">
-                                {% hook 'article_buttons' %}
-                                <li><a href="{{ article.local_url }}print/" aria-label="{% trans 'print article' %}"><i class="fa fa-print">&nbsp;</i></a></li>
-                                <li><a href="javascript:resizeText(-1)" aria-label="{% trans 'decrease text size' %}">A-</a></li>
-                                <li><a href="javascript:resizeText(1)" aria-label="{% trans 'increase text size' %}">A+</a></li>
-                                {% if author.display_email and not journal_settings.article.hide_author_email_links %}<li><a href="mailto:{{ article.correspondence_author.email }}"><i class="fa fa-envelope"></i></a></li>{% endif %}
-                                <li><a href="#" id="dyslexia-mode" aria-label="{% trans 'Dyslexia mode' %}">{% trans "Dyslexia" %}</a></li>
-                                <li>
-                                    <a href="#" aria-label="{% trans 'Cite article' %}"><i class="fa fa-comments">&nbsp;</i></a>
-                                    <ul class="menu vertical">
-                                        <li><a href="#" data-open="HarvardModal">{% trans "Harvard Citation Style" %}</a></li>
-                                        <li><a href="#" data-open="VancouverModal">{% trans "Vancouver Citation Style" %}</a></li>
-                                        <li><a href="#" data-open="APAModal">{% trans "APA Citation Style" %}</a></li>
-                                        <li><a href="{% url 'serve_article_ris' 'id' article.pk %}"> {% trans 'Download' %} RIS</a></li>
-                                        <li><a href="{% url 'serve_article_bib' 'id' article.pk %}">{% trans ' Download' %} BibTeX</a></li>
-                                    </ul>
-                                </li>
-                            </ul>
+                        <div class="small-8 medium-9 large-10 columns">
+                            <div class = "float-right">
+                                <ul class="menu vertical medium-horizontal"
+                                    data-responsive-menu="dropdown">
+                                    {% hook 'article_buttons' %}
+                                    <li><a href="{{ article.local_url }}print/" aria-label="{% trans 'print article' %}"><i class="fa fa-print">&nbsp;</i></a></li>
+                                    <li><a href="javascript:resizeText(-1)" aria-label="{% trans 'decrease text size' %}">A-</a></li>
+                                    <li><a href="javascript:resizeText(1)" aria-label="{% trans 'increase text size' %}">A+</a></li>
+                                    {% if author.display_email and not journal_settings.article.hide_author_email_links %}<li><a href="mailto:{{ article.correspondence_author.email }}"><i class="fa fa-envelope"></i></a></li>{% endif %}
+                                    <li><a href="#" id="dyslexia-mode" aria-label="{% trans 'Dyslexia mode' %}">{% trans "Dyslexia" %}</a></li>
+                                    <li>
+                                        <a href="#" aria-label="{% trans 'Cite article' %}"><i class="fa fa-comments">&nbsp;</i></a>
+                                        <ul class="menu vertical">
+                                            <li><a href="#" data-open="HarvardModal">{% trans "Harvard Citation Style" %}</a></li>
+                                            <li><a href="#" data-open="VancouverModal">{% trans "Vancouver Citation Style" %}</a></li>
+                                            <li><a href="#" data-open="APAModal">{% trans "APA Citation Style" %}</a></li>
+                                            <li><a href="{% url 'serve_article_ris' 'id' article.pk %}"> {% trans 'Download' %} RIS</a></li>
+                                            <li><a href="{% url 'serve_article_bib' 'id' article.pk %}">{% trans ' Download' %} BibTeX</a></li>
+                                        </ul>
+                                    </li>
+                                </ul>
+                            </div>
                         </div>
                     </div>
                 </div>

--- a/src/themes/clean/assets/css/clean.css
+++ b/src/themes/clean/assets/css/clean.css
@@ -453,3 +453,7 @@ header svg {
 .page-item.active .page-link {
   background-color: #4F637D;
 }
+
+.social-share-btn{
+    border: 1px black solid;
+}

--- a/src/themes/clean/templates/journal/article.html
+++ b/src/themes/clean/templates/journal/article.html
@@ -185,6 +185,18 @@
                 {% endif %}
 
                 {% if article.is_published or proofing %}
+                    <h2>{% trans "Share" %}</h2>
+                    {% with article.get_doi_url as doi_url%}
+                    <a class="waves-effect waves-light btn btn-small social-share-btn facebook-bg"
+                        href="https://www.facebook.com/share.php?p[url]={% if doi_url %}{{ doi_url }}{% else %}{{ article.url }}{% endif %}" 
+                        target="_blank" aria-label="{% trans 'Share on Facebook' %}"><i class="fa fa-facebook"></i></a>
+                    <a class="waves-effect waves-light btn btn-small social-share-btn twitter-x" 
+                        href="https://twitter.com/intent/tweet?text={{ article.title }} {% if doi_url %}{{ doi_url }}{% else %}{{ article.url }}{% endif %}"
+                        target="_blank" aria-label="{% trans 'Share on X' %}">&#120143;</a>
+                    <a class="waves-effect waves-light btn btn-small social-share-btn linkedin-bg"
+                        href="https://www.linkedin.com/sharing/share-offsite?url={% if doi_url %}{{ doi_url }}{% else %}{{ article.url }}{% endif %}"
+                        target="_blank" aria-label="{% trans 'Share on LinkedIn' %}"><i class="fa fa-linkedin"></i></a></button>
+                    {% endwith %}
                     <h2>{% trans "Download" %}</h2>
                     <ul>
                         {% for galley in galleys %}

--- a/src/themes/material/assets/mat.css
+++ b/src/themes/material/assets/mat.css
@@ -562,8 +562,8 @@ nav a.sidenav-trigger i {
 :root {
     --facebook: #3b5998;
     --facebook-hover: #3b5998;
-    --twitter: #00acee;
-    --twitter-hover: #008abe;
+    --twitter: black;
+    --twitter-hover: white;
     --linkedin: #0e76a8;
     --linkedin-hover: #0b5e87;
 }
@@ -584,10 +584,12 @@ nav a.sidenav-trigger i {
 
 .twitter-bg {
     background-color: var(--twitter);
+    color: var(--twitter-hover) !important;
 }
 
 .twitter-bg:hover {
     background-color: var(--twitter-hover);
+    color: var(--twitter) !important;
 }
 
 .linkedin-bg {

--- a/src/themes/material/templates/journal/article.html
+++ b/src/themes/material/templates/journal/article.html
@@ -255,9 +255,9 @@
                         <a class="waves-effect waves-light btn btn-small facebook-bg"
                             href="https://www.facebook.com/share.php?p[url]={% if doi_url %}{{ doi_url }}{% else %}{{ article.url }}{% endif %}" 
                             target="_blank" aria-label="{% trans 'Share on Facebook' %}"><i class="fa fa-facebook"></i></a>
-                        <a class="waves-effect waves-light btn btn-small twitter-bg" 
+                        <a class="waves-effect waves-light btn btn-small twitter-bg twitter-x" 
                             href="https://twitter.com/intent/tweet?text={{ article.title }} {% if doi_url %}{{ doi_url }}{% else %}{{ article.url }}{% endif %}"
-                            target="_blank" aria-label="{% trans 'Share on X' %}"><i class="fa fa-twitter"></i></a>
+                            target="_blank" aria-label="{% trans 'Share on X' %}">&#120143;</a>
                         <a class="waves-effect waves-light btn btn-small linkedin-bg"
                             href="https://www.linkedin.com/sharing/share-offsite?url={% if doi_url %}{{ doi_url }}{% else %}{{ article.url }}{% endif %}"
                             target="_blank" aria-label="{% trans 'Share on LinkedIn' %}"><i class="fa fa-linkedin"></i></a></button>


### PR DESCRIPTION
Updated the share links across all themes for a11y.

- OLH - tab order of share bar now matches visual order, and a small alignment fix.
- Clean - now has share links
- All themes: now have X instead of Twitter (and updates to css to make X in black instead of the blue bird).


NB the share links for Clean are buttons because of the need to meet WCAG minimum target size. More comments on this [with screenshots on issue itself.](https://github.com/BirkbeckCTP/janeway/issues/4353#issuecomment-2277758130)

Closes #4353 

which encompassed these, so it also:

Closes #3933 
Closes #4340
Closes #1863