### PR TITLE
bugfix: handle repeated submission review access gracefully

### DIFF
--- a/src/security/decorators.py
+++ b/src/security/decorators.py
@@ -1502,13 +1502,36 @@ def article_is_not_submitted(func):
     def _article_is_not_submitted(request, *args, **kwargs):
         article_id = kwargs.get("article_id")
         try:
-            article = models.Article.objects.get(
+            models.Article.objects.get(
                 pk=article_id,
                 journal=request.journal,
                 date_submitted__isnull=True,
             )
             return func(request, *args, **kwargs)
         except models.Article.DoesNotExist:
+            submitted_article = models.Article.objects.filter(
+                pk=article_id,
+                journal=request.journal,
+            ).first()
+
+            if submitted_article and (
+                request.user.is_staff
+                or (
+                    getattr(request.user, "pk", None)
+                    and request.user.pk == submitted_article.owner_id
+                )
+            ):
+                messages.info(
+                    request,
+                    "This article has already been submitted. Showing its status instead.",
+                )
+                return redirect(
+                    reverse(
+                        "core_dashboard_article",
+                        kwargs={"article_id": submitted_article.pk},
+                    )
+                )
+
             raise Http404("This article has already been submitted.")
 
     return _article_is_not_submitted

--- a/src/security/test_security.py
+++ b/src/security/test_security.py
@@ -4301,6 +4301,28 @@ class TestSecurity(TestCase):
         with self.assertRaises(Http404):
             decorated_func(request, **kwargs)
 
+    def test_article_is_not_submitted_complete_redirects_author(self):
+        func = Mock()
+        decorated_func = decorators.article_is_not_submitted(func)
+        kwargs = {"article_id": self.article_unassigned.pk}
+
+        request = self.prepare_request_with_user(
+            self.regular_user,
+            journal=self.journal_one,
+        )
+
+        response = decorated_func(request, **kwargs)
+
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(
+            response.url,
+            reverse(
+                "core_dashboard_article",
+                kwargs={"article_id": self.article_unassigned.pk},
+            ),
+        )
+        self.assertFalse(func.called)
+
     def test_article_is_not_submitted_unsubmitted(self):
         func = Mock()
         decorated_func = decorators.article_is_not_submitted(func)

--- a/src/templates/admin/core/article.html
+++ b/src/templates/admin/core/article.html
@@ -1,5 +1,5 @@
 {% extends "admin/core/base.html" %}
-{% load hooks %}
+{% load hooks i18n %}
 
 {% block title %}Article {{ article.pk }} Information{% endblock %}
 {% block breadcrumbs %}
@@ -18,6 +18,34 @@
             {% hook 'edit_article' %}
         {% endif %}
         <div class="content">
+            <table class="scroll">
+                <tr>
+                    <th>{% trans "Current Stage" %}</th>
+                    <td>{{ article.get_stage_display }}</td>
+                </tr>
+                <tr>
+                    <th>{% trans "Submitted" %}</th>
+                    <td>{{ article.date_submitted|default:_("Not yet submitted") }}</td>
+                </tr>
+                <tr>
+                    <th>{% trans "Section" %}</th>
+                    <td>{{ article.section.name|default:_("Not set") }}</td>
+                </tr>
+                <tr>
+                    <th>{% trans "Correspondence Author" %}</th>
+                    <td>
+                        {% if article.correspondence_author %}
+                            {{ article.correspondence_author.full_name|default:article.correspondence_author.email }}
+                        {% else %}
+                            {% trans "Not set" %}
+                        {% endif %}
+                    </td>
+                </tr>
+                <tr>
+                    <th>{% trans "Abstract" %}</th>
+                    <td>{{ article.abstract|safe|default:_("No abstract provided") }}</td>
+                </tr>
+            </table>
         </div>
     </div>
 


### PR DESCRIPTION
This improves the submission flow for already-submitted articles.

Instead of returning a 404 when the submitting author revisits `/submit/<id>/review/`, Janeway now redirects them to the article status page. The author-facing status page was also expanded to show useful article metadata.

Validation:
- `lando manage test submission` passed
- targeted security tests for the new redirect behavior passed

Note:
- the broader `security` suite still reports one unrelated inconsistent test around `submission_authorised_with_good_user`
