### PR TITLE
Fixes an issue where some PII was available to editors in triple anon mode

### DIFF
--- a/src/templates/admin/copyediting/add_copyeditor_assignment.html
+++ b/src/templates/admin/copyediting/add_copyeditor_assignment.html
@@ -4,7 +4,7 @@
 
 {% block title %}Add Copyeditor{% endblock %}
 {% block title-section %}Add Copyeditor{% endblock %}
-{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.safe_title }}{% endblock %}
+{% block title-sub %}{% include "admin/elements/article_title_sub.html" %}{% endblock %}
 
 {% block breadcrumbs %}
     {{ block.super }}

--- a/src/templates/admin/copyediting/article_copyediting.html
+++ b/src/templates/admin/copyediting/article_copyediting.html
@@ -3,7 +3,7 @@
 
 {% block title %}Copyediting {{ article.title }}{% endblock %}
 {% block title-section %}Copyediting{% endblock %}
-{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.safe_title }}{% endblock %}
+{% block title-sub %}{% include "admin/elements/article_title_sub.html" %}{% endblock %}
 
 {% block breadcrumbs %}
     {{ block.super }}

--- a/src/templates/admin/copyediting/delete_author_review.html
+++ b/src/templates/admin/copyediting/delete_author_review.html
@@ -5,7 +5,7 @@
 {% block title-section %}
     Delete Author Copyedit Request #{{ author_review.id }}
 {% endblock %}
-{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.safe_title }}{% endblock %}
+{% block title-sub %}{% include "admin/elements/article_title_sub.html" %}{% endblock %}
 
 {% block breadcrumbs %}
     {{ block.super }}

--- a/src/templates/admin/copyediting/edit_assignment.html
+++ b/src/templates/admin/copyediting/edit_assignment.html
@@ -3,7 +3,7 @@
 
 {% block title %}Edit Assignment{% endblock %}
 {% block title-section %}Edit Assignment{% endblock %}
-{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.safe_title }}{% endblock %}
+{% block title-sub %}{% include "admin/elements/article_title_sub.html" %}{% endblock %}
 
 {% block breadcrumbs %}
     {{ block.super }}

--- a/src/templates/admin/copyediting/editor_review.html
+++ b/src/templates/admin/copyediting/editor_review.html
@@ -4,7 +4,7 @@
 {% block title %}Editor Review Copyedit{% endblock %}
 {% block title-section %}Review Copyedit Assignment #{{ copyedit.id }} by
     {{ copyedit.copyeditor.full_name }}{% endblock %}
-{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.safe_title }}{% endblock %}
+{% block title-sub %}{% include "admin/elements/article_title_sub.html" %}{% endblock %}
 
 {% block breadcrumbs %}
     {{ block.super }}

--- a/src/templates/admin/copyediting/notify_copyeditor_assignment.html
+++ b/src/templates/admin/copyediting/notify_copyeditor_assignment.html
@@ -5,7 +5,7 @@
 
 {% block css %}<link href="{% static "common/css/jquery-te-1.4.0.css" %}" rel="stylesheet">{% endblock %}
 {% block title %}Editor Assignment Notification{% endblock %}
-{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.safe_title }}{% endblock %}
+{% block title-sub %}{% include "admin/elements/article_title_sub.html" %}{% endblock %}
 
 {% block body %}
 

--- a/src/templates/admin/copyediting/request_author_copyedit.html
+++ b/src/templates/admin/copyediting/request_author_copyedit.html
@@ -5,7 +5,7 @@
 {% block title-section %}
     Request Author Copyedit #{{ author_review.id }}
 {% endblock %}
-{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.safe_title }}{% endblock %}
+{% block title-sub %}{% include "admin/elements/article_title_sub.html" %}{% endblock %}
 
 {% block breadcrumbs %}
     {{ block.super }}

--- a/src/templates/admin/elements/article_title_sub.html
+++ b/src/templates/admin/elements/article_title_sub.html
@@ -1,0 +1,1 @@
+#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.safe_title }}

--- a/src/templates/admin/elements/article_title_sub_pii.html
+++ b/src/templates/admin/elements/article_title_sub_pii.html
@@ -1,0 +1,1 @@
+{% load securitytags %}#{{ article.pk }} / {{ article.correspondence_author.last_name|se_can_see_pii:article }} / {{ article.safe_title }}

