### PR TITLE
[TGDK][Proposal] Add review round tabs to improve Decision Panel usability and accuracy

### DIFF
--- a/src/review/models.py
+++ b/src/review/models.py
@@ -3,6 +3,8 @@ __author__ = "Martin Paul Eve & Andy Byers"
 __license__ = "AGPL v3"
 __maintainer__ = "Birkbeck Centre for Technology and Publishing"
 
+from collections import Counter
+
 from django.db import models
 from django.utils import timezone
 from django.db.models import Max, Q, Value
@@ -127,6 +129,34 @@ class ReviewRound(models.Model):
         ).order_by(
             'decision',
         )
+
+    def complete_reviews(self):
+        return self.reviewassignment_set.filter(
+            is_complete=True,
+            date_complete__isnull=False,
+        ).exclude(
+            decision='withdrawn',
+        )
+
+    def uncomplete_reviews(self):
+        return self.reviewassignment_set.filter(
+            is_complete=False,
+            date_complete__isnull=True,
+        ).union(
+            self.withdraw_reviews()
+        )
+
+    def withdraw_reviews(self):
+        return self.reviewassignment_set.filter(
+            decision='withdrawn',
+        )
+
+    def decisions_count(self):
+        reviews = self.reviewassignment_set.all()
+        decisions = Counter(
+            [review.get_decision_display() for review in reviews if review.decision]
+        )
+        return dict(decisions)
 
     @classmethod
     def latest_article_round(cls, article):

--- a/src/review/views.py
+++ b/src/review/views.py
@@ -2813,6 +2813,8 @@ def decision_helper(request, article_id):
         article=article,
     )
 
+    review_rounds = models.ReviewRound.objects.filter(article=article)
+
     uncomplete_reviews = reviews.filter(
         article=article,
         is_complete=False,
@@ -2878,6 +2880,7 @@ def decision_helper(request, article_id):
     template = 'admin/review/decision_helper.html'
     context = {
         'article': article,
+        'review_rounds': review_rounds,
         'complete_reviews': complete_reviews,
         'uncomplete_reviews': uncomplete_reviews,
         'decisions': dict(decisions)

--- a/src/templates/admin/review/decision_helper.html
+++ b/src/templates/admin/review/decision_helper.html
@@ -14,6 +14,19 @@
 {% endblock breadcrumbs %}
 
 {% block body %}
+<div class="box" style="margin-bottom: 0;" >
+    <ul class="tabs" data-tabs id="round-tabs">
+        {% for round in review_rounds %}
+            <li class="tabs-title {% if forloop.first %} is-active{% endif %}"><a
+                    href="#tab{{ round.round_number }}"
+                    aria-selected="true">Round {{ round.round_number }}</a></li>
+        {% endfor %}
+    </ul>
+</div>
+
+<div class="tabs-content" data-tabs-content="round-tabs" style="background: none;">
+    {% for round in review_rounds %}
+    <div class="tabs-panel{% if forloop.first %} is-active{% endif %}" id="tab{{ round.round_number }}" style="padding:0;">
     <div class="box">
         <div class="row expanded">
             <div class="large-6 columns">
@@ -21,8 +34,10 @@
                 {% user_has_role request 'editor' as editor %}
                 <h2 style="color: #5bc0de;"><span class="fa fa-clipboard"></span> Reviewer Recommendations</h2>
                 <div class="bs-callout bs-callout-info">
-                    {% for decision, counter in decisions.items %}
+                    {% for decision, counter in round.decisions_count.items %}
                     <p><strong>{{ decision|capfirst }}</strong>: {{ counter }}</p>
+                    {% empty %}
+                    No Reviewer Decisions.
                     {% endfor %}
                 </div>
             </div>
@@ -80,9 +95,9 @@
         <div class="row expanded">
             <div class="large-6 columns">
                 <h2 class="success green"><i
-                        class="fa fa-check-square"></i> {{ complete_reviews.count }}
+                        class="fa fa-check-square"></i> {{ round.complete_reviews.count }}
                     completed reviews</h2>
-                {% for review in complete_reviews %}
+                {% for review in round.complete_reviews %}
                     <div class="bs-callout bs-callout-{% if review.for_author_consumption %}success{% else %}warning{% endif %}">
                         <h4>
                             #{{ review.pk }} {{ review.reviewer.full_name }} (Round {{ review.review_round.round_number }})
@@ -121,9 +136,9 @@
             </div>
             <div class="large-6 columns">
                 <h2 class="danger red"><i
-                        class="fa fa-exclamation-triangle"></i> {{ uncomplete_reviews.count }}
+                        class="fa fa-exclamation-triangle"></i> {{ round.uncomplete_reviews.count }}
                     uncompleted reviews </h2>
-                {% for review in uncomplete_reviews %}
+                {% for review in round.uncomplete_reviews %}
                     <div class="bs-callout {% if review.date_accepted %}bs-callout-warning{% else %}bs-callout-danger{% endif %}">
                         <h4>{{ review.reviewer.full_name }} (Round {{ review.review_round.round_number }})</h4>
                         <p>This review was assigned
@@ -140,6 +155,9 @@
             </div>
         </div>
     </div>
+    </div>
+{% endfor %}
+</div>
 
     {% for review in complete_reviews %}
     {% include "elements/review/decision_form_modal.html" with review=review %}


### PR DESCRIPTION
>[!IMPORTANT]
> This implementation is part of a set of features and fixes developed within the context of a project for the TGDK academic journal, with the goal of customizing Janeway to meet the journal's specific needs, which may also be extended to other contexts.

## Problem / Objective
The current decision panel provides essential information to help editors make final decisions on articles (accept, reject, or request revisions). However, the information displayed is aggregated across all review rounds, which may not always accurately represent the article's current status.

This creates confusion when previous review rounds have significant changes that are no longer relevant to the current state of the article. The decision panel does not sufficiently balance historical recommendations and results with the current review context.

## Solution
The proposed solution is to introduce tabs at the top of the panel that allow editors to switch between different review rounds. These tabs will organize the information displayed below them, ensuring it aligns with the selected review round.

- By default, the panel will display information for the most recent review round, prioritizing the current state of the article.
- Editors can easily navigate to previous review rounds to access their recommendations, decisions, and feedback.
- This structure separates information by review round, representing the article's status more accurately and allowing editors to better evaluate the progression of the article through the review process.

![image](https://github.com/user-attachments/assets/3695034e-0f69-46f0-a614-a3a01e95dd3f)

This solution maintains consistency with the current functionality of decision-making actions (accept, reject, request revisions) while adding flexibility and accuracy in displaying review data.