### PR TITLE
Fix a bug that kept coauthors from seeing submitted article status

### DIFF
--- a/src/core/views.py
+++ b/src/core/views.py
@@ -857,7 +857,8 @@ def dashboard(request):
         "is_reviewer": request.user.is_reviewer(request),
         "section_editor_articles": section_editor_articles,
         "active_submission_count": submission_models.Article.objects.filter(
-            owner=request.user, journal=request.journal
+            frozenauthor__author=request.user,
+            journal=request.journal,
         )
         .exclude(stage=submission_models.STAGE_UNSUBMITTED)
         .count(),
@@ -936,7 +937,8 @@ def dashboard(request):
             typesetter=request.user,
         ).count(),
         "active_submissions": submission_models.Article.objects.filter(
-            owner=request.user, journal=request.journal
+            frozenauthor__author=request.user,
+            journal=request.journal,
         )
         .exclude(
             stage__in=[


### PR DESCRIPTION
Fixes #4971.

This turned out to be a simple mistake in implementing the author submission logic in 1.8. Authors can now see the same thing they could before: articles that have been submitted for which they are a co-author.

Note that co-authors *cannot* see unsubmitted articles, and could not before 1.8 either.