--- a/src/templates/admin/journal/document_management.html
+++ b/src/templates/admin/journal/document_management.html
@@ -6,7 +6,7 @@
 
 {% block title %}Article Document Management{% endblock title %}
 {% block title-section %}Article Document Management{% endblock %}
-{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.safe_title }}{% endblock %}
+{% block title-sub %}{% include "admin/elements/article_title_sub.html" %}{% endblock %}
 
 {% block body %}
     {% csrf_token %}

--- a/src/templates/admin/journal/publish_article.html
+++ b/src/templates/admin/journal/publish_article.html
@@ -10,7 +10,7 @@
 {% endblock css %}
 {% block title %}Pre Publication - {{ article.pk }}{% endblock title %}
 {% block title-section %}Pre Publication Checklist{% endblock %}
-{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.safe_title }}{% endblock %}
+{% block title-sub %}{% include "admin/elements/article_title_sub.html" %}{% endblock %}
 
 {% block breadcrumbs %}
 {{ block.super }}

--- a/src/templates/admin/production/assigned_article.html
+++ b/src/templates/admin/production/assigned_article.html
@@ -8,7 +8,7 @@
 
 {% block title %}Article Production{% endblock title %}
 {% block admin-header %}}Article Production{% endblock %}
-{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.safe_title }}{% endblock %}
+{% block title-sub %}{% include "admin/elements/article_title_sub.html" %}{% endblock %}
 
 {% block breadcrumbs %}
     {{ block.super }}

--- a/src/templates/admin/production/edit_galley.html
+++ b/src/templates/admin/production/edit_galley.html
@@ -5,7 +5,7 @@
 
 {% block title %}Edit Galley - {{ galley.pk }}{% endblock title %}
 {% block title-section %}Edit Galley - {{ galley.pk }}{% endblock %}
-{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.safe_title }}{% endblock %}
+{% block title-sub %}{% include "admin/elements/article_title_sub.html" %}{% endblock %}
 
 {% block breadcrumbs %}
     {{ block.super }}

--- a/src/templates/admin/production/edit_typesetter_assignment.html
+++ b/src/templates/admin/production/edit_typesetter_assignment.html
@@ -5,7 +5,7 @@
     {{ typeset.typesetter.full_name }}{% endblock %}
 {% block title-section %}#{{ typeset.pk }} -
     {{ typeset.typesetter.full_name }}{% endblock %}
-{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.safe_title }}{% endblock %}
+{% block title-sub %}{% include "admin/elements/article_title_sub.html" %}{% endblock %}
 
 {% block breadcrumbs %}
     {{ block.super }}

--- a/src/templates/admin/production/non_workflow_assign.html
+++ b/src/templates/admin/production/non_workflow_assign.html
@@ -6,7 +6,7 @@
 
 {% block title %}Article - {{ article.pk }}{% endblock title %}
 {% block admin-header %}Article - {{ article.pk }}{% endblock %}
-{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.safe_title }}{% endblock %}
+{% block title-sub %}{% include "admin/elements/article_title_sub.html" %}{% endblock %}
 
 {% block breadcrumbs %}
     {{ block.super }}

--- a/src/templates/admin/production/notify_typesetter.html
+++ b/src/templates/admin/production/notify_typesetter.html
@@ -3,7 +3,7 @@
 
 {% block title %}Notify Typesetter{% endblock title %}
 {% block title-section %}Notify Typesetter{% endblock %}}
-{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.safe_title }}{% endblock %}
+{% block title-sub %}{% include "admin/elements/article_title_sub.html" %}{% endblock %}
 
 {% block breadcrumbs %}
 {{ block.super }}

--- a/src/templates/admin/production/typeset_task.html
+++ b/src/templates/admin/production/typeset_task.html
@@ -6,7 +6,7 @@
 
 {% block title %}Typeset Task - {{ typeset_task.pk }}{% endblock title %}
 {% block title-section %}Typeset Task - {{ typeset_task.pk }}{% endblock %}
-{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.safe_title }}{% endblock %}
+{% block title-sub %}{% include "admin/elements/article_title_sub.html" %}{% endblock %}
 
 {% block breadcrumbs %}
     {{ block.super }}

--- a/src/templates/admin/proofing/acknowledge.html
+++ b/src/templates/admin/proofing/acknowledge.html
@@ -3,7 +3,7 @@
 
 {% block css %}<link href="{% static "common/css/jquery-te-1.4.0.css" %}" rel="stylesheet">{% endblock %}
 {% block title %}Acknowledge Task{% endblock title %}
