### PR TITLE
Superusers can now update revision request objects in admin without having to add an action item

### DIFF
--- a/src/review/migrations/0025_alter_revisionrequest_actions.py
+++ b/src/review/migrations/0025_alter_revisionrequest_actions.py
@@ -4,15 +4,14 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
-        ('review', '0024_remove_frozenreviewformelement_width_and_more'),
+        ("review", "0024_remove_frozenreviewformelement_width_and_more"),
     ]
 
     operations = [
         migrations.AlterField(
-            model_name='revisionrequest',
-            name='actions',
-            field=models.ManyToManyField(blank=True, to='review.revisionaction'),
+            model_name="revisionrequest",
+            name="actions",
+            field=models.ManyToManyField(blank=True, to="review.revisionaction"),
         ),
     ]

--- a/src/review/models.py
+++ b/src/review/models.py
@@ -629,7 +629,7 @@ class RevisionRequest(models.Model):
     )  # Note from Author to Editor
     actions = models.ManyToManyField(
         RevisionAction,
-        blank=True, 
+        blank=True,
     )  # List of actions Author took during Revision Request
     type = models.CharField(
         max_length=20,


### PR DESCRIPTION
Does what it says on the tin.