### PR TITLE
feat: Allow devs to force builtin XSL render #4899

### DIFF
--- a/src/core/dev_settings.py
+++ b/src/core/dev_settings.py
@@ -3,6 +3,7 @@
 import os
 
 DEBUG = True
+FORCE_BUILTIN_XSL = False
 SECRET_KEY = "uxprsdhk^gzd-r=_287byolxn)$k6tsd8_cepl^s^tms2w1qrv"
 
 # This is the default redirect if no other sites are found.

--- a/src/core/files.py
+++ b/src/core/files.py
@@ -372,7 +372,7 @@ def render_xml(file_to_render, article, xsl_path=None, recover=False):
 
     if not os.path.isfile(xsl_path):
         logger.error("The required XSLT file {} was not found".format(xsl_path))
-        xsl_path = os.path.join(settings.BASE_DIR, "transform/xsl/default.xsl")
+        xsl_path = settings.BUILTIN_XSL_PATH
         logger.debug("Rendering engine using {}".format(xsl_path))
 
     return transform_with_xsl(path, xsl_path, recover=recover)

--- a/src/core/janeway_global_settings.py
+++ b/src/core/janeway_global_settings.py
@@ -519,6 +519,12 @@ HTTP_TIMEOUT_SECONDS = 5
 # are first uploaded
 DEFAULT_XSL_FILE_LABEL = "Janeway default (1.6.0)"
 
+# When this setting is enabled, Janeway will ignore the preserved XSLT
+# associated with a galley and will instead rely on src/xsl/default.xsl
+# useful for XSLT development
+FORCE_BUILTIN_XSL = False
+BUILTIN_XSL_PATH = os.path.join(BASE_DIR, "transform/xsl/default.xsl")
+
 # Skip migrations by default on sqlite for faster execution
 if IN_TEST_RUNNER and "--keepdb" not in COMMAND:
     from collections.abc import Mapping

--- a/src/core/models.py
+++ b/src/core/models.py
@@ -1652,10 +1652,13 @@ class Galley(AbstractLastModifiedModel):
         )
 
     def render(self, recover=False):
+        xsl_path = self.xsl_file.file.path
+        if settings.FORCE_BUILTIN_XSL:
+            xsl_path = settings.BUILTIN_XSL_PATH
         return files.render_xml(
             self.file,
             self.article,
-            xsl_path=self.xsl_file.file.path,
+            xsl_path=xsl_path,
             recover=recover,
         )
 


### PR DESCRIPTION
Adds a new setting (`FORCE_BUILTIN_XSL`) that allows developers to ingore the XSLT file system and always render XML to HTML galleys off the builtin XSL provided by Janeway.