-{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.safe_title }}{% endblock %}
+{% block title-sub %}{% include "admin/elements/article_title_sub.html" %}{% endblock %}
 
 {% block breadcrumbs %}
 {{ block.super }}  

--- a/src/templates/admin/proofing/complete_proofing.html
+++ b/src/templates/admin/proofing/complete_proofing.html
@@ -5,7 +5,7 @@
     <link href="{% static "common/css/jquery-te-1.4.0.css" %}" rel="stylesheet">{% endblock %}
 {% block title %}Complete Proofing{% endblock title %}
 {% block title-section %}Complete Proofing{% endblock %}
-{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.safe_title }}{% endblock %}
+{% block title-sub %}{% include "admin/elements/article_title_sub.html" %}{% endblock %}
 
 {% block breadcrumbs %}
     {{ block.super }}

--- a/src/templates/admin/proofing/delete_proofing_round.html
+++ b/src/templates/admin/proofing/delete_proofing_round.html
@@ -5,7 +5,7 @@
 
 {% block title %}Deleting Proofing Round #{{ round.number }}{% endblock %}
 {% block title-section %}Deleting Proofing Round #{{ round.number }}{% endblock %}
-{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.safe_title }}{% endblock %}
+{% block title-sub %}{% include "admin/elements/article_title_sub.html" %}{% endblock %}
 
 {% block breadcrumbs %}
     {{ block.super }}

--- a/src/templates/admin/proofing/edit_proofing_assignment.html
+++ b/src/templates/admin/proofing/edit_proofing_assignment.html
@@ -5,7 +5,7 @@
 
 {% block title %}#{{ proofing_task.pk }} - {{ proofing_task.proofreader.full_name }}{% endblock %}
 {% block title-section %}#{{ proofing_task.pk }} - {{ proofing_task.proofreader.full_name }}{% endblock %}
-{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.safe_title }}{% endblock %}
+{% block title-sub %}{% include "admin/elements/article_title_sub.html" %}{% endblock %}
 
 {% block breadcrumbs %}
     {{ block.super }}

--- a/src/templates/admin/proofing/notify_proofreader.html
+++ b/src/templates/admin/proofing/notify_proofreader.html
@@ -4,7 +4,7 @@
 {% block css %}<link href="{% static "common/css/jquery-te-1.4.0.css" %}" rel="stylesheet">{% endblock %}
 {% block title %}Notify Proofreader{% endblock title %}
 {% block title-section %}Notify Proofreader{% endblock %}
-{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.safe_title }}{% endblock %}
+{% block title-sub %}{% include "admin/elements/article_title_sub.html" %}{% endblock %}
 
 {% block breadcrumbs %}
 {{ block.super }}

--- a/src/templates/admin/proofing/notify_typesetter_changes.html
+++ b/src/templates/admin/proofing/notify_typesetter_changes.html
@@ -4,7 +4,7 @@
 {% block css %}<link href="{% static "common/css/jquery-te-1.4.0.css" %}" rel="stylesheet">{% endblock %}
 {% block title %}Notify Typesetter{% endblock title %}
 {% block admin-header %}Notify Typesetter{% endblock %}
-{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.safe_title }}{% endblock %}
+{% block title-sub %}{% include "admin/elements/article_title_sub.html" %}{% endblock %}
 
 {% block breadcrumbs %} 
     {{ block.super }}

--- a/src/templates/admin/proofing/proofing_article.html
+++ b/src/templates/admin/proofing/proofing_article.html
@@ -9,7 +9,7 @@
 
 {% block title %}Proofing - {{ article.pk }}{% endblock title %}
 {% block title-section %}Proofing{% endblock %}
-{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.safe_title }}{% endblock %}
+{% block title-sub %}{% include "admin/elements/article_title_sub.html" %}{% endblock %}
 
 {% block breadcrumbs %}
     {{ block.super }}

--- a/src/templates/admin/proofing/request_typesetting_changes.html
+++ b/src/templates/admin/proofing/request_typesetting_changes.html
@@ -8,7 +8,7 @@
 
 {% block title %}Request Corrections{% endblock title %}
 {% block title-section %}Request Corrections{% endblock %}
-{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.safe_title }}{% endblock %}
+{% block title-sub %}{% include "admin/elements/article_title_sub.html" %}{% endblock %}
 
 {% block breadcrumbs %}
     {{ block.super }}

