### PR TITLE
Fixed a bug where discord notifications would fail to send

### DIFF
--- a/src/utils/notify_plugins/notify_webhook.py
+++ b/src/utils/notify_plugins/notify_webhook.py
@@ -1,11 +1,24 @@
 import requests
 import threading
 
+from utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+def _post_and_check(url, data, headers):
+    try:
+        response = requests.post(url, data=data, headers=headers)
+        response.raise_for_status()
+    except requests.RequestException as error:
+        logger.error("Webhook POST to %s failed: %s", url, error)
+
 
 def send_message(hook_url, message, headers=None):
-    # this sends a non-blocking post to a web URL
+    # Fire and forget call to avoid blocking
+    # TODO: use a queue and worker
     hook_thread = threading.Thread(
-        target=requests.post, args=(hook_url, message, headers), kwargs={}
+        target=_post_and_check, args=(hook_url, message, headers or {})
     )
     hook_thread.start()
 


### PR DESCRIPTION
The fix is to map arguments as kwargs explicitly, we were passing the `headers` argument as `json` payload to the `requets.post` call.

I've also added a check for response errors. The call is still fire-and-forget since we fire the thread and return immediately, but the scheduler should give us a chance to check the status response before the thread exits (best we can do until we implement a queue+worker for Janeway)