### PR TITLE
Auto-detect browser timezone for manager users on accept form

### DIFF
--- a/src/repository/tests/test_views.py
+++ b/src/repository/tests/test_views.py
@@ -306,6 +306,36 @@ class TestViews(TestCase):
         )
 
     @override_settings(URL_CONFIG="domain")
+    @freeze_time(FROZEN_DATETIME)
+    def test_accept_preprint_with_user_timezone(self):
+        # Regression for #3392: when a user's preferred_timezone is set,
+        # date_published should be correctly converted to UTC and not end up
+        # in the future relative to the server.
+        self.preprint_one.make_new_version(self.preprint_one.submission_file)
+        path = reverse(
+            "repository_manager_article",
+            kwargs={"preprint_id": self.preprint_one.pk},
+        )
+        self.client.force_login(self.repo_manager)
+        # User is in Asia/Karachi (UTC+5). FROZEN_DATETIME is 15:00 UTC,
+        # so their local time is 20:00. They submit their local time with
+        # their correct timezone — date_published should equal FROZEN_DATETIME.
+        self.client.post(
+            path,
+            data={
+                "accept": "",
+                "datetime": "2024-03-25T20:00",
+                "timezone": "Asia/Karachi",
+            },
+            SERVER_NAME=self.server_name,
+        )
+        preprint = rm.Preprint.objects.get(pk=self.preprint_one.pk)
+        self.assertEqual(
+            preprint.date_published.timestamp(),
+            FROZEN_DATETIME.timestamp(),
+        )
+
+    @override_settings(URL_CONFIG="domain")
     @freeze_time(FROZEN_DATETIME, tz_offset=5)
     def test_accept_preprint_bad_date(self):
         self.preprint_one.make_new_version(self.preprint_one.submission_file)

--- a/src/templates/admin/core/base.html
+++ b/src/templates/admin/core/base.html
@@ -120,6 +120,8 @@
 {% endblock toastr %}
 {% include "admin/core/partials/htmx_messages.html" %}
 {% include "admin/core/partials/htmx_spinner.html" %}
+<script src="{% static "common/js/timezone-setter.js" %}"></script>
+{% if not request.timezone %}<script>setTimezone();</script>{% endif %}
 
 {% block js %}{% endblock %}
 </body>

--- a/src/templates/admin/elements/repository/accept_preprint.html
+++ b/src/templates/admin/elements/repository/accept_preprint.html
@@ -25,6 +25,8 @@
                     <input type="datetime-local" name="datetime" id="datetime" required value="{% if preprint.date_published %}{{ preprint.date_published|date:'Y-m-d\TH:i' }}{% else %}{% now 'Y-m-d\TH:i' %}{% endif %}">
                     {% get_current_timezone as TIME_ZONE %}
                     <input type="hidden" id="timezone" name="timezone" value="{{ TIME_ZONE }}" />
+                    <p class="help-text">Your Janeway timezone is set to <strong>{{ TIME_ZONE }}</strong>.
+                    {% if not request.user.preferred_timezone %}You can set your preferred timezone in your <a href="{% url 'core_edit_profile' %}">profile</a>.{% endif %}</p>
                 </div>
                         <div class="large-12 columns">
                             <button type="submit" name="accept" class="small success button">Save</button>


### PR DESCRIPTION
Closes #3392 

Adds timezone set/detection on the manager interface and warns preprint managers what their timezone is when accepting/publishing a preprint.