### PR TITLE
Fix undefined names in Python code

### DIFF
--- a/src/core/tests/test_validators.py
+++ b/src/core/tests/test_validators.py
@@ -50,7 +50,7 @@ class TestValidators(TestCase):
         try:
             validators.validate_email_setting(test_value)
         except ValidationError as e:
-            error = error
+            error = e
         else:
             error = None
         self.assertIsNone(error)

--- a/src/identifiers/logic.py
+++ b/src/identifiers/logic.py
@@ -31,6 +31,8 @@ from submission import models as submission_models
 
 logger = get_logger(__name__)
 
+CROSSREF_LIVE_URL = "https://doi.crossref.org/servlet/deposit"
+CROSSREF_TEST_URL = "https://test.crossref.org/servlet/deposit"
 CROSSREF_TIMEOUT_SECONDS = 30
 
 

--- a/src/press/models.py
+++ b/src/press/models.py
@@ -7,6 +7,7 @@ __maintainer__ = "Birkbeck Centre for Technology and Publishing"
 import json
 import os
 import uuid
+from datetime import timezone
 
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType

--- a/src/submission/forms.py
+++ b/src/submission/forms.py
@@ -6,6 +6,7 @@ __maintainer__ = "Birkbeck Centre for Technology and Publishing"
 import re
 
 from django import forms
+from django.db.models import Q
 from django.utils.translation import gettext, gettext_lazy as _
 
 from submission import models

--- a/src/submission/logic.py
+++ b/src/submission/logic.py
@@ -10,6 +10,7 @@ from bs4 import BeautifulSoup
 from django.db.models import Q
 from django.shortcuts import get_object_or_404
 from django.contrib import messages
+from django.core.exceptions import ValidationError
 from django.utils.translation import get_language, gettext_lazy as _
 
 from core.forms import OrcidAffiliationForm

--- a/src/utils/forms.py
+++ b/src/utils/forms.py
@@ -11,7 +11,7 @@ from django.forms import (
 )
 from django.utils.translation import gettext_lazy as _
 from django.conf import settings
-from django.core.exceptions import ValidationError
+from django.core.exceptions import ImproperlyConfigured, ValidationError
 from django.utils.safestring import mark_safe
 
 from modeltranslation import forms as mt_forms, translator


### PR DESCRIPTION
## Why is this bad?
An undefined name is likely to raise `NameError` at runtime.

Before: % `ruff check --select=F821 --output-format=concise`
```
src/core/tests/test_validators.py:53:21: F821 Undefined name `error`
src/identifiers/logic.py:717:19: F821 Undefined name `CROSSREF_TEST_URL`
src/identifiers/logic.py:719:19: F821 Undefined name `CROSSREF_LIVE_URL`
src/metrics/views.py:1119:17: F821 Undefined name `report_months`
src/metrics/views.py:1142:17: F821 Undefined name `report_months`
src/metrics/views.py:1159:21: F821 Undefined name `report_months`
src/metrics/views.py:1176:21: F821 Undefined name `report_months`
src/press/models.py:457:33: F821 Undefined name `timezone`
src/submission/forms.py:554:21: F821 Undefined name `Q`
src/submission/forms.py:556:26: F821 Undefined name `Q`
src/submission/logic.py:336:15: F821 Undefined name `ValidationError`
src/submission/logic.py:574:15: F821 Undefined name `ValidationError`
src/submission/logic.py:605:15: F821 Undefined name `ValidationError`
src/utils/forms.py:194:19: F821 Undefined name `ImproperlyConfigured`
Found 14 errors.
```
---
After: % `ruff check --select=F821 --output-format=concise ` # I do not see the proper fix...
```
src/metrics/views.py:1119:17: F821 Undefined name `report_months`
src/metrics/views.py:1142:17: F821 Undefined name `report_months`
src/metrics/views.py:1159:21: F821 Undefined name `report_months`
src/metrics/views.py:1176:21: F821 Undefined name `report_months`
Found 4 errors.
```

Normally, we would add [`report_months`](https://github.com/search?q=repo%3Aopenlibhums%2Fjaneway+report_months) to the [`j5_tsv()`](https://github.com/search?q=repo%3Aopenlibhums%2Fjaneway+j5_tsv) function signature but that function is never called.

Should `j5_tsv()` be removed as dead code?

---
% `ruff rule F821 ` # https://docs.astral.sh/ruff/rules/undefined-name
# undefined-name (F821)

Derived from the **Pyflakes** linter.

## What it does
Checks for uses of undefined names.

## Why is this bad?
An undefined name is likely to raise `NameError` at runtime.

## Example
```python
def double():
    return n * 2  # raises `NameError` if `n` is undefined when `double` is called
```

Use instead:
```python
def double(n):
    return n * 2
```

## Options
- [`target-version`]: Can be used to configure which symbols Ruff will understand
  as being available in the `builtins` namespace.

## References
- [Python documentation: Naming and binding](https://docs.python.org/3/reference/executionmodel.html#naming-and-binding)