--- a/src/templates/admin/proofing/typesetting/typesetting_corrections.html
+++ b/src/templates/admin/proofing/typesetting/typesetting_corrections.html
@@ -6,7 +6,7 @@
 
 {% block title %}Proofing Corrections{% endblock title %}
 {% block title-section %}Proofing Corrections{% endblock %}
-{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.safe_title }}{% endblock %}
+{% block title-sub %}{% include "admin/elements/article_title_sub.html" %}{% endblock %}
 
 {% block breadcrumbs %}
     {{ block.super }}

--- a/src/templates/admin/review/add_files.html
+++ b/src/templates/admin/review/add_files.html
@@ -3,7 +3,7 @@
 
 {% block title %}Add Review Files{% endblock title %}
 {% block title-section %}Add Files{% endblock %}
-{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.safe_title }}{% endblock %}
+{% block title-sub %}{% include "admin/elements/article_title_sub_pii.html" %}{% endblock %}
 
 {% block breadcrumbs %}
     {{ block.super }}

--- a/src/templates/admin/review/add_review_assignment.html
+++ b/src/templates/admin/review/add_review_assignment.html
@@ -2,7 +2,7 @@
 {% load foundation %}
 {% block title %}Add Review Assignment{% endblock title %}
 {% block title-section %}Add Review Assignment{% endblock %}
-{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.safe_title }}{% endblock %}
+{% block title-sub %}{% include "admin/elements/article_title_sub_pii.html" %}{% endblock %}
 
 {% block breadcrumbs %}
     {{ block.super }}

--- a/src/templates/admin/review/assignment_notification.html
+++ b/src/templates/admin/review/assignment_notification.html
@@ -3,7 +3,7 @@
 {% load settings %}
 
 {% block css %}<link href="{% static "common/css/jquery-te-1.4.0.css" %}" rel="stylesheet">{% endblock %}
-{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.safe_title }}{% endblock %}
+{% block title-sub %}{% include "admin/elements/article_title_sub_pii.html" %}{% endblock %}
 
 {% block body %}
 

--- a/src/templates/admin/review/decision.html
+++ b/src/templates/admin/review/decision.html
@@ -3,7 +3,7 @@
 
 {% block title %}{{ decision|capfirst }} Article{% endblock title %}
 {% block title-section %}{{ decision|capfirst }} Article{% endblock %}
-{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name|se_can_see_pii:article }} / {{ article.safe_title }}{% endblock %}
+{% block title-sub %}{% include "admin/elements/article_title_sub_pii.html" %}{% endblock %}
 
 {% block breadcrumbs %}
     {{ block.super }}

--- a/src/templates/admin/review/decision_helper.html
+++ b/src/templates/admin/review/decision_helper.html
@@ -5,7 +5,7 @@
 
 {% block title %}#{{ article.pk }} Decision Helper{% endblock title %}
 {% block title-section %}#{{ article.pk }} Decision Helper{% endblock %}
-{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name|se_can_see_pii:article }} / {{ article.safe_title }}{% endblock %}
+{% block title-sub %}{% include "admin/elements/article_title_sub_pii.html" %}{% endblock %}
 
 {% block breadcrumbs %}
     {{ block.super }}

--- a/src/templates/admin/review/delete_review.html
+++ b/src/templates/admin/review/delete_review.html
@@ -2,7 +2,7 @@
 
 {% block title %}Delete Review{% endblock title %}
 {% block title-section %}Delete Review{% endblock %}
-{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.safe_title }}{% endblock %}
+{% block title-sub %}{% include "admin/elements/article_title_sub_pii.html" %}{% endblock %}
 
 {% block breadcrumbs %}
 {{ block.super }}

--- a/src/templates/admin/review/draft_decision.html
+++ b/src/templates/admin/review/draft_decision.html
@@ -5,7 +5,7 @@
 
 {% block title %}Draft Decision{% endblock title %}
 {% block admin-header %}Draft Decision{% endblock %}
-{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.safe_title }}{% endblock %}
+{% block title-sub %}{% include "admin/elements/article_title_sub_pii.html" %}{% endblock %}
 
 {% block breadcrumbs %}
     {{ block.super }}

--- a/src/templates/admin/review/edit_review.html
+++ b/src/templates/admin/review/edit_review.html
@@ -3,7 +3,7 @@
 
 {% block title %}Edit Review{% endblock title %}
 {% block title-section %}Edit Review{% endblock %}
