### PR TITLE
When suggested reviewers is enabled ensure only one reviewer is returned

### DIFF
--- a/src/review/logic.py
+++ b/src/review/logic.py
@@ -127,7 +127,7 @@ def get_reviewers(article, candidate_queryset, exclude_pks):
                 default=Value(False),
                 output_field=BooleanField(),
             )
-        )
+        ).distinct()
 
     return reviewers
 


### PR DESCRIPTION
Ensure distinct reviewers are returned from the query. Currently you get one per interest.