### PR TITLE
Use ruff v14 on Janeway 1.8

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -7,4 +7,4 @@ freezegun
 snakeviz
 django-browser-reload
 tox
-ruff
+ruff==0.14.14


### PR DESCRIPTION
We need to use ruff version 14 for Janeway 1.8. We will separately tag version 15 for Janeway 1.9+.