### PR TITLE
Use journal replyto_address in submission acknowledgement emails

### DIFF
--- a/src/utils/tests.py
+++ b/src/utils/tests.py
@@ -45,6 +45,7 @@ from utils.forms import (
 )
 from utils.logic import generate_sitemap
 from utils.testing import helpers
+from utils.testing.context_managers import janeway_setting_override
 from utils.shared import clear_cache
 from utils.notify_plugins import notify_email
 
@@ -467,6 +468,28 @@ class TransactionalReviewEmailTests(UtilsTests):
         subject_setting = self.get_default_email_subject(subject_setting_name)
         expected_subject = "[{0}] {1}".format(self.journal_one.code, subject_setting)
         self.assertEqual(expected_subject, mail.outbox[1].subject)
+
+    def test_send_submission_acknowledgement_uses_journal_replyto(self):
+        kwargs = dict(**self.base_kwargs)
+        kwargs["article"] = self.submitted_article
+
+        with janeway_setting_override(
+            "general", "replyto_address", self.journal_one, "replyto@example.com"
+        ):
+            send_submission_acknowledgement(**kwargs)
+
+        self.assertEqual(mail.outbox[1].reply_to, ["replyto@example.com"])
+
+    def test_send_submission_acknowledgement_falls_back_to_noreply(self):
+        kwargs = dict(**self.base_kwargs)
+        kwargs["article"] = self.submitted_article
+
+        with janeway_setting_override(
+            "general", "replyto_address", self.journal_one, ""
+        ):
+            send_submission_acknowledgement(**kwargs)
+
+        self.assertIn(settings.DUMMY_EMAIL_DOMAIN, mail.outbox[1].reply_to[0])
 
     def test_send_article_decision(self):
         kwargs = dict(**self.base_kwargs)

--- a/src/utils/transactional_emails.py
+++ b/src/utils/transactional_emails.py
@@ -499,6 +499,7 @@ def send_submission_acknowledgement(**kwargs):
 
     editor_emails |= {editor.email for editor in assigned_to_section}
 
+    replyto_address = request.journal.get_setting("general", "replyto_address")
     notify_helpers.send_email_with_body_from_setting_template(
         request,
         "editor_new_submission",
@@ -506,7 +507,9 @@ def send_submission_acknowledgement(**kwargs):
         editor_emails,
         context,
         log_dict=log_dict,
-        custom_reply_to=[f"noreply{settings.DUMMY_EMAIL_DOMAIN}"],
+        custom_reply_to=[replyto_address]
+        if replyto_address
+        else [f"noreply{settings.DUMMY_EMAIL_DOMAIN}"],
     )
 
 


### PR DESCRIPTION
- Closes #4339 
- Falls back to the `DUMMY_EMAIL_DOMAIN` setting where no replyto is set to ensure we never reveal the request.user email.