-{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.safe_title }}{% endblock %}
+{% block title-sub %}{% include "admin/elements/article_title_sub_pii.html" %}{% endblock %}
 
 {% block breadcrumbs %}
     {{ block.super }}

--- a/src/templates/admin/review/edit_review_answer.html
+++ b/src/templates/admin/review/edit_review_answer.html
@@ -2,7 +2,7 @@
 
 {% block title %}Edit Review Answer{% endblock title %}
 {% block admin-header %}Edit Review Answer{% endblock %}
-{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.safe_title }}{% endblock %}
+{% block title-sub %}{% include "admin/elements/article_title_sub_pii.html" %}{% endblock %}
 
 {% block breadcrumbs %}
     {{ block.super }}

--- a/src/templates/admin/review/in_review.html
+++ b/src/templates/admin/review/in_review.html
@@ -4,7 +4,7 @@
 
 {% block title %}Review {{ article.title }}{% endblock %}
 {% block title-section %}Peer Review{% endblock %}
-{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name|se_can_see_pii:article }} / {{ article.safe_title }}{% endblock %}
+{% block title-sub %}{% include "admin/elements/article_title_sub_pii.html" %}{% endblock %}
 
 {% block breadcrumbs %}
     {{ block.super }}

--- a/src/templates/admin/review/notify_reviewer.html
+++ b/src/templates/admin/review/notify_reviewer.html
@@ -5,7 +5,7 @@
 
 {% block title %}Add Review Assignment{% endblock title %}
 {% block title-section %}Add Review Assignment{% endblock %}
-{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.safe_title }}{% endblock %}
+{% block title-sub %}{% include "admin/elements/article_title_sub_pii.html" %}{% endblock %}
 
 {% block css %}
     <link href="{% static "common/css/jquery-te-1.4.0.css" %}" rel="stylesheet">

--- a/src/templates/admin/review/projected_issue.html
+++ b/src/templates/admin/review/projected_issue.html
@@ -5,7 +5,7 @@
 
 {% block title %}Projected Issue {{ article.title }}{% endblock %}
 {% block title-section %}Projected Issue{% endblock %}
-{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.safe_title }}{% endblock %}
+{% block title-sub %}{% include "admin/elements/article_title_sub_pii.html" %}{% endblock %}
 
 {% block breadcrumbs %}
     {{ block.super }}

--- a/src/templates/admin/review/rate_reviewer.html
+++ b/src/templates/admin/review/rate_reviewer.html
@@ -2,7 +2,7 @@
 
 {% block title %}Rate Reviewer{% endblock title %}
 {% block title-section %}Rate Review{% endblock %}
-{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.safe_title }}{% endblock %}
+{% block title-sub %}{% include "admin/elements/article_title_sub_pii.html" %}{% endblock %}
 
 {% block breadcrumbs %}
     {{ block.super }}

--- a/src/templates/admin/review/reset.html
+++ b/src/templates/admin/review/reset.html
@@ -3,7 +3,7 @@
 
 {% block title %}Reset Review{% endblock title %}
 {% block title-section %}Reset Review{% endblock %}
-{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.safe_title }}{% endblock %}
+{% block title-sub %}{% include "admin/elements/article_title_sub_pii.html" %}{% endblock %}
 
 {% block breadcrumbs %}
 {{ block.super }}

--- a/src/templates/admin/review/review_warning.html
+++ b/src/templates/admin/review/review_warning.html
@@ -2,7 +2,7 @@
 
 {% block title %}Permission Denied{% endblock title %}
 {% block admin-header %}Permission Denied{% endblock %}
-{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.safe_title }}{% endblock %}
+{% block title-sub %}{% include "admin/elements/article_title_sub_pii.html" %}{% endblock %}
 
 {% block breadcrumbs %}
     {{ block.super }}

--- a/src/templates/admin/review/revision/edit_revision_request.html
+++ b/src/templates/admin/review/revision/edit_revision_request.html
@@ -3,7 +3,7 @@
 
 {% block title %}Edit Revision{% endblock title %}
 {% block title-section %}Edit Revision{% endblock %}
-{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.safe_title }}{% endblock %}
+{% block title-sub %}{% include "admin/elements/article_title_sub_pii.html" %}{% endblock %}
 
 {% block breadcrumbs %}
     {{ block.super }}

