### PR TITLE
Fixes a bug that stopped the carousel rendering on Clarity

### DIFF
--- a/src/core/homepage_elements/carousel/models.py
+++ b/src/core/homepage_elements/carousel/models.py
@@ -121,10 +121,12 @@ class Carousel(models.Model):
             else:
                 issues = chain(self.issues.all(), issues)
 
-        return sorted(
-            chain(articles, news, issues),
-            key=attrgetter("date_published"),
-            reverse=True,
+        return list(
+            sorted(
+                chain(articles, news, issues),
+                key=attrgetter("date_published"),
+                reverse=True,
+            )
         )
 
 


### PR DESCRIPTION
Converts chain() iterator to list to allow multiple iterations over the combined queryset results.