### PR TITLE
Remove `date_published` filters for identifiers

### DIFF
--- a/src/api/views.py
+++ b/src/api/views.py
@@ -497,7 +497,6 @@ class Identifiers(viewsets.ModelViewSet):
     def _get_repository_identifiers(self, preprint_id, preprint_version_id):
         queryset = identifier_models.Identifier.objects.filter(
             preprint_version__preprint__repository=self.request.repository,
-            preprint_version__preprint__date_published__lte=timezone.now(),
             enabled=True,
         )
         if preprint_id:
@@ -513,7 +512,6 @@ class Identifiers(viewsets.ModelViewSet):
     def _get_journal_identifiers(self, article_id):
         queryset = identifier_models.Identifier.objects.filter(
             article__journal=self.request.journal,
-            article__date_published__lte=timezone.now(),
             enabled=True,
         )
         if article_id:


### PR DESCRIPTION
@ajrbyers 👋 

I haven't been able to get my local environment up and running, so I'm not sure how helpful this is 😅

I think that this should open up the API endpoint to return all identifiers, regardless of whether a submission has been published or not. I didn't update any tests, so I might need some help there.