--- a/src/templates/admin/review/revision/request_revisions.html
+++ b/src/templates/admin/review/revision/request_revisions.html
@@ -3,7 +3,7 @@
 
 {% block title %}Request Revisions{% endblock title %}
 {% block title-section %}Request Revisions{% endblock %}
-{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name|se_can_see_pii:article }} / {{ article.safe_title }}{% endblock %}
+{% block title-sub %}{% include "admin/elements/article_title_sub_pii.html" %}{% endblock %}
 
 {% block breadcrumbs %}
     {{ block.super }}

--- a/src/templates/admin/review/revision/request_revisions_notification.html
+++ b/src/templates/admin/review/revision/request_revisions_notification.html
@@ -4,7 +4,7 @@
 
 {% block title %}Request Revisions{% endblock title %}
 {% block title-section %}Request Revisions{% endblock %}
-{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name|se_can_see_pii:article }} / {{ article.safe_title }}{% endblock %}
+{% block title-sub %}{% include "admin/elements/article_title_sub_pii.html" %}{% endblock %}
 
 {% block breadcrumbs %}
 {{ block.super }}

--- a/src/templates/admin/review/revision/view_revision.html
+++ b/src/templates/admin/review/revision/view_revision.html
@@ -4,7 +4,7 @@
 
 {% block title %}Revision Request{% endblock title %}
 {% block admin-header %}Revision Request{% endblock %}
-{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.safe_title }}{% endblock %}
+{% block title-sub %}{% include "admin/elements/article_title_sub_pii.html" %}{% endblock %}
 
 {% block breadcrumbs %}
     {{ block.super }}

--- a/src/templates/admin/review/send_review_reminder.html
+++ b/src/templates/admin/review/send_review_reminder.html
@@ -3,7 +3,7 @@
 
 {% block title %}Review Reminders{% endblock title %}
 {% block title-section %}Review Reminders{% endblock %}
-{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.safe_title }}{% endblock %}
+{% block title-sub %}{% include "admin/elements/article_title_sub_pii.html" %}{% endblock %}
 
 {% block breadcrumbs %}
     {{ block.super }}

--- a/src/templates/admin/review/unassign_editor.html
+++ b/src/templates/admin/review/unassign_editor.html
@@ -3,7 +3,7 @@
 
 {% block title %}Unassign Editor Request{% endblock title %}
 {% block title-section %}Unassign Editor Request{% endblock %}
-{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.safe_title }}{% endblock %}
+{% block title-sub %}{% include "admin/elements/article_title_sub_pii.html" %}{% endblock %}
 
 {% block breadcrumbs %}
     {{ block.super }}

--- a/src/templates/admin/review/unassigned_article.html
+++ b/src/templates/admin/review/unassigned_article.html
@@ -3,7 +3,7 @@
 
 {% block title %}Unassigned {{ article.title }}{% endblock %}
 {% block title-section %}Unassigned{% endblock %}
-{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name|se_can_see_pii:article }} / {{ article.safe_title }}{% endblock %}
+{% block title-sub %}{% include "admin/elements/article_title_sub_pii.html" %}{% endblock %}
 
 {% block breadcrumbs %}
     {{ block.super }}

--- a/src/templates/admin/review/view_review.html
+++ b/src/templates/admin/review/view_review.html
@@ -5,8 +5,7 @@
 
 {% block title %}View Review{% endblock title %}
 {% block title-section %}View Review{% endblock %}
-{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name|se_can_see_pii:article }} /
-    {{ article.safe_title }}{% endblock %}
+{% block title-sub %}{% include "admin/elements/article_title_sub_pii.html" %}{% endblock %}
 
 {% block breadcrumbs %}
     {{ block.super }}

--- a/src/templates/admin/review/withdraw_review.html
+++ b/src/templates/admin/review/withdraw_review.html
@@ -3,7 +3,7 @@
 
 {% block title %}Withdraw Review Request{% endblock title %}
 {% block title-section %}Withdraw Review Request{% endblock %}
-{% block title-sub %}#{{ article.pk }} / {{ article.correspondence_author.last_name }} / {{ article.safe_title }}{% endblock %}
+{% block title-sub %}{% include "admin/elements/article_title_sub_pii.html" %}{% endblock %}
 
 {% block breadcrumbs %}
     {{ block.super }}


### PR DESCRIPTION
Pulls the repeated article title sub header out into a reusable include template. Review templates get a version that applies the se_can_see_pii filter, everything else gets the plain one.

Closes #5207 